### PR TITLE
fix(prisma): support direct PostgreSQL connections via adapter

### DIFF
--- a/apps/web/lib/db/erd_query.sql
+++ b/apps/web/lib/db/erd_query.sql
@@ -1,0 +1,244 @@
+-- ERD Generation Query for Digital Garden Database
+-- Run this query in your PostgreSQL database to extract schema information for ERD tools
+-- Compatible with tools like dbdiagram.io, draw.io, or other ERD generators
+
+-- ============================================================================
+-- 1. TABLES AND COLUMNS
+-- ============================================================================
+SELECT 
+    'TABLE' as object_type,
+    t.table_schema,
+    t.table_name,
+    c.column_name,
+    c.data_type,
+    c.character_maximum_length,
+    c.is_nullable,
+    c.column_default,
+    c.ordinal_position
+FROM 
+    information_schema.tables t
+    JOIN information_schema.columns c ON t.table_name = c.table_name 
+        AND t.table_schema = c.table_schema
+WHERE 
+    t.table_schema = 'public'
+    AND t.table_type = 'BASE TABLE'
+    AND t.table_name NOT LIKE '_prisma%'
+ORDER BY 
+    t.table_name, c.ordinal_position;
+
+-- ============================================================================
+-- 2. PRIMARY KEYS
+-- ============================================================================
+SELECT 
+    'PRIMARY_KEY' as object_type,
+    tc.table_schema,
+    tc.table_name,
+    kcu.column_name,
+    tc.constraint_name
+FROM 
+    information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu 
+        ON tc.constraint_name = kcu.constraint_name
+        AND tc.table_schema = kcu.table_schema
+WHERE 
+    tc.constraint_type = 'PRIMARY KEY'
+    AND tc.table_schema = 'public'
+    AND tc.table_name NOT LIKE '_prisma%'
+ORDER BY 
+    tc.table_name, kcu.ordinal_position;
+
+-- ============================================================================
+-- 3. FOREIGN KEYS (RELATIONSHIPS)
+-- ============================================================================
+SELECT 
+    'FOREIGN_KEY' as object_type,
+    tc.table_schema,
+    tc.table_name as from_table,
+    kcu.column_name as from_column,
+    ccu.table_name as to_table,
+    ccu.column_name as to_column,
+    tc.constraint_name,
+    rc.update_rule,
+    rc.delete_rule
+FROM 
+    information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu 
+        ON tc.constraint_name = kcu.constraint_name
+        AND tc.table_schema = kcu.table_schema
+    JOIN information_schema.constraint_column_usage ccu 
+        ON ccu.constraint_name = tc.constraint_name
+        AND ccu.table_schema = tc.table_schema
+    JOIN information_schema.referential_constraints rc
+        ON tc.constraint_name = rc.constraint_name
+        AND tc.table_schema = rc.constraint_schema
+WHERE 
+    tc.constraint_type = 'FOREIGN KEY'
+    AND tc.table_schema = 'public'
+    AND tc.table_name NOT LIKE '_prisma%'
+ORDER BY 
+    tc.table_name, kcu.ordinal_position;
+
+-- ============================================================================
+-- 4. UNIQUE CONSTRAINTS
+-- ============================================================================
+SELECT 
+    'UNIQUE' as object_type,
+    tc.table_schema,
+    tc.table_name,
+    kcu.column_name,
+    tc.constraint_name
+FROM 
+    information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu 
+        ON tc.constraint_name = kcu.constraint_name
+        AND tc.table_schema = kcu.table_schema
+WHERE 
+    tc.constraint_type = 'UNIQUE'
+    AND tc.table_schema = 'public'
+    AND tc.table_name NOT LIKE '_prisma%'
+ORDER BY 
+    tc.table_name, kcu.ordinal_position;
+
+-- ============================================================================
+-- 5. INDEXES
+-- ============================================================================
+SELECT 
+    'INDEX' as object_type,
+    schemaname as table_schema,
+    tablename as table_name,
+    indexname,
+    indexdef
+FROM 
+    pg_indexes
+WHERE 
+    schemaname = 'public'
+    AND tablename NOT LIKE '_prisma%'
+ORDER BY 
+    tablename, indexname;
+
+-- ============================================================================
+-- 6. COMPREHENSIVE ERD DATA (ALL IN ONE)
+-- ============================================================================
+-- This query combines all information in a format suitable for ERD tools
+WITH table_info AS (
+    SELECT DISTINCT
+        t.table_name,
+        obj_description(c.oid, 'pg_class') as table_comment
+    FROM 
+        information_schema.tables t
+        JOIN pg_class c ON c.relname = t.table_name
+        JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    WHERE 
+        t.table_schema = 'public'
+        AND t.table_type = 'BASE TABLE'
+        AND t.table_name NOT LIKE '_prisma%'
+)
+SELECT 
+    'ERD_DATA' as query_type,
+    jsonb_build_object(
+        'tables', (
+            SELECT jsonb_agg(
+                jsonb_build_object(
+                    'name', ti.table_name,
+                    'comment', COALESCE(ti.table_comment, ''),
+                    'columns', (
+                        SELECT jsonb_agg(
+                            jsonb_build_object(
+                                'name', c.column_name,
+                                'type', c.data_type || 
+                                    CASE 
+                                        WHEN c.character_maximum_length IS NOT NULL 
+                                        THEN '(' || c.character_maximum_length || ')'
+                                        ELSE ''
+                                    END,
+                                'nullable', c.is_nullable = 'YES',
+                                'default', c.column_default,
+                                'position', c.ordinal_position
+                            ) ORDER BY c.ordinal_position
+                        )
+                        FROM information_schema.columns c
+                        WHERE c.table_name = ti.table_name
+                        AND c.table_schema = 'public'
+                    ),
+                    'primary_keys', (
+                        SELECT jsonb_agg(kcu.column_name ORDER BY kcu.ordinal_position)
+                        FROM information_schema.table_constraints tc
+                        JOIN information_schema.key_column_usage kcu 
+                            ON tc.constraint_name = kcu.constraint_name
+                        WHERE tc.table_name = ti.table_name
+                        AND tc.constraint_type = 'PRIMARY KEY'
+                    ),
+                    'foreign_keys', (
+                        SELECT jsonb_agg(
+                            jsonb_build_object(
+                                'from_column', kcu.column_name,
+                                'to_table', ccu.table_name,
+                                'to_column', ccu.column_name,
+                                'on_update', rc.update_rule,
+                                'on_delete', rc.delete_rule
+                            )
+                        )
+                        FROM information_schema.table_constraints tc
+                        JOIN information_schema.key_column_usage kcu 
+                            ON tc.constraint_name = kcu.constraint_name
+                        JOIN information_schema.constraint_column_usage ccu 
+                            ON ccu.constraint_name = tc.constraint_name
+                        JOIN information_schema.referential_constraints rc
+                            ON tc.constraint_name = rc.constraint_name
+                        WHERE tc.table_name = ti.table_name
+                        AND tc.constraint_type = 'FOREIGN KEY'
+                    ),
+                    'unique_constraints', (
+                        SELECT jsonb_agg(
+                            jsonb_build_object(
+                                'columns', jsonb_agg(kcu.column_name ORDER BY kcu.ordinal_position),
+                                'name', tc.constraint_name
+                            )
+                        )
+                        FROM information_schema.table_constraints tc
+                        JOIN information_schema.key_column_usage kcu 
+                            ON tc.constraint_name = kcu.constraint_name
+                        WHERE tc.table_name = ti.table_name
+                        AND tc.constraint_type = 'UNIQUE'
+                        GROUP BY tc.constraint_name
+                    )
+                )
+            )
+            FROM table_info ti
+        )
+    ) as erd_json;
+
+-- ============================================================================
+-- 7. SIMPLIFIED RELATIONSHIP MAP (for quick reference)
+-- ============================================================================
+SELECT 
+    'RELATIONSHIP_MAP' as query_type,
+    tc.table_name as "From Table",
+    kcu.column_name as "From Column",
+    '->' as "Relationship",
+    ccu.table_name as "To Table",
+    ccu.column_name as "To Column",
+    CASE rc.delete_rule
+        WHEN 'CASCADE' THEN 'CASCADE'
+        WHEN 'SET NULL' THEN 'SET NULL'
+        WHEN 'RESTRICT' THEN 'RESTRICT'
+        ELSE rc.delete_rule
+    END as "On Delete"
+FROM 
+    information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu 
+        ON tc.constraint_name = kcu.constraint_name
+        AND tc.table_schema = kcu.table_schema
+    JOIN information_schema.constraint_column_usage ccu 
+        ON ccu.constraint_name = tc.constraint_name
+        AND ccu.table_schema = tc.table_schema
+    JOIN information_schema.referential_constraints rc
+        ON tc.constraint_name = rc.constraint_name
+        AND tc.table_schema = rc.constraint_schema
+WHERE 
+    tc.constraint_type = 'FOREIGN KEY'
+    AND tc.table_schema = 'public'
+    AND tc.table_name NOT LIKE '_prisma%'
+ORDER BY 
+    tc.table_name, kcu.ordinal_position;
+

