### PR TITLE
fix(editor): prevent cross-document save race condition

### DIFF
--- a/components/content/content/MainPanelContent.tsx
+++ b/components/content/content/MainPanelContent.tsx
@@ -8,7 +8,7 @@
 
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { ToolSurfaceProvider } from "@/lib/domain/tools";
 import { ContentToolbar } from "../toolbar";
 import { ToolDebugPanel } from "../toolbar/ToolDebugPanel";
@@ -108,6 +108,21 @@ export function MainPanelContent() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0); // Used to force refetch
+
+  // AbortController for in-flight save requests. When the user navigates to
+  // a different document, we abort any pending fetch to prevent Doc A's content
+  // from being written to Doc B's API endpoint.
+  const saveAbortControllerRef = useRef<AbortController | null>(null);
+
+  // Cancel in-flight saves whenever selectedContentId changes
+  useEffect(() => {
+    return () => {
+      if (saveAbortControllerRef.current) {
+        saveAbortControllerRef.current.abort();
+        saveAbortControllerRef.current = null;
+      }
+    };
+  }, [selectedContentId]);
 
   // Restore selection from URL or localStorage on mount
   useEffect(() => {
@@ -325,10 +340,31 @@ export function MainPanelContent() {
     [setOutline]
   );
 
-  // Auto-save handler
+  // Auto-save handler — hardened against cross-document race conditions.
+  // The contentId is captured in the closure at creation time. Before making
+  // the API call, we verify it still matches the currently-viewed document.
+  // An AbortController cancels any in-flight fetch if the user navigates away.
   const handleSave = useCallback(
     async (content: JSONContent) => {
       if (!selectedContentId) return;
+
+      // GUARD: Read the live selectedContentId from the store at save-time.
+      // If it no longer matches the closure's value, the user navigated away
+      // and this save targets a stale document — discard it.
+      const currentId = useContentStore.getState().selectedContentId;
+      if (currentId !== selectedContentId) {
+        console.warn(
+          `[MainPanelContent] Blocked cross-document save: handleSave targets ${selectedContentId}, but store has ${currentId}`
+        );
+        return;
+      }
+
+      // Cancel any previous in-flight save
+      if (saveAbortControllerRef.current) {
+        saveAbortControllerRef.current.abort();
+      }
+      const abortController = new AbortController();
+      saveAbortControllerRef.current = abortController;
 
       setIsSaving(true);
       setHasUnsavedChanges(true);
@@ -343,6 +379,7 @@ export function MainPanelContent() {
           body: JSON.stringify({
             tiptapJson: content,
           }),
+          signal: abortController.signal,
         });
 
         const result = await response.json();
@@ -351,12 +388,28 @@ export function MainPanelContent() {
           throw new Error(result.error?.message || "Failed to save note");
         }
 
+        // Final guard: verify we're still on the same document before
+        // updating parent state. This catches the edge case where the user
+        // navigated during the network round-trip.
+        const postSaveId = useContentStore.getState().selectedContentId;
+        if (postSaveId !== selectedContentId) {
+          console.warn(
+            `[MainPanelContent] User navigated during save — skipping state update for ${selectedContentId}`
+          );
+          return;
+        }
+
         console.log("Note saved successfully");
         setLastSaved(new Date());
         // Keep parent state in sync so re-mounts (e.g., ExpandableEditor
         // collapse/reopen) receive the latest persisted content
         setNoteContent(content);
-      } catch (err) {
+      } catch (err: unknown) {
+        // AbortError is expected when we cancel a save due to navigation
+        if (err instanceof DOMException && err.name === "AbortError") {
+          console.log(`[MainPanelContent] Save aborted for ${selectedContentId} (navigation)`);
+          return;
+        }
         console.error("Failed to save note:", err);
         throw err; // Re-throw so editor knows save failed
       } finally {
@@ -790,6 +843,7 @@ export function MainPanelContent() {
         {/* Editor */}
         <div className="flex-1 overflow-hidden">
           <MarkdownEditor
+            contentId={selectedContentId ?? undefined}
             content={noteContent}
             onSave={handleSave}
             onStatsChange={handleStatsChange}

--- a/components/content/editor/ExpandableEditor.tsx
+++ b/components/content/editor/ExpandableEditor.tsx
@@ -147,6 +147,7 @@ export function ExpandableEditor({
           onKeyDown={(e) => e.stopPropagation()}
         >
           <MarkdownEditor
+            contentId={contentId}
             content={editorContent}
             onSave={handleSave}
             editable={!readOnly}

--- a/components/content/editor/MarkdownEditor.tsx
+++ b/components/content/editor/MarkdownEditor.tsx
@@ -30,6 +30,8 @@ export interface EditorStats {
 }
 
 export interface MarkdownEditorProps {
+  /** Content ID this editor is bound to — used to prevent cross-document saves */
+  contentId?: string;
   /** Initial content in TipTap JSON format */
   content: JSONContent;
   /** Callback when content changes */
@@ -65,6 +67,7 @@ export interface MarkdownEditorProps {
 }
 
 export function MarkdownEditor({
+  contentId,
   content,
   onChange,
   onSave,
@@ -90,6 +93,15 @@ export function MarkdownEditor({
   // (parent updating state after our save) from genuine external updates
   // (navigation, refetch). Prevents cursor-jump-on-autosave bug.
   const lastSavedContentRef = useRef<JSONContent | null>(null);
+  // Snapshot the onSave callback in a ref so the timeout always uses the
+  // version that was current when the edit happened — not a stale or
+  // re-created callback that might target a different document.
+  const onSaveRef = useRef(onSave);
+  onSaveRef.current = onSave;
+  // Track which contentId this editor instance is bound to, so we can
+  // discard saves that fire after the user navigated away.
+  const contentIdRef = useRef(contentId);
+  contentIdRef.current = contentId;
 
   // Initialize editor
   const editor = useEditor({
@@ -141,16 +153,30 @@ export function MarkdownEditor({
         clearTimeout(saveTimeoutRef.current);
       }
 
-      // Schedule auto-save
-      if (onSave) {
+      // Schedule auto-save.
+      // IMPORTANT: Snapshot the save callback AND contentId at the moment the
+      // edit happens. This prevents the race condition where the user navigates
+      // to a different document during the debounce window — without this,
+      // React could give us a fresh handleSave targeting the NEW document,
+      // causing Doc A's content to overwrite Doc B.
+      const snapshotSave = onSaveRef.current;
+      const snapshotContentId = contentIdRef.current;
+      if (snapshotSave) {
         saveTimeoutRef.current = setTimeout(async () => {
+          // Guard: if contentId changed since the edit, discard this save
+          if (snapshotContentId && contentIdRef.current !== snapshotContentId) {
+            console.warn(
+              `[MarkdownEditor] Discarding stale save: edited ${snapshotContentId}, now viewing ${contentIdRef.current}`
+            );
+            return;
+          }
           setIsSaving(true);
           try {
             // Track the content object we're about to save. When the parent
             // calls setNoteContent(content) after save, it echoes back as a
             // prop change. The ref lets us skip the setContent call for that echo.
             lastSavedContentRef.current = json;
-            await onSave(json);
+            await snapshotSave(json);
             setHasUnsavedChanges(false);
           } catch (error) {
             console.error("Failed to save:", error);
@@ -244,14 +270,16 @@ export function MarkdownEditor({
     return () => window.removeEventListener("scroll-to-heading", handleScrollToHeading);
   }, [editor]);
 
-  // Cleanup timeout on unmount
+  // Cancel pending saves when contentId changes (user navigated away)
+  // or on unmount. This is the first line of defense against cross-document saves.
   useEffect(() => {
     return () => {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
       }
     };
-  }, []);
+  }, [contentId]);
 
   return (
     <div className={`flex flex-col h-full ${className}`}>


### PR DESCRIPTION
## Summary

- **Prevents autosave from writing one document's content to another document** when the user navigates between documents during the 2-second debounce window
- Three-layer defense: snapshot-at-edit-time refs, store validation guard, and AbortController for in-flight requests
- Affects 3 files: `MarkdownEditor.tsx`, `MainPanelContent.tsx`, `ExpandableEditor.tsx`

## Root Cause

When a user edits Doc A and navigates to Doc B before autosave fires:
1. React re-creates `handleSave` with Doc B's `selectedContentId`
2. TipTap's `onUpdate` references the latest callback
3. The pending timeout fires `handleSave` → PATCHes Doc A's content to Doc B's API endpoint

## Fix

**Layer 1 (MarkdownEditor):** Snapshot `onSave` callback and `contentId` in refs at the moment the edit happens. The debounced timeout uses these snapshots, not the current props. Cancel pending timeouts when `contentId` changes.

**Layer 2 (MainPanelContent):** Before making the API call, `handleSave` reads the live `selectedContentId` from the Zustand store and compares it to the closure's value. Mismatches are blocked with a console warning.

**Layer 3 (AbortController):** An `AbortController` ref cancels any in-flight `fetch` when `selectedContentId` changes, preventing stale network responses from corrupting parent state via `setNoteContent`.

## Test plan

- [x] Edit a note, quickly navigate to another note before autosave fires — verify the first note's content does NOT overwrite the second
- [x] Normal autosave still works (edit → wait 2s → save indicator)
- [x] Expandable editor (non-note content types) saves correctly
- [x] `pnpm build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)