### PR TITLE
Sprint 35: TipTap input rule bug fixes + editor rules doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,12 @@ npx prisma studio     # Database GUI (http://localhost:5555)
 
 **Build pipeline:** `pnpm build` runs three steps sequentially: `prisma generate` → `pnpm build:tokens` (style-dictionary) → `next build`.
 
-**Vercel build** uses `--webpack` flag explicitly. Local dev uses Next.js default (Turbopack).
+**Vercel build** runs `prisma migrate deploy` → `prisma generate` → `build:tokens` → `next build --webpack`. Local dev uses Turbopack (no webpack flag).
 
 ## Environment Setup
 
 ```bash
-cp .env.example .env.local    # Then edit with your values
+# Create .env.local with required vars (see below)
 npx prisma generate           # Generate Prisma client
 npx prisma migrate reset --force  # Dev only! Creates tables + seeds
 pnpm dev
@@ -120,6 +120,7 @@ All stores in `state/`. Pattern: `create<T>()(persist((set, get) => ({...}), { n
 - `left-panel-view-store.ts` / `left-panel-collapse-store.ts` — Left sidebar view/collapse
 - `upload-settings-store.ts` — Upload preferences
 - `file-tree-filter-store.ts` — File tree filtering
+- `ai-chat-store.ts` — AI chat panel state
 - `debug-view-store.ts` — Dev debug toggles
 
 ### TipTap Editor
@@ -165,6 +166,26 @@ Collaboration hooks for Excalidraw, Mermaid diagrams, and diagrams.net. Security
 
 Custom OAuth with Google Sign-In. `lib/infrastructure/auth/` (barrel export via `index.ts`). Role hierarchy: owner > admin > member > guest. Admin endpoints require `requireRole("owner")`.
 
+### AI Integration
+
+**Location:** `lib/domain/ai/`
+
+AI SDK v6 integration with BYOK (Bring Your Own Key) support.
+
+- `types.ts` — Chat types, model configuration
+- `providers/` — Model provider factories (Anthropic, OpenAI) using `createAnthropic()` / `createOpenAI()`
+- `middleware/` — `defaultSettingsMiddleware` for model defaults
+- `tools/` — AI tool definitions: `metadata.ts` (client-safe, no Prisma), `registry.ts` (server-only, has Prisma)
+
+**AI SDK v6 conventions:**
+- `useChat()`: Use `transport: new DefaultChatTransport({ api, body })` — no `api`/`body` props directly
+- `useChat()`: No `initialMessages` — use `messages` field. No `input`/`setInput`/`handleSubmit` — use `sendMessage({ text })`
+- `tool()`: Uses `inputSchema` (not `parameters`), import `z` from `zod/v4`
+- `maxTokens` → `maxOutputTokens` in V3 call options
+- `ChatStatus`: `'ready' | 'submitted' | 'streaming' | 'error'`
+
+**AI tools ≠ Tool Surfaces** — separate directories (`lib/domain/ai/tools/` vs `lib/domain/tools/`), separate registries.
+
 ## API Routes
 
 All content endpoints under `app/api/content/`:
@@ -206,6 +227,7 @@ app/
 └── globals.css                 # Global styles + generated design tokens
 
 components/content/
+├── ai/                         # AI chat panel components
 ├── editor/                     # TipTap editor + BubbleMenu
 ├── toolbar/                    # ContentToolbar, ToolDebugPanel (Tool Surfaces)
 ├── tool-belt/                  # Tool management providers
@@ -227,6 +249,7 @@ lib/
 │   ├── editor/                 # TipTap extensions (extensions/, commands/)
 │   ├── export/                 # Converters, metadata sidecars, bulk export, validation
 │   ├── search/                 # Search filters
+│   ├── ai/                     # AI SDK v6 integration (providers, middleware, tools)
 │   ├── tools/                  # Tool Surfaces registry + context provider
 │   └── visualization/          # Excalidraw, Mermaid, diagrams.net collaboration
 ├── infrastructure/
@@ -242,7 +265,7 @@ lib/
     ├── system/                 # Liquid Glass tokens (surfaces, intents, motion)
     └── integrations/           # Third-party UI utilities
 
-state/                          # 15 Zustand stores (see State Management above)
+state/                          # 16 Zustand stores (see State Management above)
 prisma/                         # schema.prisma, migrations/, seed.ts
 ```
 
@@ -262,6 +285,7 @@ const glass0 = getSurfaceStyles("glass-0");
 
 ### Code Standards
 - TypeScript strict mode, no `any` types
+- Ignore directories with " 2" suffix (e.g., `content 2`, `editor 2`) — these are filesystem artifacts, not part of the build
 - Inline SVG for server component icons; `lucide-react` OK in client components only
 - Import from barrel exports: `lib/domain/editor`, `lib/infrastructure/auth`, `lib/features/settings`, `lib/domain/tools`
 - Use `lib/design/system/` tokens for styling
@@ -312,8 +336,3 @@ Portal rendering + boundary detection in `lib/core/menu-positioning.ts`. Two-pha
 
 **History:** `docs/notes-feature/work-tracking/history/` (Epoch 1-4 archives)
 
-## Active Plan Files
-
-Sprint plans are stored in `~/.claude/plans/`:
-- `sleepy-jingling-quiche.md` — Sprint 29 (Tool Surfaces, complete) + Sprint 30 (Universal Expandable Editor, planned)
-- `breezy-doodling-babbage.md` — Sprint 29 incremental reattempt plan (the version that was actually executed)

--- a/components/content/content/MainPanelContent.tsx
+++ b/components/content/content/MainPanelContent.tsx
@@ -8,7 +8,7 @@
 
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { ToolSurfaceProvider } from "@/lib/domain/tools";
 import { ContentToolbar } from "../toolbar";
 import { ToolDebugPanel } from "../toolbar/ToolDebugPanel";
@@ -108,6 +108,21 @@ export function MainPanelContent() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0); // Used to force refetch
+
+  // AbortController for in-flight save requests. When the user navigates to
+  // a different document, we abort any pending fetch to prevent Doc A's content
+  // from being written to Doc B's API endpoint.
+  const saveAbortControllerRef = useRef<AbortController | null>(null);
+
+  // Cancel in-flight saves whenever selectedContentId changes
+  useEffect(() => {
+    return () => {
+      if (saveAbortControllerRef.current) {
+        saveAbortControllerRef.current.abort();
+        saveAbortControllerRef.current = null;
+      }
+    };
+  }, [selectedContentId]);
 
   // Restore selection from URL or localStorage on mount
   useEffect(() => {
@@ -325,10 +340,31 @@ export function MainPanelContent() {
     [setOutline]
   );
 
-  // Auto-save handler
+  // Auto-save handler — hardened against cross-document race conditions.
+  // The contentId is captured in the closure at creation time. Before making
+  // the API call, we verify it still matches the currently-viewed document.
+  // An AbortController cancels any in-flight fetch if the user navigates away.
   const handleSave = useCallback(
     async (content: JSONContent) => {
       if (!selectedContentId) return;
+
+      // GUARD: Read the live selectedContentId from the store at save-time.
+      // If it no longer matches the closure's value, the user navigated away
+      // and this save targets a stale document — discard it.
+      const currentId = useContentStore.getState().selectedContentId;
+      if (currentId !== selectedContentId) {
+        console.warn(
+          `[MainPanelContent] Blocked cross-document save: handleSave targets ${selectedContentId}, but store has ${currentId}`
+        );
+        return;
+      }
+
+      // Cancel any previous in-flight save
+      if (saveAbortControllerRef.current) {
+        saveAbortControllerRef.current.abort();
+      }
+      const abortController = new AbortController();
+      saveAbortControllerRef.current = abortController;
 
       setIsSaving(true);
       setHasUnsavedChanges(true);
@@ -343,6 +379,7 @@ export function MainPanelContent() {
           body: JSON.stringify({
             tiptapJson: content,
           }),
+          signal: abortController.signal,
         });
 
         const result = await response.json();
@@ -351,12 +388,28 @@ export function MainPanelContent() {
           throw new Error(result.error?.message || "Failed to save note");
         }
 
+        // Final guard: verify we're still on the same document before
+        // updating parent state. This catches the edge case where the user
+        // navigated during the network round-trip.
+        const postSaveId = useContentStore.getState().selectedContentId;
+        if (postSaveId !== selectedContentId) {
+          console.warn(
+            `[MainPanelContent] User navigated during save — skipping state update for ${selectedContentId}`
+          );
+          return;
+        }
+
         console.log("Note saved successfully");
         setLastSaved(new Date());
         // Keep parent state in sync so re-mounts (e.g., ExpandableEditor
         // collapse/reopen) receive the latest persisted content
         setNoteContent(content);
-      } catch (err) {
+      } catch (err: unknown) {
+        // AbortError is expected when we cancel a save due to navigation
+        if (err instanceof DOMException && err.name === "AbortError") {
+          console.log(`[MainPanelContent] Save aborted for ${selectedContentId} (navigation)`);
+          return;
+        }
         console.error("Failed to save note:", err);
         throw err; // Re-throw so editor knows save failed
       } finally {
@@ -790,6 +843,7 @@ export function MainPanelContent() {
         {/* Editor */}
         <div className="flex-1 overflow-hidden">
           <MarkdownEditor
+            contentId={selectedContentId ?? undefined}
             content={noteContent}
             onSave={handleSave}
             onStatsChange={handleStatsChange}

--- a/components/content/editor/ExpandableEditor.tsx
+++ b/components/content/editor/ExpandableEditor.tsx
@@ -147,6 +147,7 @@ export function ExpandableEditor({
           onKeyDown={(e) => e.stopPropagation()}
         >
           <MarkdownEditor
+            contentId={contentId}
             content={editorContent}
             onSave={handleSave}
             editable={!readOnly}

--- a/components/content/editor/MarkdownEditor.tsx
+++ b/components/content/editor/MarkdownEditor.tsx
@@ -30,6 +30,8 @@ export interface EditorStats {
 }
 
 export interface MarkdownEditorProps {
+  /** Content ID this editor is bound to — used to prevent cross-document saves */
+  contentId?: string;
   /** Initial content in TipTap JSON format */
   content: JSONContent;
   /** Callback when content changes */
@@ -65,6 +67,7 @@ export interface MarkdownEditorProps {
 }
 
 export function MarkdownEditor({
+  contentId,
   content,
   onChange,
   onSave,
@@ -90,6 +93,15 @@ export function MarkdownEditor({
   // (parent updating state after our save) from genuine external updates
   // (navigation, refetch). Prevents cursor-jump-on-autosave bug.
   const lastSavedContentRef = useRef<JSONContent | null>(null);
+  // Snapshot the onSave callback in a ref so the timeout always uses the
+  // version that was current when the edit happened — not a stale or
+  // re-created callback that might target a different document.
+  const onSaveRef = useRef(onSave);
+  onSaveRef.current = onSave;
+  // Track which contentId this editor instance is bound to, so we can
+  // discard saves that fire after the user navigated away.
+  const contentIdRef = useRef(contentId);
+  contentIdRef.current = contentId;
 
   // Initialize editor
   const editor = useEditor({
@@ -141,16 +153,30 @@ export function MarkdownEditor({
         clearTimeout(saveTimeoutRef.current);
       }
 
-      // Schedule auto-save
-      if (onSave) {
+      // Schedule auto-save.
+      // IMPORTANT: Snapshot the save callback AND contentId at the moment the
+      // edit happens. This prevents the race condition where the user navigates
+      // to a different document during the debounce window — without this,
+      // React could give us a fresh handleSave targeting the NEW document,
+      // causing Doc A's content to overwrite Doc B.
+      const snapshotSave = onSaveRef.current;
+      const snapshotContentId = contentIdRef.current;
+      if (snapshotSave) {
         saveTimeoutRef.current = setTimeout(async () => {
+          // Guard: if contentId changed since the edit, discard this save
+          if (snapshotContentId && contentIdRef.current !== snapshotContentId) {
+            console.warn(
+              `[MarkdownEditor] Discarding stale save: edited ${snapshotContentId}, now viewing ${contentIdRef.current}`
+            );
+            return;
+          }
           setIsSaving(true);
           try {
             // Track the content object we're about to save. When the parent
             // calls setNoteContent(content) after save, it echoes back as a
             // prop change. The ref lets us skip the setContent call for that echo.
             lastSavedContentRef.current = json;
-            await onSave(json);
+            await snapshotSave(json);
             setHasUnsavedChanges(false);
           } catch (error) {
             console.error("Failed to save:", error);
@@ -244,14 +270,16 @@ export function MarkdownEditor({
     return () => window.removeEventListener("scroll-to-heading", handleScrollToHeading);
   }, [editor]);
 
-  // Cleanup timeout on unmount
+  // Cancel pending saves when contentId changes (user navigated away)
+  // or on unmount. This is the first line of defense against cross-document saves.
   useEffect(() => {
     return () => {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
       }
     };
-  }, []);
+  }, [contentId]);
 
   return (
     <div className={`flex flex-col h-full ${className}`}>

--- a/docs/notes-feature/STATUS.md
+++ b/docs/notes-feature/STATUS.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-03-01
-current_epoch: 7
-current_sprint: 34
+last_updated: 2026-03-06
+current_epoch: 8
+current_sprint: 35
 sprint_status: complete
 ---
 
@@ -27,26 +27,37 @@ WHAT TO UPDATE:
 
 SYNC WITH: work-tracking/CURRENT-SPRINT.md (detailed tracking)
 FULL GUIDE: STATUS-MAINTENANCE-GUIDE.md
+
+SPRINT EXECUTION PROTOCOL:
+Before commencing any sprint, always ask the user for input on the sprint plan
+before planning and executing. There may be additions or modifications.
 -->
 
 ## Current Work
 
-### Last Completed Sprint: Sprint 34 - Chat UI, AI Tools, @ Mentions
-**Duration**: Feb 28 - Mar 1, 2026
-**Branch**: `epoch-7/sprint-34`
-**Status**: ✅ COMPLETE — merged to main via PR
-
-### Active Epoch: Epoch 7 - AI Integration
-**Duration**: Feb-Apr 2026 (8 weeks, 4 sprints)
-**Theme**: AI chat, AI tools, agents, speech, BYOK, RAG
+### Active Epoch: Epoch 8 - Editor Stabilization
+**Duration**: 2 sprints (35-36)
+**Theme**: Bug fixes, TipTap rules, focus guardrails, table rebuild
 
 **Sprint Plan**:
-- Sprint 33: AI Foundation + Settings UI ✅
-- Sprint 34: Chat UI & AI Tools + Tool Settings ✅
-- Sprint 35: Planning (BYOK, Speech, Agent, or new priorities)
-- Sprint 36: Planning
+- Sprint 35: TipTap Rules Doc + Input Rule Bug Fixes (complete)
+- Sprint 36: Table Rebuild + Link Fix + Cleanup + Focus Guardrails (planned)
+
+### Next Sprint: Sprint 36 - Table Rebuild + Link Fix + Cleanup + Focus Guardrails
+**Status**: Planned — awaiting user input before commencing
 
 ## Recent Completions (Last 30 Days)
+
+**Mar 6, 2026**: Sprint 35 TipTap Rules Doc + Input Rule Bug Fixes — COMPLETE
+- TIPTAP-EDITOR-RULES.md created (living document — expand as features are added)
+- Tag autocomplete 2-second delay before popup appears (heading shortcuts get priority)
+- `##` in query immediately dismisses tag autocomplete via `allow()` guard
+- Space during delay propagates to ProseMirror for heading conversion (`# ` → H1)
+- Slash command restricted to first character of empty lines only
+- HeadingBackspace extension: empty H1→`#`, H2→`##`, H3→`###` in paragraph
+- Removed macOS Finder duplicate `index.d 2.ts` from Prisma generated output
+- Build gate passed
+- 4 files changed, 1 new extension file
 
 **Mar 1, 2026**: Sprint 34 Chat UI, AI Tools, @ Mentions — COMPLETE
 - ChatPanel (right sidebar): transient streaming chat with "Save conversation" to file tree
@@ -75,52 +86,32 @@ FULL GUIDE: STATUS-MAINTENANCE-GUIDE.md
 - Build gate passed
 
 **Feb 27, 2026**: Sprint 32 Editor Stability & Polish Complete
-- ✅ BubbleMenu persistence fix — root cause was TipTap React wrapper's shared `"bubbleMenu"` meta key causing cross-contamination between text and table BubbleMenu instances; stabilized shouldShow callbacks to module-level functions
-- ✅ Removed `.focus()` from BubbleMenu command chains (prevents focus/blur cycle exhausting preventHide flag)
-- ✅ Removed invalid `tippyOptions` prop (TipTap v3 uses Floating UI, not tippy.js)
-- ✅ Outline click-to-scroll via CustomEvent bridge pattern (text+level matching)
-- ✅ ExpandableEditor tag/wiki-link callback threading (fetchTags, createTag, fetchNotesForWikiLink, onWikiLinkClick)
-- ✅ Keyboard event scoping — `stopPropagation` on ExpandableEditor container
-- ✅ Tag/heading `# ` conflict fix — Space with empty query propagates to ProseMirror heading input rule
-- ✅ tag-suggestion `component.ref` runtime error guard
+- BubbleMenu persistence fix (root cause: shared meta key cross-contamination)
+- Outline click-to-scroll via CustomEvent bridge
+- ExpandableEditor tag/wiki-link callback threading
+- Tag/heading `# ` conflict fix
+- Build gate passed
 
 **Feb 26, 2026**: Sprint 31 Lossless Export/Import Round-Trip Complete
-- ✅ Custom two-pass markdown parser (block + inline) → TipTap JSON
-- ✅ Semantic extensions: tags, wiki-links, callouts, task lists, tables
-- ✅ Sidecar reader (.meta.json consumption for lossless restoration)
-- ✅ Import API endpoint (POST /api/content/import, multipart/form-data)
-- ✅ Import button in toolbar (Tool Surfaces registry)
-- ✅ Round-trip verification utility (dev console tool)
-- ✅ syncContentTags extracted to shared module
-- **Pending manual testing** (macOS Finder issue blocking file picker)
+- Custom two-pass markdown parser → TipTap JSON
+- Sidecar reader, Import API, toolbar button
+- Pending manual testing (macOS Finder issue)
 
 **Feb 25, 2026**: Sprint 30 Universal Expandable Editor Complete
-- ✅ ExpandableEditor component (collapsible TipTap for all content types)
-- ✅ Centralized integration in MainPanelContent
-- ✅ MarkdownEditor compact mode
-- ✅ API upsert for notePayload (any content type can now have notes)
-- **Known issue**: BubbleMenu focus-theft regression (pre-existing)
-
 **Feb 24, 2026**: Sprint 29 Tool Surfaces Architecture Complete
-- ✅ Declarative tool registry (ToolDefinition, queryTools)
-- ✅ ToolSurfaceProvider context + handler registration
-- ✅ ContentToolbar component (toolbar surface)
-- ✅ BubbleMenu wired to registry (module-level, no hooks)
-- ✅ RightSidebarHeader wired to registry (dynamic tabs)
-- ✅ ToolDebugPanel (dev-only, Cmd+Shift+T)
 
-**Feb 18, 2026**: Sprint 27 Core Folder Views Complete
-- ✅ List view component (sort controls, file type icons, keyboard navigation)
-- ✅ Grid view component (responsive layout, thumbnails, hover effects)
-- ✅ Kanban view component (drag-and-drop, status columns)
-- ✅ Folder organization system operational
+## Up Next
 
-## Up Next (Sprint 35+)
+### Epoch 8: Editor Stabilization (Sprints 35-36)
+Fix all known editor bugs, establish TipTap rules, implement focus guardrails.
 
-**Planning in progress** — original Epoch 7 plan had BYOK/Speech/Agent for Sprint 35
-and RAG/Polish for Sprint 36, but new priorities may redirect.
+### Epoch 9: Editor Enhancements (Sprints 37-42)
+Images, URL/OG embeds, YouTube, drag/reorder, templates, snapshots, context menu.
 
-**See**: [Backlog](work-tracking/BACKLOG.md) for prioritized items
+### Epoch 10: AI TipTap (Sprints 43-47)
+Pretty AI responses, agent editing tools, AI edit highlighting, chat outlines, AI image generation.
+
+**See**: [Epoch Plans](work-tracking/epochs/) for detailed sprint breakdowns
 
 ## Known Issues & Blockers
 
@@ -128,12 +119,18 @@ and RAG/Polish for Sprint 36, but new priorities may redirect.
 - **macOS Finder**: File picker not opening on dev machine — blocks manual testing of import feature
 - **macOS mmap**: `mmap failed: Operation timed out` on `git push` from main working directory — workaround: git bundle → fresh clone → push from /tmp
 
+### Known Editor Bugs (Sprint 36 targets)
+- `>` blockquote affects child content
+- Cursor adjacent to URL inherits link formatting
+- Header conversion in paragraph with `hardBreak` converts all text
+- Table extra column visual bug
+- Old console.log statements throughout editor code
+
 ### Known Limitations
-- **Sprint 31 Import**: Untested pending Finder fix — parser, API, and toolbar button built but not manually verified
-- **PDF/DOCX Export**: Stub implementations (need Puppeteer/docx library integration)
+- **Sprint 31 Import**: Untested pending Finder fix
+- **PDF/DOCX Export**: Stub implementations
 - **AI Chat**: Requires user-provided API keys (BYOK configured in /settings/ai)
-- **External Links**: Some sites have SSL certificate errors (require dev-mode bypass)
-- **Outline Panel**: Auto-scroll on editor scroll needs intersection observer (click-to-scroll works)
+- **Outline Panel**: Auto-scroll on editor scroll needs intersection observer
 - **Chat mentions**: Only injects note `searchText` (max 2000 chars), not full TipTap JSON
 
 ### Technical Debt
@@ -152,31 +149,39 @@ and RAG/Polish for Sprint 36, but new priorities may redirect.
 - Sprint 34: ~25 points (Chat UI + Tools + Mentions)
 - **Average**: ~19 points/sprint
 
-### Epoch 7 Progress
-- **Sprint 33**: ✅ Complete (AI Foundation)
-- **Sprint 34**: ✅ Complete (Chat UI & Tools)
-- **Sprint 35**: Planning
-- **Sprint 36**: Planning
+### Epoch Progress
+- **Epoch 7** (AI Integration): ✅ Sprints 33-34 complete; Sprints 35-36 redirected to Epoch 8
+- **Epoch 8** (Editor Stabilization): In Progress — Sprint 35 complete, Sprint 36 planned
+- **Epoch 9** (Editor Enhancements): Planned (Sprints 37-42)
+- **Epoch 10** (AI TipTap): Planned (Sprints 43-47)
 
 ## Roadmap
 
-### Epoch 6: Collaboration (Future)
-**Theme**: Real-time collaboration, sharing, permissions
+### Epoch 8: Editor Stabilization (Active)
+**Theme**: Bug fixes, TipTap rules, focus guardrails, table rebuild
 
-### Epoch 7: AI Integration (Active)
-**Theme**: AI chat, embeddings, semantic search, BYOK, tools, agents, speech
+### Epoch 9: Editor Enhancements (Planned)
+**Theme**: Images, embeds, templates, snapshots, context menu, drag/reorder
 
-### Epoch 8: Mobile & Performance (Future)
-**Theme**: PWA, offline support, performance optimization
+### Epoch 10: AI TipTap (Planned)
+**Theme**: AI responses, agent tools, edit highlighting, chat outlines, image generation
+
+### Future (Unplanned)
+- **Collaboration & Sharing** — real-time editing, sharing, security review
+- **UI Revisions** — theming, custom styles
+- **Main Panel Multiple Tabs** — multi-document editing
+- **YouTube Playlists & Summarizing** — video content management
 
 ## Quick Links
 
-- [Current Sprint](work-tracking/CURRENT-SPRINT.md) - Sprint 34 details
+- [Current Sprint](work-tracking/CURRENT-SPRINT.md) - Sprint 35 details
 - [Backlog](work-tracking/BACKLOG.md) - Prioritized work items
+- [Epoch Plans](work-tracking/epochs/) - Epoch 8, 9, 10, future stubs
+- [TipTap Editor Rules](guides/editor/TIPTAP-EDITOR-RULES.md) - Editor behavior rules
 - [AI Development Guide](../CLAUDE.md) - For AI assistants
 - [Start Here](00-START-HERE.md) - Documentation index
 
 ---
 
-**Last Updated**: Mar 1, 2026
-**Next Review**: Sprint 35 planning
+**Last Updated**: Mar 6, 2026
+**Next Review**: Sprint 36 kickoff (user input required before commencing)

--- a/docs/notes-feature/guides/editor/TIPTAP-EDITOR-RULES.md
+++ b/docs/notes-feature/guides/editor/TIPTAP-EDITOR-RULES.md
@@ -1,0 +1,165 @@
+# TipTap Editor Rules
+
+**Canonical behavior rules for the Digital Garden TipTap editor.** All editor extensions, input rules, and focus management must follow these rules. This document must be reviewed and approved before any focus or input rule changes are implemented.
+
+---
+
+## 1. Focus Rules
+
+### Single-Gate Principle
+The editor has **one gate** that controls focus changes. Only intentional, user-initiated actions pass through the gate. Everything else is blocked.
+
+**Allowed focus changes** (intentional):
+- User clicks inside the editor
+- User clicks an outline item in the sidebar panel (gated autofocus)
+- User triggers a focus-related keyboard shortcut
+- A document-level focus feature explicitly requests focus (e.g., search-and-replace "jump to next match")
+
+**Blocked focus changes** (distractions):
+- Component re-renders causing focus shift
+- State updates from Zustand stores moving focus
+- Sidebar interactions (other than outline click) stealing focus
+- Auto-save operations triggering focus events
+- BubbleMenu, TableBubbleMenu, or toolbar interactions stealing focus (must use `onMouseDown={e => e.preventDefault()}`)
+- Suggestion menus (tag, wiki-link, slash command) closing and moving focus away from the editor
+
+### Implementation Guidelines
+- Never call `editor.commands.focus()` from BubbleMenu command chains (causes focus/blur cycle)
+- All BubbleMenu and toolbar buttons must have `onMouseDown={e => e.preventDefault()}`
+- Do NOT use `stopPropagation()` on editor events — TipTap needs event propagation
+- Use `contentEditable` container focus, not programmatic `.focus()` calls
+- When closing suggestion menus, focus must return to the original cursor position
+
+---
+
+## 2. Input Rule Priority
+
+### Hierarchy (highest to lowest)
+1. **Heading conversion** (`# `, `## `, `### `, etc.)
+2. **Blockquote** (`> `)
+3. **List conversion** (`- `, `1. `)
+4. **Task list** (`- [ ] `, `- [x] `)
+5. **Code block** (`` ``` ``)
+6. **Horizontal rule** (`---`)
+7. **Callout** (`> [!type]`)
+8. **Autocomplete triggers** (`#` for tags, `[[` for wiki-links, `/` for slash commands)
+
+### Conflict Resolution
+When two input rules share the same trigger character:
+- **The structural rule always wins** over the autocomplete rule
+- Example: `## ` (heading) beats `#` (tag autocomplete) — the heading rule fires on `# ` (with space), tag autocomplete must wait for a delay and confirm no heading is forming
+
+---
+
+## 3. Autocomplete Rules
+
+### Universal Autocomplete Behavior
+These rules apply to ALL autocomplete/suggestion triggers (tags, wiki-links, slash commands):
+
+1. **Delay**: Autocomplete must not appear for at least **2 seconds** after the trigger character is typed
+2. **Space cancels**: If a space character is typed at any point after the trigger, autocomplete is **immediately cancelled** — no exceptions
+3. **Continued typing of trigger character cancels**: If the user types additional trigger characters (e.g., `##`), autocomplete for the first trigger is cancelled
+4. **Escape closes**: Pressing Escape always closes autocomplete and returns focus to the editor cursor
+
+### Tag Autocomplete (`#`)
+- Trigger: `#` character
+- **Must NOT trigger** inside headings (the `#` is part of the heading syntax)
+- **Must NOT trigger** when followed by a space — `# ` is a heading, not a tag
+- `##` must cancel tag autocomplete from the first `#` (user is typing a heading)
+- 2-second delay before showing the suggestion menu
+- If no tag match is found after the delay, show "Create new tag" option
+
+### Wiki-Link Autocomplete (`[[`)
+- Trigger: `[[` (two characters)
+- Space after `[[` still allows autocomplete (spaces are valid in note titles)
+- Closing `]]` or pressing Escape cancels
+
+### Slash Commands (`/`)
+- Trigger: `/` character
+- **Must only trigger on the first character of an empty line** (paragraph with no preceding text)
+- If the line has any text before `/`, do NOT trigger slash commands
+- If `/` is typed in the middle of existing text, treat as literal character
+
+---
+
+## 4. Header Behavior
+
+### Markdown-to-Header Conversion
+- Typing `# ` (hash + space) at the start of a line converts to H1
+- Typing `## ` converts to H2, `### ` to H3 (up to H6)
+- The conversion only happens when a space follows the hash chain
+- **Only the text before a `hardBreak` is converted** — if a paragraph contains a `hardBreak`, text after it stays as-is
+
+### Header Escape (Backspace Behavior)
+- Backspace on an **empty header** reverts to a paragraph containing the appropriate `#` chain for that level
+  - Empty H1 → paragraph with text `#`
+  - Empty H2 → paragraph with text `##`
+  - Empty H3 → paragraph with text `###`
+- From the `#` chain paragraph, pressing space triggers heading conversion again (re-entering the heading)
+- From the `#` chain paragraph, pressing Backspace deletes `#` characters normally
+
+### Header and Tag Interaction
+- `# ` (H1 with space) must NEVER trigger tag autocomplete
+- The heading input rule fires on space, which must consume the event before tag autocomplete can activate
+- `##` typed quickly must cancel any tag autocomplete from the first `#`
+
+---
+
+## 5. Blockquote Rules
+
+### Current Line Only
+- Typing `>` as the first character on a line creates a blockquote for **that line only**
+- `>` must NEVER affect child content, sibling lines, or nested content
+- If the cursor is inside existing content with children (e.g., a list with sub-items), `>` only wraps the current text node
+
+---
+
+## 6. Link/URL Behavior
+
+### Cursor and Formatting
+- When the cursor is **immediately adjacent** to a link (before or after), the cursor must NOT inherit the link's text formatting
+- The user must click **inside** the link text to edit it
+- Clicking adjacent to a link places the cursor in normal (non-link) text
+
+### Link Editing
+- Right-clicking a link opens a lightweight URL dialog
+- The dialog must be:
+  - Small and simple (minimal glass blur / background effects)
+  - Centered on the page
+  - Always escapable (Escape key, click outside, or close button)
+- The dialog allows editing the URL and display text
+
+---
+
+## 7. Extension Registration Order
+
+When registering extensions, ensure the order respects the input rule priority:
+1. StarterKit (provides headings, lists, blockquotes, code blocks, horizontal rule)
+2. Custom structural extensions (Callout, TaskList, BulletListBackspace)
+3. Inline extensions (Link, WikiLink, Tag)
+4. Suggestion/autocomplete extensions (SlashCommands, TagSuggestion, WikiLinkSuggestion)
+
+This ensures structural input rules are registered first and take priority over autocomplete triggers.
+
+---
+
+## 8. Console Logging Policy
+
+- **No `console.log` in production code** — remove all debug logging before merging
+- `console.warn` is acceptable for genuinely unexpected but non-fatal conditions (e.g., missing handler)
+- `console.error` is acceptable for actual errors that should be investigated
+- For development debugging, use a debug flag or the existing DebugPanel (Cmd+Shift+T)
+
+---
+
+## References
+- [TipTap Input Rules](https://tiptap.dev/docs/editor/api/input-rules)
+- [ProseMirror Plugin Priority](https://prosemirror.net/docs/ref/#state.PluginSpec.priority)
+- `lib/domain/editor/extensions-client.ts` — extension registration
+- `lib/domain/editor/extensions/` — all custom extensions
+- `components/content/editor/` — editor components
+
+---
+
+**Last Updated**: Mar 5, 2026
+**Status**: Active — living document. Expand as new TipTap features are added.

--- a/docs/notes-feature/work-tracking/BACKLOG.md
+++ b/docs/notes-feature/work-tracking/BACKLOG.md
@@ -1,294 +1,201 @@
 ---
-last_updated: 2026-03-01
+last_updated: 2026-03-05
 ---
 
 # Sprint Backlog
 
-**Prioritized work items for upcoming sprints**
+**Prioritized work items for upcoming sprints, organized by epoch.**
 
-## Sprint 28: Advanced Folder Views + Payload Stubs (Deferred)
-**Status**: Deferred — deprioritized in favor of Epoch 7 AI work
-**Estimated**: 20-25 story points
+**Sprint Execution Protocol**: Before commencing any sprint, always ask the user for input before planning and executing — there may be additions or modifications.
 
-### Backlogged from Sprint 27 (4 items, 12 points)
-**Context**: Core folder views (List, Grid, Kanban) shipped in Sprint 27. These advanced features deferred as nice-to-have.
+---
 
-- [ ] **FP-004**: Table view component (3 pts) - Advanced folder view
-  - Sortable columns (name, type, size, date)
-  - Column resize and reorder
-  - Row selection (multi-select)
-  - Filter controls
+## Epoch 8: Editor Stabilization (Sprints 35-36)
 
-- [ ] **FP-005**: Timeline view component (5 pts) - Advanced folder view
-  - Chronological visualization
-  - Date grouping (day, week, month)
-  - Zoom controls
-  - Event markers
+**Goal**: Fix all known editor bugs, establish rules, implement focus guardrails.
+**Detailed plan**: [epoch-8-editor-stabilization.md](epochs/epoch-8-editor-stabilization.md)
 
-- [ ] **FP-006**: View preference persistence (2 pts) - Enhancement
-  - User settings integration
-  - Per-folder preference storage
-  - Fallback to folder default view
+### Sprint 35: TipTap Rules Doc + Input Rule Bug Fixes
+- [ ] Create TIPTAP-EDITOR-RULES.md (focus rules, input priorities, autocomplete conventions)
+- [ ] Tag/heading conflict: `#` triggers tag autocomplete instead of heading
+- [ ] `## ` triggers tag autocomplete, sometimes fails to convert to H2
+- [ ] `##` shows persistent tag autocomplete after continued typing
+- [ ] Tag autocomplete: 2-second delay, space breaks autocomplete
+- [ ] Slash command: only on first character of empty line
+- [ ] Header escape: backspace on empty header → `#` chain
+- [ ] `# ` (H1 with space) must never trigger tag autocomplete
 
-- [ ] **FP-007**: View switcher UI (2 pts) - Enhancement
-  - View mode toggle buttons
-  - Active view indicator
-  - Keyboard shortcuts (Cmd+1-5)
+### Sprint 36: Table Rebuild + Link Fix + Cleanup + Focus Guardrails
+- [ ] **Table rebuild**: remove ALL CSS + logic, rebuild from TipTap docs (user approves before moving on)
+- [ ] URL/link escape: cursor adjacent to link must not inherit formatting; lightweight URL dialog
+- [ ] `>` blockquote: only affects current line, never child content
+- [ ] Header in paragraph with `hardBreak`: only convert text before hardBreak
+- [ ] Remove old console.log/console.warn from editor code
+- [ ] Implement focus guardrails per approved rules doc
 
-### High Priority (Payload Stubs)
+---
 
-- [ ] **EX-001**: ExcalidrawPayload schema and model (2 pts)
-  - Database model with Prisma schema
-  - JSON storage for drawing data
-  - Basic CRUD operations
+## Epoch 9: Editor Enhancements (Sprints 37-42)
 
-- [ ] **EX-002**: Excalidraw stub viewer component (3 pts)
-  - Placeholder UI with "Coming Soon" message
-  - Preview thumbnail (if available)
-  - Action buttons (edit, delete, export)
+**Goal**: Full-featured content editor with images, embeds, templates, snapshots, rich interactions.
+**Detailed plan**: [epoch-9-editor-enhancements.md](epochs/epoch-9-editor-enhancements.md)
 
-- [ ] **MR-001**: MermaidPayload schema and model (2 pts)
-  - Database model for diagram-as-code
-  - Text storage for Mermaid syntax
-  - Basic CRUD operations
+### Sprint 37: Images in TipTap + Referenced Content Lifecycle
+- [ ] Enable `@tiptap/extension-image` (installed, not configured)
+- [ ] Image upload via slash command + bubble menu
+- [ ] Image paste → FilePayload REFERENCED content in same folder
+- [ ] Image URL paste → ExternalPayload REFERENCED content
+- [ ] Image resize (drag handles or bubble menu)
+- [ ] Lazy loading
+- [ ] Move API: REFERENCED content follows parent on move
+- [ ] Delete REFERENCED content when removed from document
+- [ ] Image caption (custom figure node)
+- [ ] Image node `source` attribute prep for AI image generation (Sprint 45/47)
 
-- [ ] **MR-002**: Mermaid stub viewer component (3 pts)
-  - Placeholder UI
-  - Code preview (read-only)
-  - Future: Live rendering with mermaid.js
+### Sprint 38: URL/OG Embeds + YouTube + Bubble Menu
+- [ ] URL paste with OG metadata: 3 display modes (inline, small card, full preview)
+- [ ] YouTube auto-embed with fullscreen (custom iframe node)
+- [ ] Bubble menu: text color, highlight, subscript, superscript, strikethrough, text alignment
 
-- [ ] **CV-001**: CanvasPayload schema and model (2 pts)
-  - Database model for infinite canvas
-  - JSON storage for canvas state
-  - Basic CRUD operations
+### Sprint 39: Gated Autofocus + Outline + Drag/Reorder
+- [ ] Outline click → autofocus with CSS flash animation
+- [ ] Tasks in outline sidebar panel
+- [ ] Agentic edits update outlines in real-time
+- [ ] Notion-style drag/reorder: whole blocks only (paragraphs, headings, lists, images, code, callouts, tables)
+- [ ] List items reorderable within parent list
+- [ ] UI: grip icon on hover, ghost preview, drop indicator line
 
-- [ ] **CV-002**: Canvas stub viewer component (3 pts)
-  - Placeholder UI
-  - Thumbnail preview
-  - Future: Integration with tldraw or react-flow
+### Sprint 40: Templates / Forced Content Structure (full sprint)
+- [ ] Template builder UI in settings (full TipTap editor instance)
+- [ ] All TipTap features supported; wiki-links become `[[Untitled]]` placeholders
+- [ ] No templates within templates (hard rule)
+- [ ] Apply: replace on new notes, insert at cursor on existing
+- [ ] App-wide templates (pre-built) + user-created templates
+- [ ] Block forced content with "x" delete button
+- [ ] "Save selection as template" from any editor
+- [ ] "Recommend a template" → repo feedback link
 
-### Medium Priority
+### Sprint 41: Snapshots / Document History (full sprint, may expand)
+- [ ] Research spike: diff-based vs full snapshot, compression, retention
+- [ ] 30-day retention with auto-prune; user can pin snapshots
+- [ ] Document history: rollback, audit, branch
+- [ ] AI/agentic changes tracked
+- [ ] Safe DB migration (additive only, no data loss)
+- [ ] Guard regressions: save perf, DB bloat, ID conflicts, restore warnings
+- [ ] UI: snapshot browser in content toolbar + universal editor toolbar
 
-- [ ] **WB-001**: WhiteboardPayload schema and model (2 pts)
-  - Database model for whiteboard
-  - JSON storage for whiteboard data
-  - Basic CRUD operations
+### Sprint 42: Editor Context Menu + Syntax Highlighting + Drawing
+- [ ] Editor context menu: inspect, select all, copy, paste, image insert, AI tools, autocorrect
+- [ ] Explore wrapping browser context menu (app items above browser items)
+- [ ] Spell check: browser spellcheck + AI proofreader approach
+- [ ] Enhanced syntax highlighting (more languages via lowlight)
+- [ ] Drawing: Excalidraw integration (not TipTap's experimental Vue drawing)
 
-- [ ] **WB-002**: Whiteboard stub viewer component (3 pts)
-  - Placeholder UI
-  - Future: Real-time collaboration support
+---
 
-- [ ] **PDF-001**: Dedicated PdfPayload schema (2 pts)
-  - Separate from FilePayload
-  - Annotation storage support
-  - Metadata extraction
+## Epoch 10: AI TipTap (Sprints 43-47)
 
-- [ ] **PDF-002**: PDF stub viewer with annotations (5 pts)
-  - Enhanced viewer beyond basic FilePayload
-  - Annotation UI (placeholder)
-  - Future: PDF.js with annotation layer
+**Goal**: Deep AI integration into the editor experience.
+**Detailed plan**: [epoch-10-ai-tiptap.md](epochs/epoch-10-ai-tiptap.md)
 
-### Context Menu Integration
+### Sprint 43: Pretty Bot Response Enhancements
+- [ ] Visual parity with OpenAI/Claude across ALL AI experiences (chat, side panel, inline)
+- [ ] Rich rendering: headers, code blocks with syntax highlighting, lists, tables, inline code
+- [ ] Model-agnostic formatting
 
-- [ ] **CM-001**: Add "New → Excalidraw" menu item (1 pt)
-- [ ] **CM-002**: Add "New → Mermaid Diagram" menu item (1 pt)
-- [ ] **CM-003**: Add "New → Canvas" menu item (1 pt)
-- [ ] **CM-004**: Add "New → Whiteboard" menu item (1 pt)
+### Sprint 44: AI Text-Editing Tools — GATED BUILD
+- [ ] 8 tools, each built and tested individually before proceeding:
+  - Gate 1: `read_first_chunk`, Gate 2: `read_next_chunk`, Gate 3: `read_previous_chunk`
+  - Gate 4: `apply_diff`, Gate 5: `replace_document`
+  - Gate 6: `plan`, Gate 7: `ask_user`, Gate 8: `finish_with_summary`
+- [ ] Built-in commands: summarize, rephrase, translate (streaming)
+- [ ] Tab-triggered autocompletion
+- [ ] Bubble menu AI tools button
+- [ ] Meld with existing `lib/domain/ai/` — no duplication
 
-### API Endpoints
+### Sprint 45: AI Edit Highlighting + AI Image Insert
+- [ ] Human vs machine content marking (background/highlighting)
+- [ ] Copy outside app: AI formatting stripped; within app: preserved (if enabled)
+- [ ] Settings toggle + CSS retroactive enable/disable
+- [ ] "Paste as AI" special paste
+- [ ] No overlap: typing in AI paragraph = human content
+- [ ] AI image icon flag
+- [ ] Insert AI-generated images into TipTap (uses Sprint 37 infra + `source: 'ai-generated'`)
 
-- [ ] **API-001**: Create payload endpoints for all new types (3 pts)
-  - POST /api/content/content (update to support new types)
-  - Validation for each payload type
-  - Error handling
+### Sprint 46: Chat Content Outlines
+- [ ] Outline sidebar for ChatPayload nodes
+- [ ] Compact prompt outline (first line + "...")
+- [ ] Agent content: header/list previews
+- [ ] Click → autofocus with Sprint 39 animations
 
-## Sprint 29: Tool Surfaces Architecture ✅ COMPLETE
-**Duration**: Feb 19-24, 2026 (Completed)
-**Branch**: `content/tool-surfaces`
-**Plan**: `~/.claude/plans/breezy-doodling-babbage.md`
+### Sprint 47: AI Image Generation
+- [ ] AI image generation in chat + side panel
+- [ ] Generated images → REFERENCED FilePayload
+- [ ] Referenced content follows parent (Sprint 37)
+- [ ] Drag AI content to file tree (new copy) or TipTap note (referenced)
 
-Declarative tool registry mapping tools to UI surfaces (toolbar, toolbelt, sidebar-tab) with content-type filtering. See `lib/domain/tools/`.
+---
 
-- [x] Pure types (ToolSurface, ToolDefinition, ToolInstance, ToolQuery)
-- [x] Static registry + queryTools() filter/sort
-- [x] ToolSurfaceProvider context + handler registration
-- [x] ContentToolbar component (export, copy link)
-- [x] BubbleMenu wired to registry (module-level, no hooks) + focus fix
-- [x] RightSidebarHeader wired to registry (dynamic tabs by content type)
-- [x] ToolDebugPanel (dev-only, Cmd+Shift+T)
+## Future Epochs (Unplanned)
 
-## Sprint 30: Universal Expandable TipTap Editor ✅ COMPLETE
-**Duration**: Feb 25, 2026
-**Branch**: `content/universal-notes`
-**Plan**: `~/.claude/plans/sleepy-jingling-quiche.md` (Sprint 30 section)
+**Detailed stubs**: [future-epochs.md](epochs/future-epochs.md)
 
-Every content type gets a collapsible TipTap editor for annotations/notes. Centralized integration in MainPanelContent (not per-viewer).
+### Collaboration & Sharing
+- Real-time editing (TipTap collaboration), content sharing, security review required
+- Mentions, annotations, commenting layers
+- Session validation for AI features, editor session limits
 
-- [x] **UE-001**: ExpandableEditor component (5 pts)
-  - `components/content/editor/ExpandableEditor.tsx`
-  - Reuses MarkdownEditor with compact mode
-  - Per-node expansion state in localStorage
-  - Word count badge when content exists
+### UI Revisions
+- Default themes + custom user themes, editor styling, font/color customization
 
-- [x] **UE-002**: Integrate into MainPanelContent (5 pts)
-  - Centralized: wraps all non-note viewers with ExpandableEditor
-  - No per-viewer modifications needed
-  - Uses existing noteContent + handleSave from MainPanelContent
+### Main Panel Multiple Tabs
+- Multi-document editing, Obsidian-like tabs, collaboration-friendly
 
-- [x] **UE-003**: MarkdownEditor compact mode (3 pts)
-  - `compact` prop: smaller prose, compact padding (120px min-height)
-  - `placeholder` prop accepted (not yet wired through extension factory)
+### YouTube Playlists & Summarizing (much later)
+- Playlist support, AI video summarization, transcript indexing
 
-- [x] **UE-004**: API upsert for notePayload (2 pts)
-  - PATCH uses `prisma.notePayload.upsert()` (was conditional update)
-  - Any content type can now create/update notes via API
+---
 
-**Known Issues**: None remaining (BubbleMenu regression fixed in Sprint 32)
+## Deferred Items (Icebox)
 
-## Sprint 31: Lossless Export/Import Round-Trip ✅ COMPLETE
-**Duration**: Feb 25-26, 2026 (Completed)
-**Branch**: `content/universal-notes`
+### From Sprint 28 Backlog (Epoch 5-6)
+- [ ] Table view component for folders (3 pts)
+- [ ] Timeline view component for folders (5 pts)
+- [ ] View preference persistence (2 pts)
+- [ ] View switcher UI with keyboard shortcuts (2 pts)
 
-Lossless export/import round-trip. Custom two-pass parser, sidecar consumption, toolbar integration.
+### Payload Stubs
+- [ ] ExcalidrawPayload schema + stub viewer
+- [ ] MermaidPayload schema + stub viewer (includes Mermaid in TipTap — deferred from earlier work)
+- [ ] CanvasPayload schema + stub viewer
+- [ ] WhiteboardPayload schema + stub viewer
+- [ ] Dedicated PdfPayload with annotations
 
-- [x] **IM-001**: Markdown→TipTap parser — core syntax (5 pts)
-- [x] **IM-002**: Markdown→TipTap parser — semantic extensions (5 pts)
-- [x] **IM-003**: Sidecar reader — metadata restoration (3 pts)
-- [x] **IM-004**: Import API endpoint (3 pts)
-- [x] **IM-005**: Import button in ContentToolbar (2 pts)
-- [x] **IM-006**: Round-trip verification utility (2 pts)
-
-**Pending**: Manual testing (macOS Finder file picker not working)
-
-## Sprint 32: Editor Stability & Polish ✅ COMPLETE
-**Duration**: Feb 26-27, 2026 (Completed)
-**Branch**: `content/sprint-32`
-**Plan**: `~/.claude/plans/breezy-doodling-babbage.md`
-
-Post-feature stability sprint. Fixed regressions from Sprints 29-31.
-
-- [x] **BM-001**: BubbleMenu cross-contamination fix (5 pts)
-  - Root cause: TipTap React wrapper uses shared `"bubbleMenu"` meta key for all instances
-  - TableBubbleMenu's inline `shouldShow` overwrote text BubbleMenu's `shouldShow` on every re-render
-  - Fix: Stable module-level `shouldShow` for both menus; removed `.focus()` from commands; removed invalid `tippyOptions`
-- [x] **OL-001**: Outline click-to-scroll (3 pts)
-  - CustomEvent bridge (`scroll-to-heading`) from RightSidebarContent to MarkdownEditor
-  - Text+level matching via `editor.state.doc.descendants()`
-  - `activeHeadingId` state in outline store for highlight sync
-- [x] **BF-001**: ExpandableEditor tag/wiki-link threading (3 pts)
-  - Threaded `fetchTags`, `createTag`, `fetchNotesForWikiLink`, `onWikiLinkClick` from MainPanelContent → ExpandableEditor → MarkdownEditor
-- [x] **BF-002**: Keyboard event scoping (1 pt)
-  - `onKeyDown` stopPropagation on ExpandableEditor container
-- [x] **BF-003**: Tag/heading `# ` input rule conflict (2 pts)
-  - Space with empty query propagates to ProseMirror heading input rule
-  - Space with non-empty query + items selects tag
-- [x] **BF-004**: tag-suggestion runtime error guard (1 pt)
-  - Guard `component?.ref` against undefined in `onKeyDown`
-
-## Sprint 33: AI Foundation + Settings UI ✅ COMPLETE
-**Duration**: Feb 27, 2026
-**Branch**: `epoch-7/sprint-33`
-
-- [x] AI SDK v6 installed (ai@6, @ai-sdk/react, @ai-sdk/anthropic, @ai-sdk/openai)
-- [x] Provider registry with dynamic imports (`resolveChatModel`)
-- [x] Streaming chat API route (`POST /api/ai/chat`)
-- [x] `/settings/ai` page (provider, generation, toggles, usage)
-- [x] AI chat Zustand store, middleware system
-
-## Sprint 34: Chat UI, AI Tools, @ Mentions ✅ COMPLETE
-**Duration**: Feb 28 - Mar 1, 2026
-**Branch**: `epoch-7/sprint-34`
-
-- [x] ChatPanel (sidebar) + ChatViewer (main panel) with streaming
-- [x] ChatPayload CRUD (save/load conversations)
-- [x] AI tools: searchNotes, getCurrentNote, createNote
-- [x] @ file mentions with system prompt injection
-- [x] / tool commands with prompt hints
-- [x] ModelPicker, ChatSuggestionMenu, chat export
-- [x] Sidebar tab auto-switch, chat icon in file tree
-- [x] Tool settings UI
-
-## Sprint 35+: Planning
-
-### Original Epoch 7 Plan (may be redirected)
-
-**Sprint 35 — BYOK, Speech & Agent** (originally planned):
-- [ ] BYOK key management UI (secure entry, validation, per-provider)
-- [ ] Speech-to-text input (Web Speech API or Whisper)
-- [ ] Text-to-speech output (Web Speech Synthesis)
-- [ ] Agent mode (multi-step tool use with user confirmation)
-- [ ] Key management + speech settings pages
-
-**Sprint 36 — RAG, Integration & Polish** (originally planned):
-- [ ] Embeddings generation for content nodes
-- [ ] Vector similarity search (pgvector or external)
-- [ ] RAG context injection into chat
-- [ ] Chat history search
-- [ ] Cross-sprint polish and bug fixes
-
-### Deferred Work Items
-
-**Performance & Optimization**:
-- [ ] Folder view performance tuning for large folders (5 pts)
-- [ ] Virtualization for grid and kanban views (3 pts)
-
-**UX Refinements**:
-- [ ] Folder view keyboard shortcuts (Cmd+1-5) (2 pts)
-- [ ] Empty state designs for all views (2 pts)
-
-**Advanced Features**:
-- [ ] Folder sorting and filtering UI (3 pts)
-- [ ] Custom kanban columns (5 pts)
-
-## Future Backlog (Epoch 6+)
-
-### Collaboration Features
-- [ ] Real-time multiplayer editing (Yjs integration)
-- [ ] Share links with permissions (view, edit, comment)
-- [ ] Collaborative cursors and presence indicators
-- [ ] Comment threads on content
-- [ ] Activity feed and notifications
-
-### AI Integration (Partially Shipped)
-- [x] AI chat interface within IDE (Sprint 34)
-- [x] AI tools: search, read, create notes (Sprint 34)
-- [x] @ mentions with context injection (Sprint 34)
-- [ ] Semantic search with embeddings (RAG)
-- [ ] AI-powered autocomplete and suggestions
-- [ ] Content summarization
-- [ ] Smart tagging and categorization
+### From Epoch 7 (AI — partially shipped, rest deferred)
 - [ ] BYOK key management UI
-- [ ] Speech input/output
-- [ ] Agent mode (multi-step reasoning)
+- [ ] Speech-to-text / text-to-speech
+- [ ] RAG / embeddings / semantic search
+- [ ] Agent mode (may be addressed in Sprint 44)
+- [ ] Chat history search
 
-### Advanced Editor Features
-- [ ] Inline code execution (JavaScript, Python)
-- [ ] Embed external content (tweets, GitHub gists, CodePen)
-- [ ] Version history with diff view
-- [ ] Advanced table features (formulas, charts)
-- [ ] Handwriting/drawing support
+### Performance & UX
+- [ ] Folder view performance tuning for large folders
+- [ ] Virtualization for grid and kanban views
+- [ ] Empty state designs for all views
+- [ ] Folder sorting and filtering UI
+- [ ] Custom kanban columns
 
 ### Mobile & PWA
 - [ ] Mobile-responsive layout
 - [ ] Touch gesture support
 - [ ] Offline mode with service workers
-- [ ] Native mobile apps (React Native)
 
 ### Integrations
 - [ ] Google Drive sync
-- [ ] Dropbox integration
 - [ ] GitHub repository sync
 - [ ] Notion import/export
-- [ ] Slack notifications
 
-## Deferred / Icebox
-
-**Low Priority**:
-- Calendar view for folders (nice-to-have)
-- Advanced search filters (beyond current implementation)
-- Bulk operations (multi-select + batch actions)
-- Custom themes (beyond Liquid Glass)
-- Plugin system for community extensions
+---
 
 ## Estimation Reference
 
@@ -304,5 +211,5 @@ Post-feature stability sprint. Fixed regressions from Sprints 29-31.
 
 ---
 
-**Last Updated**: Mar 1, 2026
-**Next Review**: Sprint 35 planning
+**Last Updated**: Mar 5, 2026
+**Next Review**: Sprint 35 kickoff

--- a/docs/notes-feature/work-tracking/CURRENT-SPRINT.md
+++ b/docs/notes-feature/work-tracking/CURRENT-SPRINT.md
@@ -1,114 +1,87 @@
 ---
-sprint: 34
-epoch: 7 (AI Integration)
-duration: Feb 28 - Mar 1, 2026
-branch: epoch-7/sprint-34
+sprint: 35
+epoch: 8 (Editor Stabilization)
+duration: 1 session
+branch: fix/cross-document-save-race
 status: complete
 ---
 
-# Sprint 34: Chat UI, AI Tools, @ Mentions
+# Sprint 35: TipTap Rules Doc + Input Rule Bug Fixes
 
 ## Sprint Goal
-Ship the full AI chat experience: streaming ChatPanel in the right sidebar, persistent ChatViewer in the main panel, AI tools with Prisma execution, @ file mentions for context injection, and / tool commands.
+Establish canonical editor behavior rules (TIPTAP-EDITOR-RULES.md) and fix all input rule conflicts between tag autocomplete and heading conversion. The rules document must be reviewed and approved before Sprint 36 implements focus guardrails.
 
-**Status**: ✅ COMPLETE — merged to main via PR
+**Status**: ✅ Complete
 
 ## Success Criteria
 - [x] `pnpm build` passes
-- [x] ChatPanel in right sidebar streams responses
-- [x] "Save conversation" creates ChatPayload ContentNode in file tree
-- [x] ChatViewer loads saved conversations with full history
-- [x] AI tools (searchNotes, getCurrentNote, createNote) execute via tool registry
-- [x] Tool settings section in `/settings/ai`
-- [x] @ mentions search content nodes and inject into system prompt
-- [x] / commands show available AI tools with prompt hints
-- [x] Chat icon (MessageCircle) appears for chat nodes in file tree
-- [x] Sidebar tabs auto-switch when content type changes
-- [x] Chat export as Markdown from toolbar
+- [x] TIPTAP-EDITOR-RULES.md created (living document — expand as features are added)
+- [x] Tag autocomplete does not trigger when typing heading syntax (`#`, `##`, `###`).  It only triggers when typing `#` followed by text without a space.
+- [x] Tag autocomplete has 2-second delay before appearing
+- [x] Space after `#` cancels any prior tag autocomplete and triggers heading conversion
+- [x] `##` cancels any tag autocomplete from the first `#`
+- [x] Slash command only triggers on first character of an empty line
+- [x] Backspace on empty header reverts to `#` chain in paragraph
 
-## Completed Work Items
+## Work Items
 
-### Sprint 34 Core — Chat UI & Persistence
+### Documentation
+- [x] **DOC-001**: Create TIPTAP-EDITOR-RULES.md (3 pts) ✅
+  - Living document — expand as new TipTap features are added
+  - **File**: `docs/notes-feature/guides/editor/TIPTAP-EDITOR-RULES.md`
 
-| File | Purpose |
-|------|---------|
-| `components/content/ai/ChatPanel.tsx` | Right sidebar streaming chat with save-to-tree |
-| `components/content/ai/ChatViewer.tsx` | Full ChatViewer rewrite with auto-save to ChatPayload |
-| `components/content/ai/ChatInput.tsx` | Shared input with @ mention and / command detection |
-| `components/content/ai/ChatMessage.tsx` | Message rendering with mention pills, code blocks, inline formatting |
-| `components/content/ai/ModelPicker.tsx` | Per-session provider/model override dropdown |
-| `components/content/ai/ChatSuggestionMenu.tsx` | Shared keyboard-navigable dropdown for mentions + commands |
-| `lib/domain/ai/tools/registry.ts` | AI tool definitions (searchNotes, getCurrentNote, createNote) with Prisma |
-| `lib/domain/ai/tools/metadata.ts` | Client-safe tool metadata (no Prisma imports) |
-| `lib/domain/ai/tools/types.ts` | BaseToolId, BaseToolMetadata types |
-| `lib/domain/ai/tools/index.ts` | Barrel export |
+### Bug Fixes
+- [x] **BF-035-001**: Tag/heading conflict fix (5 pts) ✅
+  - **Fix**: 2-second `setTimeout` delay in `onStart`; popup hidden via `showOnCreate: false`
+  - **Files**: `lib/domain/editor/extensions/tag-suggestion.tsx`
 
-### Sprint 34 Core — API & Data Layer
+- [x] **BF-035-002**: `## ` triggers tag autocomplete instead of H2 (3 pts) ✅
+  - **Fix**: `allow()` guard checks query for `#` prefix → returns false → `onExit()` fires
+  - **Files**: `lib/domain/editor/extensions/tag-suggestion.tsx`
 
-| File | Change |
-|------|--------|
-| `app/api/ai/chat/route.ts` | Added AI tools execution, mentioned content injection |
-| `app/api/content/content/[id]/route.ts` | ChatPayload GET + PATCH (messages, metadata) |
-| `app/api/content/content/route.ts` | ChatPayload POST support |
-| `lib/domain/content/api-types.ts` | ChatPayload API types |
-| `lib/domain/ai/types.ts` | StoredChatMessage, ChatMetadata updates |
-| `components/settings/AISettingsPage.tsx` | Tool settings section (tool choice, enabled tools) |
-| `lib/features/settings/validation.ts` | toolChoice, enabledTools schema fields |
+- [x] **BF-035-003**: Persistent tag autocomplete on `##` (2 pts) ✅
+  - **Fix**: Same `allow()` guard + defense-in-depth `onUpdate` `##` check
+  - **Files**: `lib/domain/editor/extensions/tag-suggestion.tsx`
 
-### Sprint 34 Core — UI Integration
+- [x] **BF-035-004**: Tag autocomplete delay + space-break (3 pts) ✅
+  - **Fix**: During 2s delay, `isVisible=false` → `onKeyDown` returns false for all keys → ProseMirror handles space normally → `allowSpaces: false` causes suggestion exit
+  - **Files**: `lib/domain/editor/extensions/tag-suggestion.tsx`
 
-| File | Change |
-|------|--------|
-| `components/content/LeftSidebar.tsx` | Tree refresh event listener, chat creation handler |
-| `components/content/content/LeftSidebarContent.tsx` | Chat content type in create request |
-| `components/content/headers/LeftSidebarHeader.tsx` | onCreateChat prop |
-| `components/content/menu-items/new-content-menu.tsx` | Chat in new content menu |
-| `components/content/content/RightSidebarContent.tsx` | ChatPanel replaces placeholder |
-| `app/page.tsx` | Session-based redirect (replaces legacy AppNav) |
-| `app/global-error.tsx` | Global error boundary |
+- [x] **BF-035-005**: Slash command empty line restriction (2 pts) ✅
+  - **Fix**: `allow()` guard checks `$from.parentOffset !== 0` and `parent.textContent !== suggestionText`
+  - **Files**: `lib/domain/editor/commands/slash-commands.tsx`
 
-### Sprint 34B — Polish & Mentions
+- [x] **BF-035-006**: Header backspace escape (3 pts) ✅
+  - **Fix**: New `HeadingBackspace` extension: empty heading → paragraph with `#` chain
+  - **Files**: `lib/domain/editor/extensions/heading-backspace.ts` (new), `lib/domain/editor/extensions-client.ts`
 
-| File | Change |
-|------|--------|
-| `components/content/RightSidebar.tsx` | Tab auto-switch on content type change |
-| `components/content/FileNode.tsx` | MessageCircle icon for chat content type |
-| `components/content/content/MainPanelContent.tsx` | Editor state persistence fix + chat export handler |
-| `components/content/headers/RightSidebarHeader.tsx` | "AI Chat" tab title (was "Coming Soon") |
-| `lib/domain/tools/registry.ts` | export-chat toolbar tool registration |
+- [x] **BF-035-007**: H1 space must not trigger tag autocomplete (1 pt) ✅
+  - **Fix**: Covered by 2-second delay — popup never shown before space causes suggestion exit
+  - **Files**: `lib/domain/editor/extensions/tag-suggestion.tsx`
+
+## Estimated Points: ~22 pts
 
 ## Technical Notes
 
-### AI SDK v6 useChat + tool() API Discoveries
-1. `useChat()`: NO `api`/`body` props — use `transport: new DefaultChatTransport({ api, body })` from `ai`
-2. `useChat()`: NO `initialMessages` — field is just `messages` in `ChatInit`
-3. `useChat()`: NO `input`/`setInput`/`handleSubmit` — use `sendMessage({ text })`, manage input via local `useState`
-4. `ChatStatus` type: `'ready' | 'submitted' | 'streaming' | 'error'` (replaces boolean `isLoading`)
-5. `UIMessage` has `parts[]` array, not `content` string
-6. `tool()`: uses `inputSchema` (NOT `parameters`), import `z` from `zod/v4` for type compat
-7. Dynamic `body` in transport: use function `body: () => ({ key: ref.current })` + ref pattern
+### Root Cause Analysis
+The tag autocomplete trigger (`#`) at `tag-suggestion.tsx` fires on a single character with no delay, racing against StarterKit's heading input rules (`## `). This is an architectural overlap — two features competing for the same keystrokes.
 
-### @ Mention Architecture
-- ChatInput inserts clean `@Title` in textarea (user-friendly display)
-- Parent (ChatPanel/ChatViewer) tracks mentions in `trackedMentionsRef`
-- On send: reconstructs `@[Title](id)` tokens for API + ChatMessage rendering
-- Server: fetches mentioned ContentNodes, injects searchText (max 2000 chars) into system prompt
-- ChatMessage: parses `@[Title](id)` tokens → renders as clickable `MentionPill` components
-
-## Stats
-- **29 files** changed | **+2,237** | **-141**
-- 1 commit (Sprint 34 + 34B combined)
-- New directory: `components/content/ai/` (5 components)
-- New directory: `lib/domain/ai/tools/` (4 files)
+### Fix Strategy
+1. Add 2-second `setTimeout` delay to tag suggestion's `onStart` handler
+2. In tag suggestion's `allow` guard (lines 157-179): reject when preceded by additional `#` chars
+3. In tag suggestion's space handler: dismiss suggestion and let event propagate to heading input rules
+4. Slash commands: check `$from.parentOffset === 0 && $from.parent.textContent === '/'` in allow guard
 
 ---
 
-**Last Updated**: Mar 1, 2026
+## Previous Sprint: Sprint 34 (✅ Complete)
 
-## Previous Sprint: Sprint 33 (✅ Complete)
+See [Sprint 34 archive](history/) for details. Key deliverables:
+- ChatPanel + ChatViewer with streaming
+- AI tools (searchNotes, getCurrentNote, createNote)
+- @ mentions, / commands, ModelPicker
+- Chat export, sidebar auto-switch, chat icon
 
-See [Sprint 33 archive](history/) for details. Key deliverables:
-- AI SDK v6 installed (ai@6, @ai-sdk/react, @ai-sdk/anthropic, @ai-sdk/openai)
-- Provider registry with dynamic imports (`resolveChatModel`)
-- Streaming chat API route (`POST /api/ai/chat`)
-- `/settings/ai` page (provider, generation, toggles, usage)
+---
+
+**Last Updated**: Mar 6, 2026

--- a/docs/notes-feature/work-tracking/epochs/epoch-10-ai-tiptap.md
+++ b/docs/notes-feature/work-tracking/epochs/epoch-10-ai-tiptap.md
@@ -1,0 +1,120 @@
+---
+epoch: 10
+title: AI TipTap
+duration: 5 sprints (43-47)
+status: planned
+theme: AI responses, agent tools, edit highlighting, chat outlines, image generation
+---
+
+# Epoch 10: AI TipTap
+
+## Goal
+Integrate AI deeply into the TipTap editing experience — rich AI responses, agent-powered text editing tools, human/AI content distinction, chat content outlines, and AI image generation.
+
+## Prerequisites
+- Epoch 8 (Editor Stabilization) complete
+- Epoch 9 (Editor Enhancements) complete — especially Sprint 37 (images) and Sprint 39 (autofocus)
+- Existing AI infrastructure: `lib/domain/ai/` (providers, tools, middleware)
+
+## Sprint Execution Protocol
+**Before commencing any sprint**, always ask the user for input before planning and executing — there may be additions or modifications.
+
+---
+
+## Sprint 43: Pretty Bot Response Enhancements
+
+- [ ] **Visual parity with OpenAI/Claude across ALL AI experiences**
+  - Chat panel (right sidebar)
+  - Side panel chats
+  - Inline AI responses
+  - All get rich rendering: headers, rich text, code blocks with syntax highlighting, lists, tables, inline code
+- [ ] Model-agnostic formatting (works for all providers, fork where needed for best results)
+- [ ] Research best practices for state-of-the-art AI chat UX (updatable as trends evolve)
+
+### Key Files
+- `components/content/ai/ChatMessage.tsx` — message rendering
+- `components/content/ai/ChatPanel.tsx` — sidebar chat
+- `components/content/ai/ChatViewer.tsx` — main panel chat
+
+---
+
+## Sprint 44: AI Text-Editing Tools (Agent Integration) — GATED BUILD
+
+**Meticulous, gated approach: each tool is built and tested individually before proceeding to the next.**
+
+- [ ] **Gate 1**: `read_first_chunk` — test: agent reads beginning of document
+- [ ] **Gate 2**: `read_next_chunk` — test: agent paginates through document
+- [ ] **Gate 3**: `read_previous_chunk` — test: agent navigates backward
+- [ ] **Gate 4**: `apply_diff` — test: agent makes targeted edits with before/after matching
+- [ ] **Gate 5**: `replace_document` — test: agent replaces entire document content
+- [ ] **Gate 6**: `plan` — test: agent generates step-by-step markdown plans
+- [ ] **Gate 7**: `ask_user` — test: agent prompts user for clarification mid-task
+- [ ] **Gate 8**: `finish_with_summary` — test: agent completes task with summary
+- [ ] Built-in commands: summarize, rephrase, translate (with streaming)
+- [ ] Tab-triggered autocompletion
+- [ ] Bubble menu AI integration (AI writing tools button)
+- [ ] Meld with existing `lib/domain/ai/` — no infrastructure duplication
+
+### References
+- https://tiptap.dev/docs/content-ai/capabilities/agent/custom-llms/overview
+- https://tiptap.dev/docs/content-ai/capabilities/agent/custom-llms/get-started
+- https://tiptap.dev/docs/content-ai/capabilities/agent/custom-llms/tools
+
+### Key Files
+- `lib/domain/ai/tools/registry.ts` — extend with editor tools
+- `lib/domain/ai/tools/metadata.ts` — client-safe tool metadata
+- `components/content/editor/BubbleMenu.tsx` — AI tools button
+- `app/api/ai/chat/route.ts` — tool execution
+
+---
+
+## Sprint 45: AI Edit Highlighting + AI Image Insert
+
+- [ ] Mark content as human vs machine generated (background/highlighting)
+- [ ] Copy/paste outside app: AI formatting stripped
+- [ ] Copy/paste within app: AI formatting preserved (if setting enabled)
+- [ ] Settings toggle: on/off for new content; CSS class for retroactive enable/disable
+- [ ] "Paste as AI" special paste option for external AI content
+- [ ] Human/machine highlighting never overlaps (typing from AI paragraph = human content)
+- [ ] Agent can distinguish human vs AI content (for future knowledge gap features)
+- [ ] Images: ephemeral AI icon flag for AI-generated images
+- [ ] **User can insert AI-generated images into TipTap notes** — uses Sprint 37 image infrastructure with `source: 'ai-generated'` attribute
+
+### Key Files
+- New: AI content mark/decoration extension
+- `lib/domain/editor/extensions-client.ts` — AI mark registration
+- `components/settings/` — AI highlighting settings
+
+---
+
+## Sprint 46: Chat Content Outlines
+
+- [ ] Content outline sidebar for ChatPayload nodes
+- [ ] Compact outline: agent <-> user prompts (first line + "..." overflow)
+- [ ] Agent content: headers, OL/UL previews (first few words per bullet)
+- [ ] Graphically rich sidebar for easy chat history scanning
+- [ ] Click outline item → autofocus with same CSS animations as TipTap autofocus (Sprint 39 infrastructure)
+- [ ] Image captions in chat outlines
+
+### Key Files
+- `components/content/OutlinePanel.tsx` — extend for chat content
+- `state/outline-store.ts` — chat outline extraction
+- `components/content/ai/ChatViewer.tsx` — outline integration
+
+---
+
+## Sprint 47: AI Image Generation
+
+- [ ] AI image generation inside chat content nodes and side panel chats
+- [ ] Generated images → REFERENCED FilePayload content (visible in parent folder)
+- [ ] Referenced content follows parent on move (Sprint 37 infrastructure)
+- [ ] Drag AI content from chat → file tree (new copy, non-referenced) or → TipTap note (as referenced content)
+
+### Key Files
+- `lib/domain/ai/tools/registry.ts` — image generation tool
+- `components/content/ai/ChatMessage.tsx` — image rendering in chat
+- `app/api/content/content/move/route.ts` — referenced content follow (Sprint 37)
+
+---
+
+**Last Updated**: Mar 5, 2026

--- a/docs/notes-feature/work-tracking/epochs/epoch-8-editor-stabilization.md
+++ b/docs/notes-feature/work-tracking/epochs/epoch-8-editor-stabilization.md
@@ -1,0 +1,91 @@
+---
+epoch: 8
+title: Editor Stabilization
+duration: 2 sprints (35-36)
+status: planned
+theme: Bug fixes, TipTap rules, focus guardrails, table rebuild
+---
+
+# Epoch 8: Editor Stabilization
+
+## Goal
+Fix all known TipTap editor bugs, establish canonical editor behavior rules, and implement focus guardrails. The editor must be crisp and bug-free before adding new features.
+
+## Prerequisites
+- TIPTAP-EDITOR-RULES.md reviewed and approved by user (before Sprint 36 focus guardrails)
+
+## Success Criteria
+- All 11 known editor bugs resolved
+- TipTap Editor Rules document approved and implemented
+- Focus guardrails prevent unintentional focus changes
+- Tables rebuilt from scratch with no visual bugs
+- Zero old console.log statements in editor code
+- `pnpm build` passes
+
+---
+
+## Sprint 35: TipTap Rules Doc + Input Rule Bug Fixes
+
+**Theme:** Establish editor behavior rules, fix input rule conflicts
+
+### Documentation
+- [ ] Create `docs/notes-feature/guides/editor/TIPTAP-EDITOR-RULES.md`
+  - Focus Rules: single gate for intentional focus changes
+  - Input Rule Priority: headings > autocomplete
+  - Autocomplete Rules: 2s delay, space cancels, `##` cancels tag autocomplete
+  - Slash Command Rules: `/` only on first char of empty line
+  - Blockquote Rules: `>` only modifies current line
+  - Header Behavior: backspace → `#` chain → space → re-enter header
+
+### Bug Fixes
+- [ ] Tag/heading conflict: `#` triggers tag autocomplete instead of heading conversion
+- [ ] `## ` typed quickly triggers tag autocomplete, sometimes fails to convert to H2
+- [ ] `##` typed quickly shows persistent tag autocomplete even after continued typing
+- [ ] Tag autocomplete needs 2-second delay; space after `#` must break autocomplete
+- [ ] Slash command should only trigger on first character of an empty line
+- [ ] Header escape: backspace on empty header → revert to appropriate `#` chain
+- [ ] `# ` (H1 with space) should never trigger tag autocomplete
+
+### Key Files
+- `lib/domain/editor/extensions/tag-suggestion.tsx` — tag autocomplete trigger logic
+- `lib/domain/editor/extensions/tag.ts` — tag auto-convert plugin
+- `lib/domain/editor/commands/slash-commands.tsx` — slash command trigger
+- `lib/domain/editor/extensions-client.ts` — extension registration order
+
+---
+
+## Sprint 36: Table Rebuild + Link Fix + Cleanup + Focus Guardrails
+
+**Theme:** Rebuild tables, fix remaining bugs, implement focus system
+
+### Bug Fixes
+- [ ] **Table rebuild** (user must approve before moving on):
+  - Remove ALL table CSS from `app/globals.css` (lines 568-614)
+  - Remove any custom table logic
+  - Rebuild following TipTap docs only
+  - Simple, clean CSS
+  - Fix extra column visual bug
+  - TableBubbleMenu stays, same functionality
+- [ ] URL/link escape: cursor adjacent to link should not inherit link formatting
+  - Right-click → lightweight URL dialog (smaller, simpler LinkDialog)
+  - Center on page, always escapable
+- [ ] `>` blockquote: should only update current line, never child content
+- [ ] Header in paragraph with `hardBreak`: `##` converts ALL paragraph text to header
+  - Fix: only convert text before the hardBreak
+- [ ] Remove old console.log/console.warn:
+  - `extensions-client.ts` lines 149-150
+  - `MarkdownEditor.tsx` lines 168-170, 182
+  - `tag.ts` line 356
+  - Sweep all `components/content/` and `lib/domain/editor/`
+- [ ] Implement focus guardrails per approved TIPTAP-EDITOR-RULES.md
+
+### Key Files
+- `app/globals.css` — table CSS to remove
+- `components/content/editor/MarkdownEditor.tsx` — focus management, console logs
+- `components/content/editor/BubbleMenu.tsx` — focus prevention
+- `lib/domain/editor/extensions-client.ts` — extension config, console logs
+- `lib/domain/editor/extensions/tag.ts` — console log
+
+---
+
+**Last Updated**: Mar 5, 2026

--- a/docs/notes-feature/work-tracking/epochs/epoch-9-editor-enhancements.md
+++ b/docs/notes-feature/work-tracking/epochs/epoch-9-editor-enhancements.md
@@ -1,0 +1,142 @@
+---
+epoch: 9
+title: Editor Enhancements
+duration: 6 sprints (37-42)
+status: planned
+theme: Images, embeds, templates, snapshots, context menu, drag/reorder
+---
+
+# Epoch 9: Editor Enhancements
+
+## Goal
+Transform the TipTap editor from a functional text editor into a full-featured content IDE with images, embeds, templates, document history, and rich interaction patterns.
+
+## Prerequisites
+- Epoch 8 (Editor Stabilization) complete — all bugs fixed, rules documented
+- TIPTAP-EDITOR-RULES.md approved and implemented
+
+## Key Decisions
+- **Images**: Reuse FilePayload with `contentRole=REFERENCED` (no schema migration)
+- **Referenced content lifecycle**: follows parent on move, deleted when removed from document
+- **Templates**: Full TipTap features, replace on new notes, insert at cursor on existing
+- **Snapshots**: 30-day retention with auto-prune, pinnable snapshots
+
+---
+
+## Sprint 37: Images in TipTap + Referenced Content Lifecycle
+
+- [ ] Enable `@tiptap/extension-image` (already installed, not configured)
+- [ ] Image upload via slash command + bubble menu button
+- [ ] Image paste handling → creates FilePayload REFERENCED content in same folder
+- [ ] Image URL paste → creates ExternalPayload REFERENCED content
+- [ ] Image resize (drag handles or image-specific bubble menu)
+- [ ] Lazy loading for images
+- [ ] **Update move API** (`app/api/content/content/move/route.ts`): REFERENCED content follows parent
+- [ ] **Delete referenced content** when removed from document (onChange/save hook detects orphans)
+- [ ] Image caption support (custom figure node)
+- [ ] **AI image prep**: image node schema includes `source` attribute (user-uploaded vs ai-generated)
+
+### Key Files
+- `lib/domain/editor/extensions-client.ts` — add Image extension
+- `app/api/content/content/move/route.ts` — referenced content follow logic
+- `components/content/editor/MarkdownEditor.tsx` — paste handling, orphan detection
+
+---
+
+## Sprint 38: URL/OG Embeds + YouTube + Bubble Menu Enhancements
+
+- [ ] URL paste with OG metadata: 3 display modes (inline/hyperlinked, small card block, full preview block)
+- [ ] YouTube URL auto-converts to full embed block with fullscreen (custom iframe node)
+- [ ] Add missing formatting options to bubble menu: text color, highlight, subscript, superscript, strikethrough, text alignment
+- [ ] Note: YouTube playlists and summarizing deferred to much later epoch
+
+### Key Files
+- `components/content/editor/BubbleMenu.tsx` — new formatting buttons
+- `lib/domain/tools/registry.ts` — new tool definitions
+- New: custom iframe/embed node extension
+
+---
+
+## Sprint 39: Gated Autofocus + Outline + Drag/Reorder
+
+- [ ] Outline click → autofocus to document position with CSS flash animation
+- [ ] Tasks show up in outline sidebar panel
+- [ ] Agentic edits update outlines in real-time
+- [ ] **Drag and reorder** (Notion-style via TipTap drag handle):
+  - Drag handle: subtle grip icon on hover at left edge of block nodes
+  - Reorderable: entire paragraphs, headings, OL/UL (whole blocks), task lists, images, code blocks, callouts, tables, blockquotes
+  - List items reorderable within their parent list
+  - NOT reorderable: partial text within a paragraph
+  - **UI**: ghost preview while dragging, drop indicator line between blocks
+  - Drop zones: between sibling blocks, or into list containers
+
+### Key Files
+- `components/content/OutlinePanel.tsx` — autofocus, tasks in outline
+- `state/outline-store.ts` — outline updates
+- New: drag handle extension or TipTap drag handle configuration
+
+---
+
+## Sprint 40: Templates / Forced Content Structure (full sprint)
+
+- [ ] **Template builder UI in settings**: full TipTap editor instance (same as note editor)
+- [ ] Templates support ALL TipTap features — wiki-links become `[[Untitled]]` placeholders
+- [ ] Templates are flat (no templates within templates)
+- [ ] **Apply behavior**: replace on new/blank notes, insert at cursor on existing
+- [ ] Two categories:
+  - **App-wide templates**: pre-built, imported in bulk, distinct UI section
+  - **User-created templates**: via settings editor or "save selection as template"
+- [ ] Block forced content: deletable via "x" button (top-right)
+- [ ] "Recommend a template" → links to repo customer feedback
+- [ ] Underlying code enables future template import
+
+### Key Files
+- New: `components/settings/TemplatesPage.tsx`
+- New: `lib/domain/templates/` — template storage, schema
+- `prisma/schema.prisma` — Template model (if needed)
+
+---
+
+## Sprint 41: Snapshots / Document History (full sprint, may expand)
+
+- [ ] **Research spike first**: lowest-resource implementation
+  - Diff-based storage (deltas only)
+  - Time-based debouncing (every N minutes, not every keystroke)
+  - Size-capped retention (last 50 snapshots)
+  - Compression of TipTap JSON
+  - **Decision: 30-day retention** with auto-prune; users can pin snapshots
+- [ ] Document history: rollback, audit, branch from any point
+- [ ] AI/agentic changes tracked as snapshots
+- [ ] Safe DB migration (additive only, production data preserved)
+- [ ] **Regression risks**:
+  - Auto-save performance degradation
+  - Database bloat
+  - Content ID conflicts on branch
+  - Migration failures on existing content
+  - Restore overwriting unsaved edits (must warn)
+- [ ] **UI**: snapshot browser in content toolbar + universal editor toolbar
+- [ ] Applies to both content node notes and universal editor
+
+### Key Files
+- `prisma/schema.prisma` — Snapshot model
+- `components/content/toolbar/ContentToolbar.tsx` — snapshot browser UI
+- `app/api/content/` — snapshot API endpoints
+
+---
+
+## Sprint 42: Editor Context Menu + Syntax Highlighting + Drawing
+
+- [ ] Editor-specific context menu: browser inspect, select all, copy, paste, image insert, AI tools, autocorrect
+- [ ] Explore wrapping browser context menu (app items above browser items)
+- [ ] Spell check: browser spellcheck + AI proofreader (TipTap's linting is unmaintained)
+- [ ] Enhanced syntax highlighting for code blocks (more languages via lowlight)
+- [ ] Drawing: Excalidraw integration (already installed) rather than TipTap's experimental Vue-only drawing
+
+### Key Files
+- `components/content/context-menu/` — existing context menu system
+- `lib/core/menu-positioning.ts` — positioning utilities
+- New: editor context menu provider
+
+---
+
+**Last Updated**: Mar 5, 2026

--- a/docs/notes-feature/work-tracking/epochs/future-epochs.md
+++ b/docs/notes-feature/work-tracking/epochs/future-epochs.md
@@ -1,0 +1,94 @@
+---
+status: stubs
+last_updated: 2026-03-05
+---
+
+# Future Epochs (Unplanned)
+
+These epochs are not yet numbered or scheduled. They represent major feature areas identified during roadmap planning.
+
+---
+
+## Collaboration & Sharing Epoch
+
+**Theme:** Real-time collaboration, content sharing, permissions
+
+- Content sharing with non-users and users (view-only, edit)
+- TipTap collaboration features (real-time collaborative editing)
+- **Security review required** — security agent audit before implementation
+- Mentions system (@user)
+- Annotations & commenting layers
+- Non-users cannot access AI features (session validation required)
+- Requires compatibility with Multiple Tabs epoch
+- Dynamic drag/drop reordering between multiple users
+- Limit number of open editors per session for performance
+
+### Prerequisites
+- Epoch 8 (Editor Stabilization) complete
+- Main Panel Multiple Tabs epoch complete (or at least compatible)
+
+---
+
+## UI Revisions Epoch
+
+**Theme:** Theming, styling customization, user personalization
+
+- Default design themes + custom user themes
+- Editor styling customization
+- Font customization (file tree, main panel, side panel)
+- Background colors / surface customization
+- Define what styling is consistent (app-wide) vs customizable (user preference)
+
+### Scope Definition Needed
+- Which surfaces are themeable (editor, panels, headers, tree)?
+- How do custom themes interact with Liquid Glass tokens?
+- Where are themes stored (user settings, CSS variables, both)?
+
+---
+
+## Main Panel Multiple Tabs Epoch
+
+**Theme:** Multi-document editing with tab management
+
+- Multiple ContentNodes open simultaneously in tabs
+- Tab behavior defaults to Obsidian-like (click opens, middle-click closes, drag reorder)
+- Must be collaboration-friendly (multiple users see each other's tabs?)
+- Reference: conductor-one project for implementation patterns
+
+### Prerequisites
+- Performance profiling of multiple TipTap instances
+- Editor session limits established
+
+---
+
+## YouTube Playlists & Summarizing Epoch (much later)
+
+**Theme:** Video content management and AI summarization
+
+- YouTube playlist support and management
+- Summarizing integrations for video content
+- Transcript extraction and indexing
+- Integration with AI chat for video Q&A
+
+### Prerequisites
+- Epoch 10 (AI TipTap) complete
+- YouTube embed support from Sprint 38
+
+---
+
+## Deferred Items (from earlier planning)
+
+These items from previous backlogs may be incorporated into the above epochs or remain in the icebox:
+
+- **BYOK key management UI** (originally Epoch 7 Sprint 35 — may become part of AI TipTap or standalone)
+- **Speech-to-text / text-to-speech** (originally Epoch 7 — standalone sprint or fold into AI epoch)
+- **RAG / embeddings** (originally Epoch 7 — standalone epoch or fold into AI enhancements)
+- **Agent mode** (multi-step tool use with user confirmation — may be addressed in Sprint 44)
+- **Mermaid viewer in TipTap** (deferred from earlier work)
+- **Payload stubs** (Excalidraw, Canvas, Whiteboard, PDF — from Sprint 28 backlog)
+- **Mobile & PWA** (responsive layout, offline, touch gestures)
+- **Advanced folder views** (Table, Timeline views)
+
+---
+
+**Last Updated**: Mar 5, 2026

--- a/lib/domain/editor/commands/slash-commands.tsx
+++ b/lib/domain/editor/commands/slash-commands.tsx
@@ -386,6 +386,20 @@ export const SlashCommands = Extension.create({
       suggestion: {
         char: "/",
         pluginKey: slashCommandsPluginKey,
+        // Only trigger on first character of an empty line
+        allow: ({ state, range }: any) => {
+          const $from = state.doc.resolve(range.from);
+          // Trigger must be at the beginning of the parent node
+          if ($from.parentOffset !== 0) {
+            return false;
+          }
+          // Parent must only contain the suggestion text (was empty before /)
+          const suggestionText = state.doc.textBetween(range.from, range.to, "");
+          if ($from.parent.textContent !== suggestionText) {
+            return false;
+          }
+          return true;
+        },
         command: ({ editor, range, props }: any) => {
           props.command({ editor, range });
         },

--- a/lib/domain/editor/extensions-client.ts
+++ b/lib/domain/editor/extensions-client.ts
@@ -23,6 +23,7 @@ import { common, createLowlight } from "lowlight";
 import { SlashCommands } from "./commands/slash-commands";
 import { TaskListInputRule } from "./extensions/task-list";
 import { BulletListBackspace } from "./extensions/bullet-list";
+import { HeadingBackspace } from "./extensions/heading-backspace";
 import { Callout } from "./extensions/callout";
 import { WikiLink } from "./extensions/wiki-link";
 import { createWikiLinkSuggestion } from "./extensions/wiki-link-suggestion";
@@ -117,6 +118,7 @@ export function getEditorExtensions(options?: EditorExtensionsOptions): Extensio
 
     // M6: Bullet list backspace behavior (Obsidian-style)
     BulletListBackspace, // Backspace in empty bullet → plain text "-"
+    HeadingBackspace, // Backspace in empty heading → paragraph with # chain
 
     // M6: External links
     Link.configure({

--- a/lib/domain/editor/extensions/heading-backspace.ts
+++ b/lib/domain/editor/extensions/heading-backspace.ts
@@ -1,0 +1,52 @@
+/**
+ * Heading Backspace Escape
+ *
+ * Backspace on an empty heading reverts to paragraph with # chain:
+ * - Empty H1 → paragraph with `#`
+ * - Empty H2 → paragraph with `##`
+ * - Empty H3 → paragraph with `###`
+ *
+ * From the # chain, typing space re-enters heading mode via StarterKit input rules.
+ * Backspace in the # chain deletes # characters one at a time (default text behavior).
+ *
+ * Sprint 35 (BF-035-006)
+ */
+
+import { Extension } from "@tiptap/core";
+
+export const HeadingBackspace = Extension.create({
+  name: "headingBackspace",
+
+  addKeyboardShortcuts() {
+    return {
+      Backspace: () => {
+        const { state } = this.editor;
+        const { selection } = state;
+        const { $from, empty } = selection;
+
+        if (!empty) return false;
+
+        // Only handle in heading nodes
+        if ($from.parent.type.name !== "heading") return false;
+
+        // Only handle empty headings (no text content)
+        if ($from.parent.textContent.length > 0) return false;
+
+        // Only handle at start of heading
+        if ($from.parentOffset !== 0) return false;
+
+        const level = $from.parent.attrs.level as number;
+        const hashes = "#".repeat(level);
+
+        // Convert heading to paragraph with # chain
+        this.editor
+          .chain()
+          .setNode("paragraph")
+          .insertContent(hashes)
+          .run();
+
+        return true;
+      },
+    };
+  },
+});

--- a/lib/domain/editor/extensions/tag-suggestion.tsx
+++ b/lib/domain/editor/extensions/tag-suggestion.tsx
@@ -153,7 +153,7 @@ export function createTagSuggestion(
 
     allowSpaces: false, // Tags don't allow spaces
 
-    // Prevent tag suggestion in headings and when preceded by #
+    // Prevent tag suggestion in headings, heading syntax (##), and when preceded by #
     allow: ({ state, range }) => {
       const $from = state.doc.resolve(range.from);
 
@@ -162,15 +162,22 @@ export function createTagSuggestion(
         return false;
       }
 
+      // If query portion starts with # (user typed ##, ###, etc.), it's heading syntax.
+      // range.from is the trigger #, range.to is end of typed text.
+      // This causes the Suggestion plugin to call onExit(), dismissing the popup.
+      if (range.to > range.from + 1) {
+        const afterTrigger = state.doc.textBetween(range.from + 1, range.to, "");
+        if (afterTrigger.startsWith("#")) {
+          return false;
+        }
+      }
+
       // Check if preceded by another # (heading syntax)
-      // Look at position BEFORE the trigger # character (range.from is where # was typed)
       const charBefore = state.doc.textBetween(
         Math.max(0, range.from - 1),
         range.from,
         ""
       );
-
-      // If the character immediately before the # is also a #, don't trigger
       if (charBefore === "#") {
         return false;
       }
@@ -187,6 +194,8 @@ export function createTagSuggestion(
       let component: ReactRenderer;
       let popup: TippyInstance[];
       let currentQuery = "";
+      let delayTimer: ReturnType<typeof setTimeout> | null = null;
+      let isVisible = false;
 
       return {
         onStart: (props) => {
@@ -214,15 +223,37 @@ export function createTagSuggestion(
             getReferenceClientRect: props.clientRect as any,
             appendTo: () => document.body,
             content: component.element,
-            showOnCreate: true,
+            showOnCreate: false, // Don't show immediately — wait for 2s delay
             interactive: true,
             trigger: "manual",
             placement: "bottom-start",
           });
+
+          // 2-second delay before showing tag autocomplete popup.
+          // Gives heading input rules priority (# → H1, ## → H2, etc.)
+          delayTimer = setTimeout(() => {
+            delayTimer = null;
+            if (popup?.[0]) {
+              popup[0].show();
+              isVisible = true;
+            }
+          }, 2000);
         },
 
         onUpdate(props) {
           currentQuery = props.query || "";
+
+          // Safety: if query starts with # (user typed ##), cancel delay and hide.
+          // Normally the allow() guard catches this, but this is defense in depth.
+          if (currentQuery.startsWith("#")) {
+            if (delayTimer) {
+              clearTimeout(delayTimer);
+              delayTimer = null;
+            }
+            popup?.[0]?.hide();
+            isVisible = false;
+            return;
+          }
 
           component.updateProps({
             ...props,
@@ -244,17 +275,33 @@ export function createTagSuggestion(
 
         onKeyDown(props) {
           if (props.event.key === "Escape") {
+            if (delayTimer) {
+              clearTimeout(delayTimer);
+              delayTimer = null;
+            }
             popup?.[0]?.hide();
+            isVisible = false;
             return true;
           }
 
-          // Guard: component may not be initialized if onKeyDown fires
-          // before onStart completes (race condition in Suggestion plugin)
+          // During the 2-second delay, don't intercept any keys.
+          // This lets ProseMirror handle heading input rules (# → H1, ## → H2)
+          // and space propagation normally.
+          if (!isVisible) {
+            return false;
+          }
+
+          // Guard: component may not be initialized
           if (!component?.ref) return false;
           return (component.ref as any).onKeyDown(props) ?? false;
         },
 
         onExit() {
+          if (delayTimer) {
+            clearTimeout(delayTimer);
+            delayTimer = null;
+          }
+          isVisible = false;
           if (popup && popup[0]) {
             popup[0].destroy();
           }


### PR DESCRIPTION
## Summary
- **Tag/heading conflict fixed**: 2-second delay before tag autocomplete popup appears, giving heading input rules (`# ` → H1, `## ` → H2) priority. The `allow()` guard rejects `##` sequences, and space during the delay propagates to ProseMirror for heading conversion.
- **Slash commands restricted**: `/` only triggers on first character of an empty line (no more mid-line triggers).
- **HeadingBackspace extension**: Backspace on empty heading reverts to paragraph with `#` chain (H1→`#`, H2→`##`, H3→`###`), allowing re-entry via space.
- **Documentation**: TIPTAP-EDITOR-RULES.md (living document), epoch plans for Epochs 8-10, updated roadmap and sprint tracking.

### Files Changed
| File | Change |
|------|--------|
| `lib/domain/editor/extensions/tag-suggestion.tsx` | 2s delay, `##` rejection, defense-in-depth `onUpdate`, delay-aware `onKeyDown` |
| `lib/domain/editor/commands/slash-commands.tsx` | `allow()` guard for empty-line restriction |
| `lib/domain/editor/extensions/heading-backspace.ts` | **New** — HeadingBackspace extension |
| `lib/domain/editor/extensions-client.ts` | Import + register HeadingBackspace |
| `docs/notes-feature/guides/editor/TIPTAP-EDITOR-RULES.md` | **New** — living editor rules document |
| `docs/notes-feature/work-tracking/epochs/` | **New** — Epoch 8, 9, 10, future stubs |
| `docs/notes-feature/STATUS.md` | Sprint 35 marked complete |
| `docs/notes-feature/work-tracking/CURRENT-SPRINT.md` | All items checked off |
| `docs/notes-feature/work-tracking/BACKLOG.md` | Restructured by epoch |
| `CLAUDE.md` | AI SDK v6, directory structure, conventions |

## Test plan
- [x] Type `# ` — should convert to H1 with no tag autocomplete popup
- [x] Type `## ` — should convert to H2 with no tag autocomplete popup
- [x] Type `#` and wait 2+ seconds — tag autocomplete popup should appear
- [x] Type `#tag` — after 2 seconds, popup appears with tag suggestions
- [x] Type `/` on empty line — slash command menu appears
- [x] Type `/` mid-line (e.g., `hello /`) — no slash command menu
- [x] Create H2, clear text, press backspace — should get `##` in paragraph
- [x] From `##` in paragraph, type space — should re-enter H2
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)