--- a/apps/web/lib/db/erd_simple.sql
+++ b/apps/web/lib/db/erd_simple.sql
@@ -1,0 +1,63 @@
+-- Simple ERD Query - Run this in your PostgreSQL database
+-- Returns all tables, columns, and relationships in a format suitable for ERD tools
+
+SELECT 
+    t.table_name as "Table",
+    c.column_name as "Column",
+    c.data_type || 
+        CASE 
+            WHEN c.character_maximum_length IS NOT NULL 
+            THEN '(' || c.character_maximum_length || ')'
+            ELSE ''
+        END as "Type",
+    CASE WHEN c.is_nullable = 'NO' THEN 'NOT NULL' ELSE 'NULL' END as "Nullable",
+    CASE 
+        WHEN pk.column_name IS NOT NULL THEN 'PK'
+        WHEN fk.column_name IS NOT NULL THEN 'FK'
+        WHEN uq.column_name IS NOT NULL THEN 'UQ'
+        ELSE ''
+    END as "Key",
+    fk.ref_table as "References Table",
+    fk.ref_column as "References Column"
+FROM 
+    information_schema.tables t
+    JOIN information_schema.columns c 
+        ON t.table_name = c.table_name 
+        AND t.table_schema = c.table_schema
+    LEFT JOIN (
+        SELECT kcu.table_name, kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu 
+            ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.constraint_type = 'PRIMARY KEY'
+        AND tc.table_schema = 'public'
+    ) pk ON pk.table_name = c.table_name AND pk.column_name = c.column_name
+    LEFT JOIN (
+        SELECT 
+            kcu.table_name,
+            kcu.column_name,
+            ccu.table_name as ref_table,
+            ccu.column_name as ref_column
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu 
+            ON tc.constraint_name = kcu.constraint_name
+        JOIN information_schema.constraint_column_usage ccu 
+            ON ccu.constraint_name = tc.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+        AND tc.table_schema = 'public'
+    ) fk ON fk.table_name = c.table_name AND fk.column_name = c.column_name
+    LEFT JOIN (
+        SELECT kcu.table_name, kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu 
+            ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.constraint_type = 'UNIQUE'
+        AND tc.table_schema = 'public'
+    ) uq ON uq.table_name = c.table_name AND uq.column_name = c.column_name
+WHERE 
+    t.table_schema = 'public'
+    AND t.table_type = 'BASE TABLE'
+    AND t.table_name NOT LIKE '_prisma%'
+ORDER BY 
+    t.table_name, c.ordinal_position;
+

