### PR TITLE
fix(editor): prevent cursor jump and content loss on autosave

### DIFF
--- a/components/content/editor/MarkdownEditor.tsx
+++ b/components/content/editor/MarkdownEditor.tsx
@@ -86,6 +86,10 @@ export function MarkdownEditor({
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // Track the last content we saved so we can distinguish save-echoes
+  // (parent updating state after our save) from genuine external updates
+  // (navigation, refetch). Prevents cursor-jump-on-autosave bug.
+  const lastSavedContentRef = useRef<JSONContent | null>(null);
 
   // Initialize editor
   const editor = useEditor({
@@ -142,10 +146,15 @@ export function MarkdownEditor({
         saveTimeoutRef.current = setTimeout(async () => {
           setIsSaving(true);
           try {
+            // Track the content object we're about to save. When the parent
+            // calls setNoteContent(content) after save, it echoes back as a
+            // prop change. The ref lets us skip the setContent call for that echo.
+            lastSavedContentRef.current = json;
             await onSave(json);
             setHasUnsavedChanges(false);
           } catch (error) {
             console.error("Failed to save:", error);
+            lastSavedContentRef.current = null;
             // Keep hasUnsavedChanges=true on error
           } finally {
             setIsSaving(false);
@@ -155,11 +164,22 @@ export function MarkdownEditor({
     },
   });
 
-  // Update editor content when prop changes (external updates)
+  // Sync editor content when the prop changes from an EXTERNAL source
+  // (navigation to a different note, refetch after rename).
+  // Skip when the change is a save-echo: the parent updating state after
+  // our own autosave — applying that would reset the cursor and lose
+  // any content the user typed during the save round-trip.
   useEffect(() => {
-    if (editor && content !== editor.getJSON()) {
-      editor.commands.setContent(content);
+    if (!editor || !content) return;
+
+    // If this content matches what we just saved, it's a save-echo — skip it
+    if (content === lastSavedContentRef.current) {
+      lastSavedContentRef.current = null;
+      return;
     }
+
+    // Genuine external update — apply it
+    editor.commands.setContent(content);
   }, [content, editor]);
 
   // Initial stats update when editor is created

--- a/docs/notes-feature/STATUS.md
+++ b/docs/notes-feature/STATUS.md
@@ -1,8 +1,8 @@
 ---
-last_updated: 2026-02-27
+last_updated: 2026-03-01
 current_epoch: 7
-current_sprint: 33
-sprint_status: in_progress
+current_sprint: 34
+sprint_status: complete
 ---
 
 # Digital Garden Content IDE - Status
@@ -31,44 +31,43 @@ FULL GUIDE: STATUS-MAINTENANCE-GUIDE.md
 
 ## Current Work
 
-### Active Sprint: Sprint 33 - AI Foundation + Settings UI
-**Duration**: Feb 27 - Mar 12, 2026
-**Branch**: `epoch-7/sprint-33`
-**Goal**: Install AI SDK, create provider registry, build streaming chat API route, expand settings schema, and ship `/settings/ai` page.
-
-**Progress**: 95% (build gate passed, smoke testing remaining)
-
-**Completed Work Items**:
-- AI SDK dependencies installed (ai@6, @ai-sdk/react, @ai-sdk/anthropic, @ai-sdk/openai)
-- `lib/domain/ai/` directory structure (types, providers, middleware)
-- Provider registry with dynamic imports (`resolveChatModel`)
-- Provider catalog (`PROVIDER_CATALOG` for settings UI)
-- Middleware system (`applyMiddleware` + `defaultSettingsMiddleware`)
-- Streaming chat API route (`POST /api/ai/chat`)
-- AI chat Zustand store (`state/ai-chat-store.ts`)
-- AI settings schema expanded in `validation.ts`
-- `/settings/ai` page with 4 sections (Provider & Model, Generation Parameters, Feature Toggles, Usage)
-- AI nav item added to SettingsSidebar with Brain icon
-- `pnpm build` passes (Sprint 33 gate verified)
-
-**Remaining**:
-- Browser smoke test (settings page, chat API)
-
-**See**: [Current Sprint Details](work-tracking/CURRENT-SPRINT.md)
+### Last Completed Sprint: Sprint 34 - Chat UI, AI Tools, @ Mentions
+**Duration**: Feb 28 - Mar 1, 2026
+**Branch**: `epoch-7/sprint-34`
+**Status**: ✅ COMPLETE — merged to main via PR
 
 ### Active Epoch: Epoch 7 - AI Integration
 **Duration**: Feb-Apr 2026 (8 weeks, 4 sprints)
 **Theme**: AI chat, AI tools, agents, speech, BYOK, RAG
 
 **Sprint Plan**:
-- Sprint 33: AI Foundation + Settings UI (current)
-- Sprint 34: Chat UI & AI Tools + Tool Settings
-- Sprint 35: BYOK, Speech & Agent + Key/Speech Settings
-- Sprint 36: RAG, Integration & Polish
+- Sprint 33: AI Foundation + Settings UI ✅
+- Sprint 34: Chat UI & AI Tools + Tool Settings ✅
+- Sprint 35: Planning (BYOK, Speech, Agent, or new priorities)
+- Sprint 36: Planning
 
 ## Recent Completions (Last 30 Days)
 
-**Feb 27, 2026**: Sprint 33 AI Foundation
+**Mar 1, 2026**: Sprint 34 Chat UI, AI Tools, @ Mentions — COMPLETE
+- ChatPanel (right sidebar): transient streaming chat with "Save conversation" to file tree
+- ChatViewer (main panel): full-page persistent chat with auto-save to ChatPayload
+- ChatPayload CRUD in content API (GET/PATCH/POST)
+- AI tools registry (searchNotes, getCurrentNote, createNote) with Prisma execution layer
+- ModelPicker component for per-session provider/model override
+- Tool settings UI (tool choice, enable/disable individual tools)
+- @ file mentions: inline search → system prompt injection → clickable mention pills
+- / tool commands: browse AI tools with prompt hints
+- ChatSuggestionMenu: shared keyboard-navigable dropdown for both chat surfaces
+- Sidebar tab auto-switch when content type changes
+- MessageCircle icon for chat nodes in file tree
+- Chat export as Markdown from toolbar
+- Editor state persistence fix (collapse/reopen no longer loses edits)
+- Root page redirect (session-based, replaces legacy AppNav)
+- Global error boundary
+- 29 files changed, +2,237 lines
+- Build gate passed
+
+**Feb 27, 2026**: Sprint 33 AI Foundation + Settings UI — COMPLETE
 - AI SDK v6 installed and Zod v4 compatibility confirmed
 - Provider registry with dynamic imports (Anthropic + OpenAI)
 - Streaming chat API route with auth + middleware
@@ -116,47 +115,48 @@ FULL GUIDE: STATUS-MAINTENANCE-GUIDE.md
 - ✅ Kanban view component (drag-and-drop, status columns)
 - ✅ Folder organization system operational
 
-## Up Next (Sprint 34)
+## Up Next (Sprint 35+)
 
-**Goal**: Chat UI & AI Tools + Tool Settings
-**Planned Deliverables**:
-- Right sidebar ChatPanel with streaming responses
-- Full ChatViewer for persistent chat ContentNodes
-- "Save conversation" feature (sidebar -> ChatPayload)
-- Base AI tools (searchNotes, getCurrentNote, createNote)
-- Tool management section in AI settings
-- Message persistence (ChatPayload CRUD)
+**Planning in progress** — original Epoch 7 plan had BYOK/Speech/Agent for Sprint 35
+and RAG/Polish for Sprint 36, but new priorities may redirect.
+
+**See**: [Backlog](work-tracking/BACKLOG.md) for prioritized items
 
 ## Known Issues & Blockers
 
 ### Active Blockers
 - **macOS Finder**: File picker not opening on dev machine — blocks manual testing of import feature
+- **macOS mmap**: `mmap failed: Operation timed out` on `git push` from main working directory — workaround: git bundle → fresh clone → push from /tmp
 
 ### Known Limitations
 - **Sprint 31 Import**: Untested pending Finder fix — parser, API, and toolbar button built but not manually verified
 - **PDF/DOCX Export**: Stub implementations (need Puppeteer/docx library integration)
-- **AI Chat**: No API keys configured by default (BYOK coming Sprint 35)
+- **AI Chat**: Requires user-provided API keys (BYOK configured in /settings/ai)
 - **External Links**: Some sites have SSL certificate errors (require dev-mode bypass)
 - **Outline Panel**: Auto-scroll on editor scroll needs intersection observer (click-to-scroll works)
+- **Chat mentions**: Only injects note `searchText` (max 2000 chars), not full TipTap JSON
 
 ### Technical Debt
 - [ ] Server-side TipTap extensions missing WikiLink and Tag parsers
 - [ ] Metadata sidecar import consumer not yet implemented
+- [ ] Chat export only handles plain text messages (no tool call/result rendering)
 
 ## Metrics
 
-### Velocity (Last 4 Sprints)
+### Velocity (Last 6 Sprints)
 - Sprint 29: ~20 points (Tool Surfaces)
 - Sprint 30: ~15 points (Universal Editor)
 - Sprint 31: ~20 points (Import System)
 - Sprint 32: ~15 points (Editor Stability & Polish)
-- **Average**: ~18 points/sprint
+- Sprint 33: ~18 points (AI Foundation + Settings)
+- Sprint 34: ~25 points (Chat UI + Tools + Mentions)
+- **Average**: ~19 points/sprint
 
 ### Epoch 7 Progress
-- **Sprint 33**: 95% complete (AI Foundation)
-- **Sprint 34**: Planned (Chat UI & Tools)
-- **Sprint 35**: Planned (BYOK, Speech, Agent)
-- **Sprint 36**: Planned (RAG, Polish)
+- **Sprint 33**: ✅ Complete (AI Foundation)
+- **Sprint 34**: ✅ Complete (Chat UI & Tools)
+- **Sprint 35**: Planning
+- **Sprint 36**: Planning
 
 ## Roadmap
 
@@ -171,12 +171,12 @@ FULL GUIDE: STATUS-MAINTENANCE-GUIDE.md
 
 ## Quick Links
 
-- [Current Sprint](work-tracking/CURRENT-SPRINT.md) - Sprint 33 details
+- [Current Sprint](work-tracking/CURRENT-SPRINT.md) - Sprint 34 details
 - [Backlog](work-tracking/BACKLOG.md) - Prioritized work items
 - [AI Development Guide](../CLAUDE.md) - For AI assistants
 - [Start Here](00-START-HERE.md) - Documentation index
 
 ---
 
-**Last Updated**: Feb 27, 2026
-**Next Review**: Mar 3, 2026
+**Last Updated**: Mar 1, 2026
+**Next Review**: Sprint 35 planning

--- a/docs/notes-feature/work-tracking/BACKLOG.md
+++ b/docs/notes-feature/work-tracking/BACKLOG.md
@@ -1,13 +1,13 @@
 ---
-last_updated: 2026-02-27
+last_updated: 2026-03-01
 ---
 
 # Sprint Backlog
 
 **Prioritized work items for upcoming sprints**
 
-## Sprint 28: Advanced Folder Views + Payload Stubs
-**Duration**: Mar 4-17, 2026 (Planned)
+## Sprint 28: Advanced Folder Views + Payload Stubs (Deferred)
+**Status**: Deferred — deprioritized in favor of Epoch 7 AI work
 **Estimated**: 20-25 story points
 
 ### Backlogged from Sprint 27 (4 items, 12 points)
@@ -185,30 +185,60 @@ Post-feature stability sprint. Fixed regressions from Sprints 29-31.
 - [x] **BF-004**: tag-suggestion runtime error guard (1 pt)
   - Guard `component?.ref` against undefined in `onKeyDown`
 
-## Sprint 33+: TBD
-**Estimated**: 18-22 story points
+## Sprint 33: AI Foundation + Settings UI ✅ COMPLETE
+**Duration**: Feb 27, 2026
+**Branch**: `epoch-7/sprint-33`
 
-### Potential Work Items
+- [x] AI SDK v6 installed (ai@6, @ai-sdk/react, @ai-sdk/anthropic, @ai-sdk/openai)
+- [x] Provider registry with dynamic imports (`resolveChatModel`)
+- [x] Streaming chat API route (`POST /api/ai/chat`)
+- [x] `/settings/ai` page (provider, generation, toggles, usage)
+- [x] AI chat Zustand store, middleware system
+
+## Sprint 34: Chat UI, AI Tools, @ Mentions ✅ COMPLETE
+**Duration**: Feb 28 - Mar 1, 2026
+**Branch**: `epoch-7/sprint-34`
+
+- [x] ChatPanel (sidebar) + ChatViewer (main panel) with streaming
+- [x] ChatPayload CRUD (save/load conversations)
+- [x] AI tools: searchNotes, getCurrentNote, createNote
+- [x] @ file mentions with system prompt injection
+- [x] / tool commands with prompt hints
+- [x] ModelPicker, ChatSuggestionMenu, chat export
+- [x] Sidebar tab auto-switch, chat icon in file tree
+- [x] Tool settings UI
+
+## Sprint 35+: Planning
+
+### Original Epoch 7 Plan (may be redirected)
+
+**Sprint 35 — BYOK, Speech & Agent** (originally planned):
+- [ ] BYOK key management UI (secure entry, validation, per-provider)
+- [ ] Speech-to-text input (Web Speech API or Whisper)
+- [ ] Text-to-speech output (Web Speech Synthesis)
+- [ ] Agent mode (multi-step tool use with user confirmation)
+- [ ] Key management + speech settings pages
+
+**Sprint 36 — RAG, Integration & Polish** (originally planned):
+- [ ] Embeddings generation for content nodes
+- [ ] Vector similarity search (pgvector or external)
+- [ ] RAG context injection into chat
+- [ ] Chat history search
+- [ ] Cross-sprint polish and bug fixes
+
+### Deferred Work Items
 
 **Performance & Optimization**:
 - [ ] Folder view performance tuning for large folders (5 pts)
 - [ ] Virtualization for grid and kanban views (3 pts)
-- [ ] Lazy loading for timeline view (3 pts)
 
 **UX Refinements**:
 - [ ] Folder view keyboard shortcuts (Cmd+1-5) (2 pts)
-- [ ] View transition animations (2 pts)
 - [ ] Empty state designs for all views (2 pts)
 
 **Advanced Features**:
 - [ ] Folder sorting and filtering UI (3 pts)
 - [ ] Custom kanban columns (5 pts)
-- [ ] Timeline zoom controls (3 pts)
-
-**Documentation**:
-- [ ] Feature documentation for folder views (2 pts)
-- [ ] User guide for new content types (2 pts)
-- [ ] API documentation updates (1 pt)
 
 ## Future Backlog (Epoch 6+)
 
@@ -219,12 +249,17 @@ Post-feature stability sprint. Fixed regressions from Sprints 29-31.
 - [ ] Comment threads on content
 - [ ] Activity feed and notifications
 
-### AI Integration
-- [ ] AI chat interface within IDE
-- [ ] Semantic search with embeddings
+### AI Integration (Partially Shipped)
+- [x] AI chat interface within IDE (Sprint 34)
+- [x] AI tools: search, read, create notes (Sprint 34)
+- [x] @ mentions with context injection (Sprint 34)
+- [ ] Semantic search with embeddings (RAG)
 - [ ] AI-powered autocomplete and suggestions
 - [ ] Content summarization
 - [ ] Smart tagging and categorization
+- [ ] BYOK key management UI
+- [ ] Speech input/output
+- [ ] Agent mode (multi-step reasoning)
 
 ### Advanced Editor Features
 - [ ] Inline code execution (JavaScript, Python)
@@ -269,5 +304,5 @@ Post-feature stability sprint. Fixed regressions from Sprints 29-31.
 
 ---
 
-**Last Updated**: Feb 24, 2026
-**Next Review**: After Sprint 30 completion
+**Last Updated**: Mar 1, 2026
+**Next Review**: Sprint 35 planning

--- a/docs/notes-feature/work-tracking/CURRENT-SPRINT.md
+++ b/docs/notes-feature/work-tracking/CURRENT-SPRINT.md
@@ -1,95 +1,114 @@
 ---
-sprint: 33
+sprint: 34
 epoch: 7 (AI Integration)
-duration: Feb 27 - Mar 12, 2026
-branch: epoch-7/sprint-33
-status: in_progress
+duration: Feb 28 - Mar 1, 2026
+branch: epoch-7/sprint-34
+status: complete
 ---
 
-# Sprint 33: AI Foundation + Settings UI
+# Sprint 34: Chat UI, AI Tools, @ Mentions
 
 ## Sprint Goal
-Install AI SDK, create provider registry, build streaming chat API route, expand settings schema, and ship the `/settings/ai` page so everything is testable from the UI immediately.
+Ship the full AI chat experience: streaming ChatPanel in the right sidebar, persistent ChatViewer in the main panel, AI tools with Prisma execution, @ file mentions for context injection, and / tool commands.
 
-**Status**: 95% Complete
+**Status**: ✅ COMPLETE — merged to main via PR
 
 ## Success Criteria
-- [x] `pnpm build` passes with AI SDK packages installed
-- [x] `/settings/ai` page renders all 4 sections (provider, generation, toggles, usage)
-- [x] Settings changes persist via `PATCH /api/user/settings` and survive page reload
-- [x] `POST /api/ai/chat` returns streaming response (test with `curl --no-buffer`)
-- [x] Chat API reads user's stored provider/model/temperature settings
-- [x] Provider registry resolves Anthropic and OpenAI models without error
-- [x] Zod v4 compatibility confirmed (schemas compile and validate)
-- [ ] No console errors in browser dev tools on page load (needs smoke test)
+- [x] `pnpm build` passes
+- [x] ChatPanel in right sidebar streams responses
+- [x] "Save conversation" creates ChatPayload ContentNode in file tree
+- [x] ChatViewer loads saved conversations with full history
+- [x] AI tools (searchNotes, getCurrentNote, createNote) execute via tool registry
+- [x] Tool settings section in `/settings/ai`
+- [x] @ mentions search content nodes and inject into system prompt
+- [x] / commands show available AI tools with prompt hints
+- [x] Chat icon (MessageCircle) appears for chat nodes in file tree
+- [x] Sidebar tabs auto-switch when content type changes
+- [x] Chat export as Markdown from toolbar
 
 ## Completed Work Items
 
-### Dependencies
-- [x] `ai@6.0.104` — AI SDK core
-- [x] `@ai-sdk/react@3.0.106` — React hooks (useChat, useCompletion)
-- [x] `@ai-sdk/anthropic@5.0.11` — Anthropic provider
-- [x] `@ai-sdk/openai@4.0.4` — OpenAI provider
-
-### Files Created
+### Sprint 34 Core — Chat UI & Persistence
 
 | File | Purpose |
 |------|---------|
-| `lib/domain/ai/index.ts` | Barrel export (client-safe types + catalog) |
-| `lib/domain/ai/types.ts` | `AIProviderId`, `AIModelId`, `ProviderConfig`, `StoredChatMessage`, `ChatMetadata` |
-| `lib/domain/ai/providers/index.ts` | Provider barrel |
-| `lib/domain/ai/providers/registry.ts` | `resolveChatModel()` — dynamic imports, BYOK key injection via `createAnthropic/createOpenAI` |
-| `lib/domain/ai/providers/catalog.ts` | `PROVIDER_CATALOG` — Anthropic (4 models) + OpenAI (3 models) metadata |
-| `lib/domain/ai/providers/types.ts` | `ProviderMeta`, `ModelMeta`, `ModelCapability`, `CostTier` |
-| `lib/domain/ai/middleware/index.ts` | `applyMiddleware()` — composes middleware via `wrapLanguageModel()` |
-| `lib/domain/ai/middleware/default-settings.ts` | Wraps SDK's built-in `defaultSettingsMiddleware` with DG-friendly interface |
-| `app/api/ai/chat/route.ts` | POST — streaming chat: auth -> validate -> resolve model -> middleware -> streamText |
-| `state/ai-chat-store.ts` | Zustand store: activeContentId, isStreaming, error, sidebarContext |
-| `app/(authenticated)/settings/ai/page.tsx` | Server page for AI settings route |
-| `components/settings/AISettingsPage.tsx` | Client component — 4-section AI settings form |
+| `components/content/ai/ChatPanel.tsx` | Right sidebar streaming chat with save-to-tree |
+| `components/content/ai/ChatViewer.tsx` | Full ChatViewer rewrite with auto-save to ChatPayload |
+| `components/content/ai/ChatInput.tsx` | Shared input with @ mention and / command detection |
+| `components/content/ai/ChatMessage.tsx` | Message rendering with mention pills, code blocks, inline formatting |
+| `components/content/ai/ModelPicker.tsx` | Per-session provider/model override dropdown |
+| `components/content/ai/ChatSuggestionMenu.tsx` | Shared keyboard-navigable dropdown for mentions + commands |
+| `lib/domain/ai/tools/registry.ts` | AI tool definitions (searchNotes, getCurrentNote, createNote) with Prisma |
+| `lib/domain/ai/tools/metadata.ts` | Client-safe tool metadata (no Prisma imports) |
+| `lib/domain/ai/tools/types.ts` | BaseToolId, BaseToolMetadata types |
+| `lib/domain/ai/tools/index.ts` | Barrel export |
 
-### Files Modified
+### Sprint 34 Core — API & Data Layer
 
 | File | Change |
 |------|--------|
-| `lib/features/settings/validation.ts` | Added `providerId`, `modelId`, `temperature`, `maxTokens`, `streamingEnabled` to AI schema |
-| `components/settings/SettingsSidebar.tsx` | Added BrainIcon + "AI" nav item with "New" badge |
-| `.env.local` | Added commented `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` placeholders |
+| `app/api/ai/chat/route.ts` | Added AI tools execution, mentioned content injection |
+| `app/api/content/content/[id]/route.ts` | ChatPayload GET + PATCH (messages, metadata) |
+| `app/api/content/content/route.ts` | ChatPayload POST support |
+| `lib/domain/content/api-types.ts` | ChatPayload API types |
+| `lib/domain/ai/types.ts` | StoredChatMessage, ChatMetadata updates |
+| `components/settings/AISettingsPage.tsx` | Tool settings section (tool choice, enabled tools) |
+| `lib/features/settings/validation.ts` | toolChoice, enabledTools schema fields |
+
+### Sprint 34 Core — UI Integration
+
+| File | Change |
+|------|--------|
+| `components/content/LeftSidebar.tsx` | Tree refresh event listener, chat creation handler |
+| `components/content/content/LeftSidebarContent.tsx` | Chat content type in create request |
+| `components/content/headers/LeftSidebarHeader.tsx` | onCreateChat prop |
+| `components/content/menu-items/new-content-menu.tsx` | Chat in new content menu |
+| `components/content/content/RightSidebarContent.tsx` | ChatPanel replaces placeholder |
+| `app/page.tsx` | Session-based redirect (replaces legacy AppNav) |
+| `app/global-error.tsx` | Global error boundary |
+
+### Sprint 34B — Polish & Mentions
+
+| File | Change |
+|------|--------|
+| `components/content/RightSidebar.tsx` | Tab auto-switch on content type change |
+| `components/content/FileNode.tsx` | MessageCircle icon for chat content type |
+| `components/content/content/MainPanelContent.tsx` | Editor state persistence fix + chat export handler |
+| `components/content/headers/RightSidebarHeader.tsx` | "AI Chat" tab title (was "Coming Soon") |
+| `lib/domain/tools/registry.ts` | export-chat toolbar tool registration |
 
 ## Technical Notes
 
-### AI SDK v6 Type Changes Discovered
-1. `LanguageModelV1` -> `LanguageModel` (union: `string | LanguageModelV3 | LanguageModelV2`)
-2. `LanguageModelV1Middleware` -> `LanguageModelMiddleware` (V3 spec, requires `specificationVersion: 'v3'`)
-3. `.withOptions({ apiKey })` removed — use factory functions (`createAnthropic()`, `createOpenAI()`)
-4. `maxTokens` -> `maxOutputTokens` in V3 call options
-5. `wrapLanguageModel` accepts `LanguageModelV3` specifically (not the union type)
+### AI SDK v6 useChat + tool() API Discoveries
+1. `useChat()`: NO `api`/`body` props — use `transport: new DefaultChatTransport({ api, body })` from `ai`
+2. `useChat()`: NO `initialMessages` — field is just `messages` in `ChatInit`
+3. `useChat()`: NO `input`/`setInput`/`handleSubmit` — use `sendMessage({ text })`, manage input via local `useState`
+4. `ChatStatus` type: `'ready' | 'submitted' | 'streaming' | 'error'` (replaces boolean `isLoading`)
+5. `UIMessage` has `parts[]` array, not `content` string
+6. `tool()`: uses `inputSchema` (NOT `parameters`), import `z` from `zod/v4` for type compat
+7. Dynamic `body` in transport: use function `body: () => ({ key: ref.current })` + ref pattern
 
-### Architecture Decisions
-- **Dynamic provider imports**: Only load the provider package being used via `await import()`. Node caches after first import.
-- **SDK's built-in middleware**: Re-use `defaultSettingsMiddleware` from `ai` package rather than custom V3 middleware (avoids `specificationVersion` compliance issues).
-- **Type narrowing in middleware**: `applyMiddleware` accepts broad `LanguageModel` but casts to `ConcreteModel` internally for `wrapLanguageModel`.
-- **Settings page as separate component**: `AISettingsPage.tsx` in `components/settings/` (not inline in `page.tsx`) because it will grow across sprints.
+### @ Mention Architecture
+- ChatInput inserts clean `@Title` in textarea (user-friendly display)
+- Parent (ChatPanel/ChatViewer) tracks mentions in `trackedMentionsRef`
+- On send: reconstructs `@[Title](id)` tokens for API + ChatMessage rendering
+- Server: fetches mentioned ContentNodes, injects searchText (max 2000 chars) into system prompt
+- ChatMessage: parses `@[Title](id)` tokens → renders as clickable `MentionPill` components
 
-## Sprint Transition Gate: Sprint 33 -> 34
-
-- [x] `pnpm build` passes with AI SDK packages installed
-- [x] `/settings/ai` page renders all 4 sections (provider, generation, toggles, usage)
-- [x] Provider registry resolves Anthropic and OpenAI models without error
-- [x] Zod v4 compatibility confirmed
-- [ ] Settings changes persist via `PATCH /api/user/settings` (needs browser test)
-- [ ] `POST /api/ai/chat` returns streaming response (needs curl test)
-- [ ] No console errors in browser dev tools
-
-## Next Sprint Preview
-
-**Sprint 34: Chat UI & AI Tools + Tool Settings**
-- Replace chat placeholders with streaming ChatPanel (sidebar) and ChatViewer (main panel)
-- "Save conversation" button creates ChatPayload ContentNode
-- Base AI tools: searchNotes, getCurrentNote, createNote
-- Tool management section in /settings/ai
-- Message persistence for ChatViewer
+## Stats
+- **29 files** changed | **+2,237** | **-141**
+- 1 commit (Sprint 34 + 34B combined)
+- New directory: `components/content/ai/` (5 components)
+- New directory: `lib/domain/ai/tools/` (4 files)
 
 ---
 
-**Last Updated**: Feb 27, 2026
+**Last Updated**: Mar 1, 2026
+
+## Previous Sprint: Sprint 33 (✅ Complete)
+
+See [Sprint 33 archive](history/) for details. Key deliverables:
+- AI SDK v6 installed (ai@6, @ai-sdk/react, @ai-sdk/anthropic, @ai-sdk/openai)
+- Provider registry with dynamic imports (`resolveChatModel`)
+- Streaming chat API route (`POST /api/ai/chat`)
+- `/settings/ai` page (provider, generation, toggles, usage)


### PR DESCRIPTION
## Summary

- **Critical bug fix**: Autosave was causing the cursor to jump to the end of the document and any content typed during the save round-trip to be lost
- **Root cause**: `handleSave` called `setNoteContent(content)` after saving (added in Sprint 34B for ExpandableEditor), which triggered a `useEffect` in `MarkdownEditor` that blindly replaced the editor document via `editor.commands.setContent()`. The comparison `content !== editor.getJSON()` used reference inequality (always true), so every save reset the editor.
- **Fix**: Track the last saved content in a ref (`lastSavedContentRef`). When the content prop changes to match our last save (same object reference), skip the `setContent` call. Genuine external updates (navigation, refetch) still apply normally.
- Docs updated for Sprint 33-34 completion status

## Test plan

- [x] Open a note with existing content
- [x] Type in the middle of the document
- [x] Wait for autosave (2s debounce) — cursor should NOT move
- [x] Type rapidly across multiple save cycles — no content loss
- [ ] Navigate away and back — content loads correctly
- [x] ExpandableEditor: collapse and reopen — latest saved content preserved
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)