--- a/apps/web/lib/db/prisma.ts
+++ b/apps/web/lib/db/prisma.ts
@@ -1,39 +1,42 @@
 // Prisma Client singleton
 // This ensures we only create one instance of Prisma Client
 
-let prismaClient: any;
+import { PrismaClient, Prisma } from "@/lib/generated/prisma/client";
+import { Pool } from "pg";
+import { PrismaPg } from "@prisma/adapter-pg";
 
-try {
-  // Try to import the generated Prisma client
-  const { PrismaClient } = require("@/lib/generated/prisma/client");
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
 
-  const globalForPrisma = globalThis as unknown as {
-    prisma: typeof PrismaClient | undefined;
-  };
+const databaseUrl = process.env.DATABASE_URL || "";
+const isAccelerateUrl =
+  databaseUrl.startsWith("prisma://") ||
+  databaseUrl.startsWith("prisma+postgres://");
 
-  prismaClient =
-    globalForPrisma.prisma ??
-    new PrismaClient({
-      log:
-        process.env.NODE_ENV === "development"
-          ? ["query", "error", "warn"]
-          : ["error"],
-    });
+const logLevels: Prisma.LogLevel[] =
+  process.env.NODE_ENV === "development"
+    ? ["query", "error", "warn"]
+    : ["error"];
 
-  if (process.env.NODE_ENV !== "production")
-    globalForPrisma.prisma = prismaClient;
-} catch (error) {
-  // Prisma client not yet generated - create a proxy that throws helpful errors
-  prismaClient = new Proxy({} as any, {
-    get() {
-      throw new Error(
-        "Prisma client not initialized. Please run:\n" +
-          "  1. pnpm install (to install @prisma/client)\n" +
-          "  2. pnpm exec prisma generate\n" +
-          "  3. pnpm exec prisma migrate dev"
-      );
-    },
-  });
-}
+// Prisma client configuration
+// If using Accelerate, use accelerateUrl; otherwise use adapter for direct PostgreSQL connection
+const prismaClient = isAccelerateUrl
+  ? new PrismaClient({
+      log: logLevels,
+      accelerateUrl: databaseUrl,
+    })
+  : // For direct PostgreSQL connections, use the pg adapter
+    (() => {
+      const pool = new Pool({ connectionString: databaseUrl });
+      const adapter = new PrismaPg(pool);
+      return new PrismaClient({
+        log: logLevels,
+        adapter,
+      });
+    })();
 
-export const prisma = prismaClient;
+// No new client is created if one already exists
+export const prisma = globalForPrisma.prisma ?? prismaClient;
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@prisma/adapter-pg": "^7.2.0",
     "@prisma/client": "7.2.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -60,6 +61,7 @@
     "@tailwindcss/postcss": "^4",
     "@types/bcrypt": "^5.0.2",
     "@types/node": "^20",
+    "@types/pg": "^8.16.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/uuid": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.69.0(react@19.2.1))
+      '@prisma/adapter-pg':
+        specifier: ^7.2.0
+        version: 7.2.0
       '@prisma/client':
         specifier: 7.2.0
         version: 7.2.0(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3))(typescript@5.9.3)
@@ -165,6 +168,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.24
+      '@types/pg':
+        specifier: ^8.16.0
+        version: 8.16.0
       '@types/react':
         specifier: ^19
         version: 19.2.7
@@ -815,6 +821,9 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@prisma/adapter-pg@7.2.0':
+    resolution: {integrity: sha512-euIdQ13cRB2wZ3jPsnDnFhINquo1PYFPCg6yVL8b2rp3EdinQHsX9EDdCtRr489D5uhphcRk463OdQAFlsCr0w==}
+
   '@prisma/client-runtime-utils@7.2.0':
     resolution: {integrity: sha512-dn7oB53v0tqkB0wBdMuTNFNPdEbfICEUe82Tn9FoKAhJCUkDH+fmyEp0ClciGh+9Hp2Tuu2K52kth2MTLstvmA==}
 
@@ -841,6 +850,9 @@ packages:
 
   '@prisma/dev@0.17.0':
     resolution: {integrity: sha512-6sGebe5jxX+FEsQTpjHLzvOGPn6ypFQprcs3jcuIWv1Xp/5v6P/rjfdvAwTkP2iF6pDx2tCd8vGLNWcsWzImTA==}
+
+  '@prisma/driver-adapter-utils@7.2.0':
+    resolution: {integrity: sha512-gzrUcbI9VmHS24Uf+0+7DNzdIw7keglJsD5m/MHxQOU68OhGVzlphQRobLiDMn8CHNA2XN8uugwKjudVtnfMVQ==}
 
   '@prisma/engines-version@7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3':
     resolution: {integrity: sha512-KezsjCZDsbjNR7SzIiVlUsn9PnLePI7r5uxABlwL+xoerurZTfgQVbIjvjF2sVr3Uc0ZcsnREw3F84HvbggGdA==}
@@ -1814,6 +1826,9 @@ packages:
 
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
+  '@types/pg@8.16.0':
+    resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
 
   '@types/react-dom@19.2.2':
     resolution: {integrity: sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==}
@@ -3937,6 +3952,10 @@ packages:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
 
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
   postgres-bytea@1.0.0:
     resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
     engines: {node: '>=0.10.0'}
@@ -5398,6 +5417,14 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@prisma/adapter-pg@7.2.0':
+    dependencies:
+      '@prisma/driver-adapter-utils': 7.2.0
+      pg: 8.16.3
+      postgres-array: 3.0.4
+    transitivePeerDependencies:
+      - pg-native
+
   '@prisma/client-runtime-utils@7.2.0': {}
 
   '@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3))(typescript@5.9.3)':
@@ -5441,6 +5468,10 @@ snapshots:
       zeptomatch: 2.0.2
     transitivePeerDependencies:
       - typescript
+
+  '@prisma/driver-adapter-utils@7.2.0':
+    dependencies:
+      '@prisma/debug': 7.2.0
 
   '@prisma/engines-version@7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3': {}
 
@@ -6460,6 +6491,12 @@ snapshots:
 
   '@types/offscreencanvas@2019.7.3': {}
 
+  '@types/pg@8.16.0':
+    dependencies:
+      '@types/node': 24.9.2
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+
   '@types/react-dom@19.2.2(@types/react@19.2.2)':
     dependencies:
       '@types/react': 19.2.2
@@ -7349,7 +7386,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.8
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -7372,6 +7409,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.1(jiti@2.6.1)
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -7387,29 +7439,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.1(jiti@2.6.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -7434,7 +7471,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9092,6 +9129,8 @@ snapshots:
       source-map-js: 1.2.1
 
   postgres-array@2.0.0: {}
+
+  postgres-array@3.0.4: {}
 
   postgres-bytea@1.0.0: {}
 


### PR DESCRIPTION
Add @prisma/adapter-pg to support direct PostgreSQL connections as well as
Prisma Accelerate. The client   detects DATABASE_URL L to use the appropriate connection method.

Add package dependencies.

Fixes initialization errors when using standard postgresql:// URLs with Neon database.

Also added ERD query files for schema visualization.