### PR TITLE
UI polish, calendar recurrence, People panel fixes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2600,7 +2600,27 @@ mark {
   border-radius: 0.12rem;
 }
 
-/* ─── Allotment sash overrides ─────────────────────────────────────────── */
+/* ─── Inline Timestamp ──────────────────────────────────────────────────── */
+
+/* The .inline-timestamp span flows inside paragraphs. Style overrides live
+   here rather than in JS so they respond to dark mode and theme tokens. */
+.inline-timestamp {
+  display: inline;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 1px 4px;
+  background: rgba(201, 168, 108, 0.1);
+  color: var(--gold-primary);
+  font-size: inherit;
+  line-height: inherit;
+  transition: background 0.1s;
+  user-select: none;
+}
+.inline-timestamp:hover {
+  background: rgba(201, 168, 108, 0.2);
+}
+
+/* ─── Allotment sash overrides ──────────────────────────────────────────── */
 
 /* Vertical sash: restrict the hover indicator to below the tab header area.
    The sash hit-area (JS-managed inline width) spans full height, but the

--- a/app/globals.css
+++ b/app/globals.css
@@ -2650,3 +2650,41 @@ mark {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
+/* ─── Global minimal scrollbar ──────────────────────────────────────────── */
+/* Thin, low-contrast scrollbars everywhere. .scrollbar-hide wins via specificity. */
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.12) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.12);
+  border-radius: 9999px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.22);
+}
+
+.dark * {
+  scrollbar-color: rgba(255, 255, 255, 0.12) transparent;
+}
+
+.dark *::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.dark *::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.22);
+}

--- a/components/content/MainPanelNavigation.tsx
+++ b/components/content/MainPanelNavigation.tsx
@@ -99,6 +99,16 @@ NavigationButtons.displayName = "NavigationButtons";
 export function MainPanelNavigation({ paneId }: MainPanelNavigationProps) {
   const layoutMode = useContentStore((state) => state.layoutMode);
   const paneContentId = useContentStore((state) => getPaneActiveContentId(state, paneId));
+  const activeTabTitle = useContentStore((state) => {
+    const pane = state.panes[paneId];
+    if (!pane?.activeTabId) return null;
+    return state.tabs[pane.activeTabId]?.title ?? null;
+  });
+  const activeTabContentType = useContentStore((state) => {
+    const pane = state.panes[paneId];
+    if (!pane?.activeTabId) return null;
+    return state.tabs[pane.activeTabId]?.contentType ?? null;
+  });
   const setSelectedContentId = useContentStore((state) => state.setSelectedContentId);
   const setLayoutMode = useContentStore((state) => state.setLayoutMode);
   const shellNavigationControls = useExtensionShellNavigationControls();
@@ -129,8 +139,11 @@ export function MainPanelNavigation({ paneId }: MainPanelNavigationProps) {
       return;
     }
 
-    addToHistory(paneContentId, paneId);
-  }, [paneContentId, paneId, addToHistory]);
+    addToHistory(paneContentId, paneId, activeTabTitle
+      ? { title: activeTabTitle, contentType: activeTabContentType ?? undefined }
+      : undefined
+    );
+  }, [paneContentId, paneId, addToHistory, activeTabTitle, activeTabContentType]);
 
   useEffect(() => {
     if (!isLayoutMenuOpen) return;

--- a/components/content/MainPanelNavigation.tsx
+++ b/components/content/MainPanelNavigation.tsx
@@ -271,7 +271,7 @@ export function MainPanelNavigation({ paneId }: MainPanelNavigationProps) {
             {isLayoutMenuOpen && (
               <div
                 ref={layoutMenuRef}
-                className="absolute left-0 top-full z-40 mt-2 min-w-48 rounded-md border border-white/10 bg-white/95 p-1 shadow-lg backdrop-blur-sm dark:bg-gray-900/95"
+                className="absolute left-0 top-full z-50 mt-2 min-w-48 rounded-md border border-white/10 bg-white/95 p-1 shadow-lg backdrop-blur-sm dark:bg-gray-900/95"
               >
                 {LAYOUT_OPTIONS.map((option) => {
                   const Icon = option.icon;

--- a/components/content/NavigationHistoryDropdown.tsx
+++ b/components/content/NavigationHistoryDropdown.tsx
@@ -2,11 +2,9 @@
  * Navigation History Dropdown
  *
  * Shows navigation history when holding down the back button.
- * Features:
- * - Compact list with file name and preview
- * - Max height with scrolling
- * - Click to navigate to history item
- * - Portal rendering with boundary-aware positioning
+ * Titles and content types are stored directly in the history entries
+ * (set at navigation time), so display is instant with no network round-trip.
+ * A secondary fetch enriches entries with a text preview snippet.
  */
 
 "use client";
@@ -18,10 +16,8 @@ import { calculateMenuPosition } from "@/lib/core/menu-positioning";
 import { getContentTypeIcon } from "@/lib/domain/content/types";
 import * as LucideIcons from "lucide-react";
 
-interface PreviewData {
+interface PreviewSnippet {
   id: string;
-  title: string;
-  contentType: string;
   preview: string | null;
 }
 
@@ -42,48 +38,39 @@ export function NavigationHistoryDropdown({
 }: NavigationHistoryDropdownProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
-  const [previews, setPreviews] = useState<Map<string, PreviewData>>(new Map());
-  const [isLoading, setIsLoading] = useState(false);
+  const [snippets, setSnippets] = useState<Map<string, string>>(new Map());
 
   // Close on outside click
   useEffect(() => {
     if (!isOpen) return;
-
     const handleClickOutside = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         onClose();
       }
     };
-
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen, onClose]);
 
-  // Close on Escape key
+  // Close on Escape
   useEffect(() => {
     if (!isOpen) return;
-
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
+      if (e.key === "Escape") onClose();
     };
-
     document.addEventListener("keydown", handleEscape);
     return () => document.removeEventListener("keydown", handleEscape);
   }, [isOpen, onClose]);
 
-  // Fetch previews for history items (lazy load)
+  // Secondary fetch: enrich with text preview snippets (best-effort, non-blocking)
   useEffect(() => {
     if (!isOpen || historyItems.length === 0) return;
 
     const contentIds = historyItems
       .map((item) => item.contentId)
-      .filter((id): id is string => id !== null);
+      .filter((id): id is string => id !== null && !id.startsWith("person:"));
 
     if (contentIds.length === 0) return;
-
-    setIsLoading(true);
 
     fetch("/api/content/content/preview", {
       method: "POST",
@@ -92,26 +79,20 @@ export function NavigationHistoryDropdown({
     })
       .then((res) => res.json())
       .then((data) => {
-        if (data.previews) {
-          const previewMap = new Map<string, PreviewData>();
-          data.previews.forEach((preview: PreviewData) => {
-            previewMap.set(preview.id, preview);
+        if (Array.isArray(data.previews)) {
+          const map = new Map<string, string>();
+          data.previews.forEach((p: { id: string; preview: string | null }) => {
+            if (p.preview) map.set(p.id, p.preview);
           });
-          setPreviews(previewMap);
+          setSnippets(map);
         }
       })
-      .catch((err) => {
-        console.error("[NavigationHistoryDropdown] Failed to fetch previews:", err);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, [isOpen, historyItems]);
+      .catch(() => {/* best-effort, ignore errors */});
+  }, [isOpen]);  // intentionally omit historyItems — stale snippets are fine
 
-  // Calculate menu position (two-phase rendering)
+  // Two-phase menu positioning
   useEffect(() => {
     if (!isOpen || !menuRef.current) return;
-
     const menuRect = menuRef.current.getBoundingClientRect();
     const calculatedPosition = calculateMenuPosition({
       triggerPosition,
@@ -119,7 +100,6 @@ export function NavigationHistoryDropdown({
       preferredPlacementX: "right",
       preferredPlacementY: "bottom",
     });
-
     setMenuPosition(calculatedPosition);
   }, [isOpen, triggerPosition]);
 
@@ -127,17 +107,13 @@ export function NavigationHistoryDropdown({
 
   const menuStyle = !menuPosition
     ? { visibility: "hidden" as const, position: "fixed" as const, left: 0, top: 0 }
-    : {
-        position: "fixed" as const,
-        left: `${menuPosition.x}px`,
-        top: `${menuPosition.y}px`,
-        zIndex: 9999,
-      };
+    : { position: "fixed" as const, left: `${menuPosition.x}px`, top: `${menuPosition.y}px`, zIndex: 9999 };
 
-  const getIcon = (contentType: string) => {
+  const getIcon = (contentType?: string) => {
+    if (!contentType) return <div className="h-4 w-4" />;
     const iconName = getContentTypeIcon(contentType as any);
     const LucideIcon = (LucideIcons as any)[iconName];
-    return LucideIcon ? <LucideIcon className="h-4 w-4 text-gray-400" /> : null;
+    return LucideIcon ? <LucideIcon className="h-4 w-4 text-gray-400" /> : <div className="h-4 w-4" />;
   };
 
   const menuContent = (
@@ -153,20 +129,17 @@ export function NavigationHistoryDropdown({
         </div>
       </div>
 
-      {/* Content */}
+      {/* Items */}
       <div className="max-h-96 overflow-y-auto">
-        {isLoading ? (
-          <div className="px-3 py-4 text-center text-sm text-gray-500">
-            Loading previews...
-          </div>
-        ) : historyItems.length === 0 ? (
+        {historyItems.length === 0 ? (
           <div className="px-3 py-4 text-center text-sm text-gray-500">
             No history available
           </div>
         ) : (
           <div className="py-1">
             {historyItems.map((item, index) => {
-              const preview = item.contentId ? previews.get(item.contentId) : null;
+              const title = item.title || null;
+              const snippet = item.contentId ? snippets.get(item.contentId) : null;
 
               return (
                 <button
@@ -177,22 +150,19 @@ export function NavigationHistoryDropdown({
                   }}
                   className="w-full px-3 py-2 flex items-start gap-2 hover:bg-white/5 transition-colors text-left"
                 >
-                  {/* Icon */}
                   <div className="flex-shrink-0 mt-0.5">
-                    {preview ? getIcon(preview.contentType) : <div className="h-4 w-4" />}
+                    {getIcon(item.contentType)}
                   </div>
 
-                  {/* Content */}
                   <div className="flex-1 min-w-0">
-                    {/* Title */}
                     <div className="text-sm font-medium text-gray-200 truncate">
-                      {preview ? preview.title : item.contentId || "Unknown"}
+                      {title ?? (
+                        <span className="text-gray-500 italic">No title</span>
+                      )}
                     </div>
-
-                    {/* Preview */}
-                    {preview && preview.preview && (
-                      <div className="text-xs text-gray-400 truncate mt-0.5">
-                        {preview.preview}
+                    {snippet && (
+                      <div className="text-xs text-gray-500 truncate mt-0.5">
+                        {snippet}
                       </div>
                     )}
                   </div>

--- a/components/content/content/LeftSidebarContent.tsx
+++ b/components/content/content/LeftSidebarContent.tsx
@@ -14,6 +14,7 @@ import { FileTreeSkeleton } from "../skeletons/FileTreeSkeleton";
 import { SearchPanel } from "../SearchPanel";
 import { ConfirmDialog } from "../ConfirmDialog";
 import { ExternalLinkDialog } from "../external/ExternalLinkDialog";
+import { FileUploadDialog } from "../dialogs/FileUploadDialog";
 import { IconSelector } from "../IconSelector";
 import { LeftSidebarStatusBar } from "../LeftSidebarStatusBar";
 import { RootNodeHeader } from "../file-tree/RootNodeHeader";
@@ -191,6 +192,10 @@ export function LeftSidebarContent({
     title: string;
     message: string;
   } | null>(null);
+  const [uploadDialog, setUploadDialog] = useState<{
+    open: boolean;
+    parentId: string | null;
+  }>({ open: false, parentId: null });
   const [hasGoogleAuth, setHasGoogleAuth] = useState(false);
   const [deleteFromGoogleDrive, setDeleteFromGoogleDrive] = useState(true); // Default to true
 
@@ -1753,12 +1758,9 @@ export function LeftSidebarContent({
     requestedParentId: string | null,
     type: "folder" | "note" | "file" | "code" | "html" | "docx" | "xlsx" | "json" | "external" | "chat" | "visualization" | "data" | "hope" | "workflow"
   ) => {
-    // File upload requires special two-phase flow - show dialog instead
+    // File upload requires special two-phase flow - open upload dialog
     if (type === "file") {
-      setErrorDialog({
-        title: "File upload not implemented",
-        message: "File upload requires selecting a file. This will be implemented with a file picker dialog in a future update.",
-      });
+      setUploadDialog({ open: true, parentId: requestedParentId });
       return;
     }
 
@@ -2043,6 +2045,19 @@ export function LeftSidebarContent({
         currentIcon={iconSelector.currentIcon}
         triggerPosition={iconSelector.triggerPosition}
       />
+
+      {/* File upload dialog */}
+      {uploadDialog.open && (
+        <FileUploadDialog
+          parentId={uploadDialog.parentId}
+          onSuccess={async (fileId) => {
+            setUploadDialog({ open: false, parentId: null });
+            await fetchTree();
+            setSelectedContentId(fileId);
+          }}
+          onCancel={() => setUploadDialog({ open: false, parentId: null })}
+        />
+      )}
 
       {/* Error dialog */}
       {errorDialog && (

--- a/components/content/content/MainPanelContent.tsx
+++ b/components/content/content/MainPanelContent.tsx
@@ -1386,7 +1386,7 @@ export function MainPanelContent({ paneId }: MainPanelContentProps) {
     const editorElement = (
       <div className="flex flex-col h-full">
         {/* Note title header with debug toggle */}
-        <div className="flex-none px-6 pt-6 pb-4 flex items-start justify-between shadow-[0_2px_4px_rgba(15,23,42,0.09),0_8px_28px_rgba(15,23,42,0.06),0_24px_64px_rgba(15,23,42,0.03)]">
+        <div className="flex-none px-6 pt-6 pb-4 flex items-start justify-between shadow-[0_4px_8px_-2px_rgba(15,23,42,0.08),0_10px_24px_-6px_rgba(15,23,42,0.05)]">
           {isTitleEditing ? (
             <input
               ref={titleInputRef}
@@ -1490,7 +1490,7 @@ export function MainPanelContent({ paneId }: MainPanelContentProps) {
                 onSaveAsPageTemplate={handleSaveAsTemplate}
               />
             )}
-            <div className="flex-1 min-h-0 overflow-auto">{contentElement}</div>
+            <div className="flex-1 min-h-[150px] overflow-auto">{contentElement}</div>
             {notesPanelPosition !== "above" && (
               <ExpandableEditor
                 contentId={selectedContentId}

--- a/components/content/content/MainPanelContent.tsx
+++ b/components/content/content/MainPanelContent.tsx
@@ -1490,7 +1490,7 @@ export function MainPanelContent({ paneId }: MainPanelContentProps) {
                 onSaveAsPageTemplate={handleSaveAsTemplate}
               />
             )}
-            <div className="flex-1 min-h-0 overflow-hidden">{contentElement}</div>
+            <div className="flex-1 min-h-0 overflow-auto">{contentElement}</div>
             {notesPanelPosition !== "above" && (
               <ExpandableEditor
                 contentId={selectedContentId}

--- a/components/content/content/MainPanelContent.tsx
+++ b/components/content/content/MainPanelContent.tsx
@@ -51,6 +51,7 @@ import type { OutlineHeading } from "@/lib/domain/content/outline-extractor";
 import { extractOutline } from "@/lib/domain/content/outline-extractor";
 import { SaveAsPageTemplateDialog } from "../dialogs/SaveAsPageTemplateDialog";
 import { useNotesPanelStore } from "@/state/notes-panel-store";
+import { setDocumentDates } from "@/lib/domain/editor/extensions/inline-timestamp";
 import {
   Dialog,
   DialogContent,
@@ -77,6 +78,8 @@ interface ContentResponse {
     isPublished: boolean;
     customIcon?: string | null;
     iconColor?: string | null;
+    createdAt?: string;
+    updatedAt?: string;
     note?: {
       tiptapJson: any; // Prisma Json type
       searchText: string;
@@ -317,6 +320,11 @@ export function MainPanelContent({ paneId }: MainPanelContentProps) {
         setContentType(result.data.contentType);
         setContentCustomIcon(result.data.customIcon ?? null);
         setContentIconColor(result.data.iconColor ?? null);
+        // Provide creation/updated dates to inline-timestamp nodes
+        setDocumentDates(
+          result.data.createdAt ? new Date(result.data.createdAt).toISOString().slice(0, 10) : "",
+          result.data.updatedAt ? new Date(result.data.updatedAt).toISOString().slice(0, 10) : ""
+        );
         updateContentTab(selectedContentId, {
           title: result.data.title,
           contentType: result.data.contentType,

--- a/components/content/editor/ExpandableEditor.tsx
+++ b/components/content/editor/ExpandableEditor.tsx
@@ -167,7 +167,8 @@ export function ExpandableEditor({
       {/* Expandable Editor */}
       {isExpanded && (
         <div
-          className="px-2 pt-0 pb-1"
+          className="overflow-y-auto px-2 pb-1 pt-0"
+          style={{ maxHeight: "35vh" }}
           onKeyDown={(e) => e.stopPropagation()}
         >
           <MarkdownEditor

--- a/components/content/headers/MainPanelHeader.tsx
+++ b/components/content/headers/MainPanelHeader.tsx
@@ -440,15 +440,14 @@ export function MainPanelHeader({
   return (
     <>
       <div
-        className="relative z-40 flex w-full max-w-full shrink-0 items-center overflow-visible border-b border-white/10"
+        className="relative z-40 flex w-full max-w-full shrink-0 items-center overflow-hidden border-b border-white/10 bg-white/[0.06] dark:bg-black/[0.5]"
         style={{
-          background: glass1.background,
           backdropFilter: glass1.backdropFilter,
         }}
       >
-        <div className="flex min-w-0 max-w-full flex-1 items-stretch overflow-visible pr-1">
+        <div className="flex min-w-0 max-w-full flex-1 items-stretch overflow-x-auto scrollbar-hide pr-1">
           {tabs.length === 0 ? (
-            <div className="flex items-center px-3 py-2 text-xs font-medium uppercase tracking-[0.18em] text-gray-500">
+            <div className="flex items-center px-2 py-1.5 text-xs font-medium uppercase tracking-[0.18em] text-gray-500">
               {getPaneLabel(layoutMode, paneId)}
             </div>
           ) : tabs.map((tab) => {
@@ -466,9 +465,9 @@ export function MainPanelHeader({
                     tabElementsRef.current.delete(tab.id);
                   }
                 }}
-                className={`group relative flex min-w-0 max-w-[14rem] shrink items-center gap-2 overflow-visible border-r border-white/10 px-3 py-2 text-sm transition-colors ${
+                className={`group relative flex min-w-[6rem] max-w-[22rem] shrink items-center gap-1.5 overflow-hidden border-r border-r-black/[0.08] px-2 py-1.5 text-[13px] transition-colors dark:border-r-white/10 ${
                   isActive
-                    ? "-mb-px border-b-2 border-gold-primary bg-black/[0.04] text-gold-primary shadow-[0_1px_2px_rgba(15,23,42,0.04)]"
+                    ? "border-b-2 border-gold-primary bg-black/[0.04] text-gold-primary shadow-[0_1px_2px_rgba(15,23,42,0.04)]"
                     : "text-gray-600 hover:bg-black/[0.035] hover:text-gray-900"
                 } ${isDragging ? "cursor-grabbing opacity-60" : "cursor-grab"}`}
                 data-pane-id={paneId}
@@ -518,30 +517,21 @@ export function MainPanelHeader({
                 ) : (
                   <button
                     type="button"
-                    className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left"
+                    className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden text-left"
                     onClick={() => activateContentTab(tab.id)}
                     onDoubleClick={(e) => { e.preventDefault(); startRename(tab.id, tab.title); }}
                   >
-                    <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                    <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
                     <span className="truncate">{tab.title}</span>
                   </button>
                 )}
-                <span
-                  className={`ml-auto flex shrink-0 items-center ${
-                    isActive ? "opacity-100" : "opacity-70 group-hover:opacity-100"
-                  }`}
-                >
-                  <span
-                    className={`mr-1 h-1.5 w-1.5 rounded-full ${
-                      tab.isPinned ? "bg-gold-primary/80" : "bg-transparent"
-                    }`}
-                  />
+                <span className="absolute inset-y-0 right-0 flex items-center px-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
                   <button
                     type="button"
                     className={`rounded p-0.5 transition-colors ${
                       isActive
-                        ? "hover:bg-gold-primary/10 hover:text-gold-primary"
-                        : "hover:bg-black/[0.05] hover:text-gray-900"
+                        ? "bg-[#f5f1e8] text-gold-primary hover:bg-[#ede7d5] dark:bg-[#2a2218]"
+                        : "bg-white text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:bg-[#1e2830] dark:text-gray-300 dark:hover:bg-[#253340]"
                     }`}
                     aria-label={`Close ${tab.title}`}
                     onClick={() => closeContentTab(tab.id)}

--- a/components/content/people/PeoplePanel.tsx
+++ b/components/content/people/PeoplePanel.tsx
@@ -1600,12 +1600,14 @@ const PeopleContextMenu = forwardRef<HTMLDivElement, {
     >
       <PeopleContextMenuButton
         disabled={!canCreatePeopleRecords}
+        icon={<LucideIcons.UserPlus className="h-3.5 w-3.5" />}
         onClick={() => { onCreatePerson(); onClose(); }}
       >
         Add Contact
       </PeopleContextMenuButton>
       <PeopleContextMenuButton
         disabled={!canCreatePeopleRecords}
+        icon={<LucideIcons.FolderPlus className="h-3.5 w-3.5" />}
         onClick={() => { onCreateGroup(); onClose(); }}
       >
         Add Subgroup
@@ -1619,14 +1621,24 @@ const PeopleContextMenu = forwardRef<HTMLDivElement, {
       />
       <div className="my-0.5 border-t border-gray-200/50 dark:border-gray-700/50" />
       {isPerson ? (
-        <PeopleContextMenuButton onClick={() => { onEditProfile(); onClose(); }}>
+        <PeopleContextMenuButton
+          icon={<LucideIcons.UserCog className="h-3.5 w-3.5" />}
+          onClick={() => { onEditProfile(); onClose(); }}
+        >
           Edit Contact
         </PeopleContextMenuButton>
       ) : null}
-      <PeopleContextMenuButton onClick={() => { onRename(); onClose(); }}>
+      <PeopleContextMenuButton
+        icon={<LucideIcons.PencilLine className="h-3.5 w-3.5" />}
+        onClick={() => { onRename(); onClose(); }}
+      >
         Rename
       </PeopleContextMenuButton>
-      <PeopleContextMenuButton destructive onClick={() => { onDelete(); onClose(); }}>
+      <PeopleContextMenuButton
+        destructive
+        icon={<LucideIcons.Trash2 className="h-3.5 w-3.5" />}
+        onClick={() => { onDelete(); onClose(); }}
+      >
         Delete
       </PeopleContextMenuButton>
     </div>
@@ -1636,11 +1648,13 @@ PeopleContextMenu.displayName = "PeopleContextMenu";
 
 function PeopleContextMenuButton({
   children,
+  icon,
   disabled = false,
   destructive = false,
   onClick,
 }: {
   children: ReactNode;
+  icon?: ReactNode;
   disabled?: boolean;
   destructive?: boolean;
   onClick: () => void;
@@ -1650,12 +1664,17 @@ function PeopleContextMenuButton({
       type="button"
       disabled={disabled}
       onClick={onClick}
-      className={`flex w-full items-center px-2.5 py-1 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+      className={`flex w-full items-center gap-2 px-2.5 py-1 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
         destructive
           ? "text-gray-900 hover:bg-red-500/10 hover:text-red-600 dark:text-gray-100 dark:hover:text-red-400"
           : "text-gray-900 hover:bg-primary/10 hover:text-primary dark:text-gray-100"
       }`}
     >
+      {icon && (
+        <span className={`shrink-0 ${destructive ? "text-red-400" : "text-gray-400 dark:text-gray-500"}`}>
+          {icon}
+        </span>
+      )}
       {children}
     </button>
   );

--- a/components/content/people/PeoplePanel.tsx
+++ b/components/content/people/PeoplePanel.tsx
@@ -122,6 +122,12 @@ export function PeoplePanel() {
   const [renameValue, setRenameValue] = useState("");
   const [isSubmittingRename, setIsSubmittingRename] = useState(false);
   const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null);
+  const [isDragOverRoot, setIsDragOverRoot] = useState(false);
+  const [insertTarget, setInsertTarget] = useState<{
+    groupId: string;
+    position: "before" | "after";
+    parentGroupId: string | null;
+  } | null>(null);
   const [selection, setSelection] = useState<PeopleSelection | null>(null);
   const [contextMenu, setContextMenu] = useState<PeopleContextMenuState>(null);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
@@ -132,6 +138,25 @@ export function PeoplePanel() {
   const [contextMenuPosition, setContextMenuPosition] = useState<{ x: number; y: number; maxHeight: number } | null>(null);
 
   const setSelectedContentId = useContentStore((state) => state.setSelectedContentId);
+  const updateContentTab = useContentStore((state) => state.updateContentTab);
+
+  // Optimistically update a content node title in the local tree state so the
+  // sidebar reflects the rename immediately, without waiting for the refetch.
+  const patchTreeContentTitle = useCallback((contentId: string, newTitle: string) => {
+    const patchNodes = (nodes: PeopleTreeContentNode[]): PeopleTreeContentNode[] =>
+      nodes.map((n) =>
+        n.contentId === contentId
+          ? { ...n, title: newTitle, children: patchNodes(n.children) }
+          : { ...n, children: patchNodes(n.children) }
+      );
+    const patchGroup = (g: PeopleTreeGroupNode): PeopleTreeGroupNode => ({
+      ...g,
+      content: patchNodes(g.content),
+      people: g.people.map((p) => ({ ...p, content: patchNodes(p.content) })),
+      childGroups: g.childGroups.map(patchGroup),
+    });
+    setTree((prev) => prev ? { ...prev, groups: prev.groups.map(patchGroup) } : prev);
+  }, []);
 
   const trimmedQuery = query.trim();
   const isSearchMode = trimmedQuery.length > 0;
@@ -342,7 +367,7 @@ export function PeoplePanel() {
     });
   }, [setSelectedContentId]);
 
-  const movePeopleRecord = useCallback(async (payload: PeopleDragPayload, targetGroupId: string) => {
+  const movePeopleRecord = useCallback(async (payload: PeopleDragPayload, targetGroupId: string | null) => {
     try {
       const response = await fetch("/api/people/move", {
         method: "POST",
@@ -599,8 +624,14 @@ export function PeoplePanel() {
         }
       }
 
+      const trimmedName = renameValue.trim();
+      // Keep open tabs and sidebar tree in sync immediately — don't wait for refetch.
+      if (renameTarget.kind === "content") {
+        updateContentTab(renameTarget.contentId, { title: trimmedName });
+        patchTreeContentTitle(renameTarget.contentId, trimmedName);
+      }
       toast.success("Renamed", {
-        description: renameValue.trim(),
+        description: trimmedName,
       });
       setRenameTarget(null);
       setRenameValue("");
@@ -613,7 +644,7 @@ export function PeoplePanel() {
     } finally {
       setIsSubmittingRename(false);
     }
-  }, [refreshViews, renameTarget, renameValue]);
+  }, [refreshViews, renameTarget, renameValue, updateContentTab, patchTreeContentTitle]);
 
   const handleDeleteSelection = useCallback(async (target: PeopleSelection) => {
     const label = target.kind === "content" ? target.title : target.label;
@@ -824,13 +855,27 @@ export function PeoplePanel() {
             description="Your default People group will be created automatically."
           />
         ) : (
-          <div className="space-y-1">
+          <div
+            className="space-y-1"
+            onDragLeave={(event) => {
+              if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+                setInsertTarget(null);
+                setIsDragOverRoot(false);
+              }
+            }}
+            onDrop={() => {
+              // If no group row captured it, clear states
+              setInsertTarget(null);
+              setIsDragOverRoot(false);
+            }}
+          >
             {visibleGroups.map((group) => (
               <PeopleGroupRow
                 key={group.id}
                 group={group}
                 depth={0}
                 dragOverGroupId={dragOverGroupId}
+                insertTarget={insertTarget}
                 selectedId={selection?.id ?? null}
                 expandedIds={expandedIds}
                 onSelect={setSelection}
@@ -839,8 +884,16 @@ export function PeoplePanel() {
                 onOpenProfile={openProfile}
                 onOpenPersonWorkspace={openPersonWorkspace}
                 onOpenContent={openContentWorkspace}
-                onDragOverGroup={setDragOverGroupId}
+                onDragOverGroup={(id) => {
+                  setDragOverGroupId(id);
+                  if (id) { setInsertTarget(null); setIsDragOverRoot(false); }
+                }}
+                onDragInsertNear={(groupId, position, parentGroupId) => {
+                  setDragOverGroupId(null);
+                  setInsertTarget(groupId ? { groupId, position, parentGroupId } : null);
+                }}
                 onDropOnGroup={(payload, targetGroupId) => void movePeopleRecord(payload, targetGroupId)}
+                onDropInsertNear={(payload, parentGroupId) => void movePeopleRecord(payload, parentGroupId)}
               />
             ))}
           </div>
@@ -1029,6 +1082,7 @@ function PeopleGroupRow({
   group,
   depth,
   dragOverGroupId,
+  insertTarget,
   selectedId,
   expandedIds,
   onSelect,
@@ -1038,11 +1092,14 @@ function PeopleGroupRow({
   onOpenPersonWorkspace,
   onOpenContent,
   onDragOverGroup,
+  onDragInsertNear,
   onDropOnGroup,
+  onDropInsertNear,
 }: {
   group: PeopleTreeGroupNode;
   depth: number;
   dragOverGroupId: string | null;
+  insertTarget: { groupId: string; position: "before" | "after"; parentGroupId: string | null } | null;
   selectedId: string | null;
   expandedIds: Set<string>;
   onSelect: (selection: PeopleSelection) => void;
@@ -1052,7 +1109,9 @@ function PeopleGroupRow({
   onOpenPersonWorkspace: (person: { personId: string; label: string }) => void;
   onOpenContent: (content: PeopleTreeContentNode) => void;
   onDragOverGroup: (groupId: string | null) => void;
-  onDropOnGroup: (payload: PeopleDragPayload, targetGroupId: string) => void;
+  onDragInsertNear: (groupId: string | null, position: "before" | "after", parentGroupId: string | null) => void;
+  onDropOnGroup: (payload: PeopleDragPayload, targetGroupId: string | null) => void;
+  onDropInsertNear: (payload: PeopleDragPayload, parentGroupId: string | null) => void;
 }) {
   const isDragTarget = dragOverGroupId === group.groupId;
   const isSelected = selectedId === group.id;
@@ -1060,8 +1119,15 @@ function PeopleGroupRow({
   const isExpanded = expandedIds.has(group.id);
   const hasChildren = group.content.length > 0 || group.people.length > 0 || group.childGroups.length > 0;
 
+  const isInsertBefore = insertTarget?.groupId === group.groupId && insertTarget.position === "before";
+  const isInsertAfter = insertTarget?.groupId === group.groupId && insertTarget.position === "after";
+
   return (
     <div>
+      {/* Insert-before indicator */}
+      {isInsertBefore && (
+        <div className="pointer-events-none mx-1 h-0.5 rounded-full bg-gold-primary/70" style={{ marginLeft: 8 + depth * 14 }} />
+      )}
       <div
         role="treeitem"
         tabIndex={0}
@@ -1094,14 +1160,44 @@ function PeopleGroupRow({
           if (!hasPeopleDrag(event)) return;
           event.preventDefault();
           event.dataTransfer.dropEffect = "move";
-          onDragOverGroup(group.groupId);
+
+          const rect = event.currentTarget.getBoundingClientRect();
+          const relY = (event.clientY - rect.top) / rect.height;
+          const edgeZone = 0.3;
+
+          if (relY < edgeZone) {
+            // Top edge → insert before (move to same parent)
+            onDragInsertNear(group.groupId, "before", group.parentGroupId ?? null);
+            onDragOverGroup(null);
+          } else if (relY > 1 - edgeZone) {
+            // Bottom edge → insert after (move to same parent)
+            onDragInsertNear(group.groupId, "after", group.parentGroupId ?? null);
+            onDragOverGroup(null);
+          } else {
+            // Center → drop into this group
+            onDragInsertNear(null, "before", null);
+            onDragOverGroup(group.groupId);
+          }
         }}
-        onDragLeave={() => onDragOverGroup(null)}
+        onDragLeave={() => {
+          onDragOverGroup(null);
+          onDragInsertNear(null, "before", null);
+        }}
         onDrop={(event) => {
           const payload = getPeopleDragPayload(event);
           if (!payload) return;
+          // Prevent dropping a group onto itself
+          if (payload.kind === "peopleGroup" && payload.groupId === group.groupId) {
+            event.preventDefault();
+            return;
+          }
           event.preventDefault();
-          onDropOnGroup(payload, group.groupId);
+          // If an insert indicator is active for this group, move to parent level
+          if (insertTarget?.groupId === group.groupId) {
+            onDropInsertNear(payload, group.parentGroupId ?? null);
+          } else {
+            onDropOnGroup(payload, group.groupId);
+          }
         }}
         className={`flex items-center gap-2 rounded px-2 py-1.5 text-sm outline-none transition-colors hover:bg-gray-50 focus:bg-gray-50 ${
           isSelected ? "bg-gold-primary/10 ring-1 ring-gold-primary/30" : ""
@@ -1129,6 +1225,10 @@ function PeopleGroupRow({
         </div>
         <MountBadge mounted={Boolean(group.mount)} />
       </div>
+      {/* Insert-after indicator */}
+      {isInsertAfter && (
+        <div className="pointer-events-none mx-1 h-0.5 rounded-full bg-gold-primary/70" style={{ marginLeft: 8 + depth * 14 }} />
+      )}
 
       {isExpanded ? (
         <>
@@ -1168,6 +1268,7 @@ function PeopleGroupRow({
               group={childGroup}
               depth={depth + 1}
               dragOverGroupId={dragOverGroupId}
+              insertTarget={insertTarget}
               selectedId={selectedId}
               expandedIds={expandedIds}
               onSelect={onSelect}
@@ -1177,7 +1278,9 @@ function PeopleGroupRow({
               onOpenPersonWorkspace={onOpenPersonWorkspace}
               onOpenContent={onOpenContent}
               onDragOverGroup={onDragOverGroup}
+              onDragInsertNear={onDragInsertNear}
               onDropOnGroup={onDropOnGroup}
+              onDropInsertNear={onDropInsertNear}
             />
           ))}
         </>
@@ -1596,6 +1699,8 @@ function NestedAddMenuButton({
   onLeafAction: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [submenuPos, setSubmenuPos] = useState<{ x: number; y: number } | null>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const scheduleClose = () => {
@@ -1609,30 +1714,42 @@ function NestedAddMenuButton({
     }
   };
 
+  const openSubmenu = () => {
+    if (disabled) return;
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (rect) {
+      setSubmenuPos({ x: rect.right + 2, y: rect.top });
+    }
+    setOpen(true);
+  };
+
   return (
     <div
+      ref={triggerRef}
       className="relative"
-      onMouseEnter={() => { cancelClose(); if (!disabled) setOpen(true); }}
+      onMouseEnter={() => { cancelClose(); openSubmenu(); }}
       onMouseLeave={scheduleClose}
     >
       <button
         type="button"
         disabled={disabled}
-        onClick={() => { if (!disabled) setOpen((c) => !c); }}
+        onClick={() => { if (!disabled) setOpen((c) => { if (!c) openSubmenu(); return !c; }); }}
         className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-gray-700 transition-colors hover:bg-primary/8 hover:text-primary disabled:cursor-not-allowed disabled:text-gray-300 dark:text-gray-300 dark:hover:text-primary"
       >
         <span className="shrink-0 text-gray-400 dark:text-gray-500">{icon}</span>
         <span className="flex-1">{label}</span>
         <ChevronRight className="h-3.5 w-3.5 text-gray-400" />
       </button>
-      {open ? (
+      {open && submenuPos ? createPortal(
         <div
-          className="absolute left-full top-0 z-30 min-w-52 overflow-visible rounded-md border border-white/20 bg-white/95 py-1 shadow-lg backdrop-blur-sm dark:bg-gray-900/95"
+          className="fixed z-[250] min-w-52 rounded-md border border-white/20 bg-white/95 py-1 shadow-lg backdrop-blur-sm dark:bg-gray-900/95"
+          style={{ left: submenuPos.x, top: submenuPos.y }}
           onMouseEnter={cancelClose}
           onMouseLeave={scheduleClose}
         >
           <RecursiveMenuItems items={items} onLeafAction={onLeafAction} />
-        </div>
+        </div>,
+        document.body
       ) : null}
     </div>
   );

--- a/components/content/toolbar/ContentToolbar.tsx
+++ b/components/content/toolbar/ContentToolbar.tsx
@@ -31,7 +31,7 @@ export function ContentToolbar() {
 
   return (
     <div
-      className="flex min-h-11 shrink-0 items-center gap-1 overflow-x-auto bg-background px-3 py-1.5"
+      className="flex min-h-11 shrink-0 items-center gap-1 overflow-x-auto px-3 py-1.5"
       role="toolbar"
       aria-label="Content actions"
     >

--- a/components/content/viewer/FolderViewer.tsx
+++ b/components/content/viewer/FolderViewer.tsx
@@ -136,7 +136,7 @@ export function FolderViewer({
       </div>
 
       {/* Content - Delegated to FolderViewContainer */}
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 overflow-auto">
         <FolderViewContainer
           viewMode={viewMode}
           folderId={contentId}

--- a/docs/notes-feature/work-tracking/BACKLOG.md
+++ b/docs/notes-feature/work-tracking/BACKLOG.md
@@ -315,6 +315,9 @@ The following sprints were originally 38-42 in Epoch 9 but are deferred to Epoch
 - [ ] **Settings: back arrow navigation** — Add a back arrow at the top of the Settings page to navigate back to the content IDE. Should return to the last viewed note (or once tabs exist, restore the full workspace state). (2 pts)
 - [ ] **Storage Settings: show existing providers** — The Providers tab should list all currently configured storage providers (with status, type, default indicator) and allow editing/removing them. Currently only shows "+ Add Provider" with no visibility into what's already configured. (3 pts)
 
+### Refactoring / Tech Debt
+- [ ] **People panel drag-and-drop: consolidate with file tree** — The People panel reimplements drag logic (insert indicators, edge-zone detection, drop-into-group vs drop-beside) that mirrors the file tree. Extract the shared logic into a reusable hook or utility (`useSortableDragDrop` or similar) so both trees use the same implementation. Currently in `components/content/people/PeoplePanel.tsx` (`PeopleGroupRow`) and `components/content/FileTree.tsx`. (3 pts)
+
 ### Bug Fixes
 - [ ] **Desktop logo missing in content layout** — The Digital Garden tree logo inside the gold medallion (NotesNavBar → NotesLogo → CompactLogo) renders on mobile and the home page but is invisible on desktop in the content layout. The gold medallion ring appears but the animated SVG tree inside is blank. Likely a `useLogoAnimation` issue where SVG paths stay at `opacity: 0` if the draw animation fails silently on desktop. (2 pts)
 

--- a/extensions/calendar/components/CalendarQuickAddDialog.tsx
+++ b/extensions/calendar/components/CalendarQuickAddDialog.tsx
@@ -55,6 +55,7 @@ export function CalendarQuickAddDialog() {
   const [endAt, setEndAt] = useState("");
   const [allDay, setAllDay] = useState(false);
   const [sourceId, setSourceId] = useState("");
+  const [recurrence, setRecurrence] = useState<string>("none");
 
   const writableSources = useMemo(
     () => sources.filter((source) => !source.isReadOnly),
@@ -69,6 +70,7 @@ export function CalendarQuickAddDialog() {
     setEndAt(toLocalDateTimeValue(quickAddDraft?.endAt || null, nextAllDay));
     setAllDay(nextAllDay);
     setSourceId(quickAddDraft?.sourceId || writableSources[0]?.id || "");
+    setRecurrence("none");
   }, [quickAddDraft, writableSources]);
 
   useEffect(() => {
@@ -121,6 +123,7 @@ export function CalendarQuickAddDialog() {
             fromLocalDateTimeValue(endAt, allDay) ||
             new Date(Date.now() + 60 * 60 * 1000).toISOString(),
           allDay,
+          recurrenceRule: recurrence === "none" ? null : recurrence,
           linkedContentId: quickAddDraft?.linkedContentId || selectedContentId || null,
         }),
       });
@@ -164,9 +167,16 @@ export function CalendarQuickAddDialog() {
                 id="calendar-event-start"
                 type={allDay ? "date" : "datetime-local"}
                 value={startAt}
-                onChange={(event) => {
-                  setStartAt(event.target.value);
-                  if (!allDay) return;
+                onChange={(event) => setStartAt(event.target.value)}
+                onBlur={(event) => {
+                  const nextStart = event.target.value;
+                  if (!nextStart || !endAt) return;
+                  const startMs = new Date(nextStart).getTime();
+                  const endMs = new Date(endAt).getTime();
+                  if (!isNaN(startMs) && !isNaN(endMs) && endMs <= startMs) {
+                    const autoEnd = new Date(startMs + 60 * 60 * 1000);
+                    setEndAt(toLocalDateTimeValue(autoEnd.toISOString(), allDay));
+                  }
                 }}
                 className="border-white/10 bg-white/5"
               />
@@ -178,10 +188,7 @@ export function CalendarQuickAddDialog() {
                 id="calendar-event-end"
                 type={allDay ? "date" : "datetime-local"}
                 value={endAt}
-                onChange={(event) => {
-                  setEndAt(event.target.value);
-                  if (!allDay) return;
-                }}
+                onChange={(event) => setEndAt(event.target.value)}
                 className="border-white/10 bg-white/5"
               />
             </div>
@@ -221,6 +228,23 @@ export function CalendarQuickAddDialog() {
               />
               All day
             </label>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="calendar-event-recurrence">Repeat</Label>
+            <select
+              id="calendar-event-recurrence"
+              value={recurrence}
+              onChange={(event) => setRecurrence(event.target.value)}
+              className="flex h-10 w-full rounded-md border border-white/10 bg-white/5 px-3 text-sm text-white"
+            >
+              <option value="none">Does not repeat</option>
+              <option value="RRULE:FREQ=DAILY">Daily</option>
+              <option value="RRULE:FREQ=WEEKLY">Weekly</option>
+              <option value="RRULE:FREQ=WEEKLY;INTERVAL=2">Biweekly (every other week)</option>
+              <option value="RRULE:FREQ=MONTHLY">Monthly</option>
+              <option value="RRULE:FREQ=YEARLY">Annually</option>
+            </select>
           </div>
 
           <div className="space-y-2">

--- a/extensions/workplaces/components/WorkspaceSelector.tsx
+++ b/extensions/workplaces/components/WorkspaceSelector.tsx
@@ -378,6 +378,19 @@ export function WorkspaceSelector() {
     workspaceId: string;
     action: "settings" | "delete";
   } | null>(null);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  // Imperatively focus the rename input after Radix has released focus management.
+  // autoFocus alone is unreliable here because createWorkspace is async and the
+  // dropdown may still be in Radix's open animation when the input first mounts.
+  useEffect(() => {
+    if (!editingWorkspaceId) return;
+    const raf = requestAnimationFrame(() => {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [editingWorkspaceId]);
 
   const recursiveFolderClaims = useMemo(
     () =>
@@ -1216,7 +1229,7 @@ export function WorkspaceSelector() {
               >
                 {isEditing ? (
                   <input
-                    autoFocus
+                    ref={renameInputRef}
                     value={editingName}
                     onChange={(event) => setEditingName(event.target.value)}
                     onBlur={() => void commitInlineRename()}

--- a/lib/domain/collaboration/extensions.ts
+++ b/lib/domain/collaboration/extensions.ts
@@ -30,6 +30,7 @@ import { ServerNumberInput } from "@/lib/domain/editor/extensions/blocks/number-
 import { ServerRatingInput } from "@/lib/domain/editor/extensions/blocks/rating-input";
 import { ServerPromptInput } from "@/lib/domain/editor/extensions/blocks/prompt-input";
 import { ServerTimestamp } from "@/lib/domain/editor/extensions/blocks/timestamp";
+import { ServerInlineTimestamp } from "@/lib/domain/editor/extensions/inline-timestamp";
 import { ServerPersonMention } from "@/lib/domain/editor/extensions/person-mention-server";
 import { ServerTag } from "@/lib/domain/editor/extensions/tag-server";
 import { ServerWikiLink } from "@/lib/domain/editor/extensions/wiki-link-server";
@@ -87,6 +88,7 @@ export function getCollaborationServerExtensions(): Extensions {
     ServerRatingInput,
     ServerPromptInput,
     ServerTimestamp,
+    ServerInlineTimestamp,
     ...getExtensionServerEditorExtensions(),
     ServerTag,
     ServerPersonMention,

--- a/lib/domain/editor/commands/slash-commands.tsx
+++ b/lib/domain/editor/commands/slash-commands.tsx
@@ -16,6 +16,7 @@ import { PluginKey } from "@tiptap/pm/state";
 import tippy, { Instance as TippyInstance } from "tippy.js";
 import { SlashCommandsList, type SlashCommandsListRef } from "./slash-commands-menu";
 import { getExtensionSlashCommands } from "@/lib/extensions/editor-client-registry";
+import { useTimestampFormatStore } from "@/state/timestamp-format-store";
 
 // Plugin key for slash commands
 export const slashCommandsPluginKey = new PluginKey("slashCommands");
@@ -493,7 +494,6 @@ export function getSlashCommands(editor: Editor): SlashCommand[] {
       description: "Insert today's date inline — click to set format & mode",
       icon: "🕐",
       command: ({ editor, range }) => {
-        const { useTimestampFormatStore } = require("@/state/timestamp-format-store");
         const { defaultFormat, defaultMode } = useTimestampFormatStore.getState();
         const d = new Date();
         const iso = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;

--- a/lib/domain/editor/commands/slash-commands.tsx
+++ b/lib/domain/editor/commands/slash-commands.tsx
@@ -487,15 +487,19 @@ export function getSlashCommands(editor: Editor): SlashCommand[] {
       },
       aliases: ["snip", "snippets", "reusable"],
     },
-    // Sprint 65: Timestamp block
+    // upnext: Inline timestamp — flows inside text, click to set format/mode
     {
       title: "Timestamp",
-      description: "Insert today's date as a frozen timestamp",
+      description: "Insert today's date inline — click to set format & mode",
       icon: "🕐",
       command: ({ editor, range }) => {
+        const { useTimestampFormatStore } = require("@/state/timestamp-format-store");
+        const { defaultFormat, defaultMode } = useTimestampFormatStore.getState();
+        const d = new Date();
+        const iso = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
         editor.chain().focus().deleteRange(range).insertContent({
-          type: "timestamp",
-          attrs: { isoDate: new Date().toISOString().slice(0, 10) },
+          type: "inlineTimestamp",
+          attrs: { isoDate: iso, format: defaultFormat, mode: defaultMode },
         }).run();
       },
       aliases: ["date", "today", "now", "stamp", "datestamp"],

--- a/lib/domain/editor/extensions-client.ts
+++ b/lib/domain/editor/extensions-client.ts
@@ -58,6 +58,7 @@ import { NumberInput } from "./extensions/blocks/number-input";
 import { RatingInput } from "./extensions/blocks/rating-input";
 import { PromptInput } from "./extensions/blocks/prompt-input";
 import { Timestamp } from "./extensions/blocks/timestamp";
+import { InlineTimestamp } from "./extensions/inline-timestamp";
 import { getExtensionClientEditorExtensions } from "@/lib/extensions/editor-client-registry";
 
 // Create lowlight instance with common languages
@@ -275,6 +276,7 @@ export function getEditorExtensions(options?: EditorExtensionsOptions): Extensio
     RatingInput,
     PromptInput,
     Timestamp,
+    InlineTimestamp,
     ...getExtensionClientEditorExtensions(),
 
     // M6: Tags with autocomplete

--- a/lib/domain/editor/extensions-server.ts
+++ b/lib/domain/editor/extensions-server.ts
@@ -39,6 +39,7 @@ import { ServerNumberInput } from "./extensions/blocks/number-input";
 import { ServerRatingInput } from "./extensions/blocks/rating-input";
 import { ServerPromptInput } from "./extensions/blocks/prompt-input";
 import { ServerTimestamp } from "./extensions/blocks/timestamp";
+import { ServerInlineTimestamp } from "./extensions/inline-timestamp";
 import { ServerPersonMention } from "./extensions/person-mention-server";
 import { ServerTag } from "./extensions/tag-server";
 import { ServerWikiLink } from "./extensions/wiki-link-server";
@@ -148,6 +149,7 @@ export function getServerExtensions(): Extensions {
     ServerRatingInput,
     ServerPromptInput,
     ServerTimestamp,
+    ServerInlineTimestamp,
     ...getExtensionServerEditorExtensions(),
     ServerTag,
     ServerWikiLink,

--- a/lib/domain/editor/extensions/inline-timestamp.ts
+++ b/lib/domain/editor/extensions/inline-timestamp.ts
@@ -1,0 +1,430 @@
+/**
+ * Inline Timestamp Extension
+ *
+ * An inline atom node that flows inside paragraphs like text.
+ * Clicking opens a popover (portaled to document.body) to set:
+ *   - format  — per-node display format (e.g. "MMMM D, YYYY")
+ *   - mode    — frozen | document-date | live
+ *
+ * Inherits paragraph-level formatting (bold, italic, headings) naturally
+ * since it lives inside those nodes. Does NOT use the block factory chrome.
+ *
+ * upnext branch
+ */
+
+import { Node, mergeAttributes, type RawCommands } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { FORMAT_PRESETS, type TimestampFormat, type TimestampMode } from "@/state/timestamp-format-store";
+
+// ─── Date formatting ─────────────────────────────────────────────────────────
+
+const MONTHS_LONG = ["January","February","March","April","May","June","July","August","September","October","November","December"];
+const MONTHS_SHORT = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+export function formatTimestampDate(isoDate: string, format: TimestampFormat): string {
+  if (!isoDate) return "";
+  const match = isoDate.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return isoDate;
+  const year = parseInt(match[1], 10);
+  const month = parseInt(match[2], 10) - 1;
+  const day = parseInt(match[3], 10);
+  const mL = MONTHS_LONG[month] ?? "";
+  const mS = MONTHS_SHORT[month] ?? "";
+  const mN = month + 1;
+  switch (format) {
+    case "MMMM D, YYYY": return `${mL} ${day}, ${year}`;
+    case "MMM D, YYYY":  return `${mS} ${day}, ${year}`;
+    case "D MMMM YYYY":  return `${day} ${mL} ${year}`;
+    case "MM/DD/YYYY":   return `${pad2(mN)}/${pad2(day)}/${year}`;
+    case "DD/MM/YYYY":   return `${pad2(day)}/${pad2(mN)}/${year}`;
+    case "YYYY-MM-DD":   return `${year}-${pad2(mN)}-${pad2(day)}`;
+    default:             return isoDate;
+  }
+}
+
+function todayIso(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+// ─── Popover ─────────────────────────────────────────────────────────────────
+// Vanilla DOM popover — no React dep in this file so it works alongside
+// the ProseMirror plugin lifecycle without hook restrictions.
+
+let activePopover: { destroy: () => void } | null = null;
+
+function destroyActivePopover() {
+  if (activePopover) {
+    activePopover.destroy();
+    activePopover = null;
+  }
+}
+
+function createTimestampPopover(opts: {
+  anchorRect: DOMRect;
+  currentFormat: TimestampFormat;
+  currentMode: TimestampMode;
+  onFormatChange: (f: TimestampFormat) => void;
+  onModeChange: (m: TimestampMode) => void;
+  onClose: () => void;
+}) {
+  destroyActivePopover();
+
+  const { anchorRect, currentFormat, currentMode, onFormatChange, onModeChange, onClose } = opts;
+
+  // Portal container
+  const portal = document.createElement("div");
+  portal.setAttribute("data-inline-timestamp-popover", "");
+  portal.style.cssText = `
+    position: fixed;
+    z-index: 9999;
+    background: var(--background, #fff);
+    border: 1px solid rgba(0,0,0,0.1);
+    border-radius: 10px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.12), 0 1px 4px rgba(0,0,0,0.06);
+    padding: 12px;
+    min-width: 220px;
+    font-family: inherit;
+    font-size: 13px;
+    color: var(--foreground, #1a1a1a);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  `;
+
+  // ── Mode row ──
+  const modeLabel = document.createElement("div");
+  modeLabel.textContent = "Mode";
+  modeLabel.style.cssText = "font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted-foreground, #888); margin-bottom: 2px;";
+
+  const modeRow = document.createElement("div");
+  modeRow.style.cssText = "display: flex; gap: 6px;";
+
+  const MODES: { key: TimestampMode; label: string; title: string }[] = [
+    { key: "frozen",        label: "🔒 Frozen",    title: "Date is set at insertion and never changes" },
+    { key: "document-date", label: "📄 Doc date",  title: "Resolves to the document's creation date — useful in templates" },
+    { key: "live",          label: "🔄 Live",      title: "Always shows today's date" },
+  ];
+
+  MODES.forEach(({ key, label, title }) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.textContent = label;
+    btn.title = title;
+    btn.style.cssText = `
+      flex: 1;
+      padding: 4px 6px;
+      border-radius: 6px;
+      border: 1px solid ${currentMode === key ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.1)"};
+      background: ${currentMode === key ? "rgba(201,168,108,0.12)" : "transparent"};
+      color: ${currentMode === key ? "var(--gold-primary, #c9a86c)" : "inherit"};
+      font-size: 12px;
+      cursor: pointer;
+      transition: all 0.1s;
+      white-space: nowrap;
+    `;
+    btn.addEventListener("click", () => {
+      onModeChange(key);
+      // Update active state visually
+      modeRow.querySelectorAll("button").forEach((b, i) => {
+        const active = MODES[i].key === key;
+        (b as HTMLButtonElement).style.border = `1px solid ${active ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.1)"}`;
+        (b as HTMLButtonElement).style.background = active ? "rgba(201,168,108,0.12)" : "transparent";
+        (b as HTMLButtonElement).style.color = active ? "var(--gold-primary, #c9a86c)" : "inherit";
+      });
+    });
+    modeRow.appendChild(btn);
+  });
+
+  // ── Format row ──
+  const formatLabel = document.createElement("div");
+  formatLabel.textContent = "Format";
+  formatLabel.style.cssText = "font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted-foreground, #888); margin-bottom: 2px;";
+
+  const formatGrid = document.createElement("div");
+  formatGrid.style.cssText = "display: grid; grid-template-columns: 1fr 1fr; gap: 4px;";
+
+  const sampleDate = todayIso();
+
+  FORMAT_PRESETS.forEach((preset) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.textContent = formatTimestampDate(sampleDate, preset);
+    btn.style.cssText = `
+      padding: 5px 8px;
+      border-radius: 6px;
+      border: 1px solid ${currentFormat === preset ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.1)"};
+      background: ${currentFormat === preset ? "rgba(201,168,108,0.12)" : "transparent"};
+      color: ${currentFormat === preset ? "var(--gold-primary, #c9a86c)" : "inherit"};
+      font-size: 12px;
+      cursor: pointer;
+      transition: all 0.1s;
+      text-align: left;
+    `;
+    btn.addEventListener("click", () => {
+      onFormatChange(preset);
+      formatGrid.querySelectorAll("button").forEach((b, i) => {
+        const active = FORMAT_PRESETS[i] === preset;
+        (b as HTMLButtonElement).style.border = `1px solid ${active ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.1)"}`;
+        (b as HTMLButtonElement).style.background = active ? "rgba(201,168,108,0.12)" : "transparent";
+        (b as HTMLButtonElement).style.color = active ? "var(--gold-primary, #c9a86c)" : "inherit";
+      });
+    });
+    formatGrid.appendChild(btn);
+  });
+
+  portal.appendChild(modeLabel);
+  portal.appendChild(modeRow);
+  portal.appendChild(formatLabel);
+  portal.appendChild(formatGrid);
+  document.body.appendChild(portal);
+
+  // ── Position: below anchor, flip up if needed ──
+  const pRect = portal.getBoundingClientRect();
+  const spaceBelow = window.innerHeight - anchorRect.bottom - 8;
+  const top = spaceBelow >= pRect.height
+    ? anchorRect.bottom + 6
+    : anchorRect.top - pRect.height - 6;
+  const left = Math.min(
+    anchorRect.left,
+    window.innerWidth - pRect.width - 8
+  );
+  portal.style.top = `${Math.max(8, top)}px`;
+  portal.style.left = `${Math.max(8, left)}px`;
+
+  // ── Click-outside to close ──
+  function handleOutside(e: MouseEvent) {
+    if (!portal.contains(e.target as globalThis.Node)) {
+      onClose();
+    }
+  }
+  // Defer so the triggering click doesn't immediately close
+  setTimeout(() => document.addEventListener("mousedown", handleOutside), 10);
+
+  function destroy() {
+    document.removeEventListener("mousedown", handleOutside);
+    portal.remove();
+  }
+
+  activePopover = { destroy };
+  return { destroy };
+}
+
+// ─── TipTap Node ─────────────────────────────────────────────────────────────
+
+export const InlineTimestamp = Node.create({
+  name: "inlineTimestamp",
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      isoDate: {
+        default: "",
+        parseHTML: (el) => el.getAttribute("data-iso-date") || "",
+        renderHTML: (attrs) => ({ "data-iso-date": attrs.isoDate }),
+      },
+      format: {
+        default: "MMMM D, YYYY" as TimestampFormat,
+        parseHTML: (el) => (el.getAttribute("data-format") || "MMMM D, YYYY") as TimestampFormat,
+        renderHTML: (attrs) => ({ "data-format": attrs.format }),
+      },
+      mode: {
+        default: "frozen" as TimestampMode,
+        parseHTML: (el) => (el.getAttribute("data-mode") || "frozen") as TimestampMode,
+        renderHTML: (attrs) => ({ "data-mode": attrs.mode }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'time[data-inline-timestamp]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const isoDate = String(HTMLAttributes["data-iso-date"] || "");
+    const format = (HTMLAttributes["data-format"] || "MMMM D, YYYY") as TimestampFormat;
+    const mode = (HTMLAttributes["data-mode"] || "frozen") as TimestampMode;
+    const resolved = mode === "live" ? todayIso() : isoDate;
+    const text = formatTimestampDate(resolved, format);
+    return [
+      "time",
+      mergeAttributes(HTMLAttributes, {
+        "data-inline-timestamp": "",
+        class: "inline-timestamp",
+        datetime: resolved,
+        contenteditable: "false",
+      }),
+      text || resolved,
+    ];
+  },
+
+  addNodeView() {
+    return ({ node, getPos, editor }) => {
+      const dom = document.createElement("time");
+      dom.setAttribute("data-inline-timestamp", "");
+      dom.setAttribute("contenteditable", "false");
+      dom.className = "inline-timestamp";
+      dom.style.cssText = `
+        display: inline;
+        cursor: pointer;
+        border-radius: 4px;
+        padding: 1px 4px;
+        background: rgba(201,168,108,0.10);
+        color: var(--gold-primary, #c9a86c);
+        font-size: inherit;
+        line-height: inherit;
+        transition: background 0.1s;
+      `;
+
+      function resolvedDate(): string {
+        return node.attrs.mode === "live" ? todayIso() : node.attrs.isoDate;
+      }
+
+      function render() {
+        dom.setAttribute("datetime", resolvedDate());
+        dom.textContent = formatTimestampDate(resolvedDate(), node.attrs.format as TimestampFormat) || resolvedDate();
+      }
+
+      render();
+
+      dom.addEventListener("mouseenter", () => {
+        dom.style.background = "rgba(201,168,108,0.20)";
+      });
+      dom.addEventListener("mouseleave", () => {
+        dom.style.background = "rgba(201,168,108,0.10)";
+      });
+
+      dom.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const anchorRect = dom.getBoundingClientRect();
+
+        createTimestampPopover({
+          anchorRect,
+          currentFormat: node.attrs.format as TimestampFormat,
+          currentMode: node.attrs.mode as TimestampMode,
+          onFormatChange: (format) => {
+            if (typeof getPos === "function") {
+              const pos = getPos() as number;
+              editor.chain().focus().command(({ tr }) => {
+                tr.setNodeMarkup(pos, undefined, { ...node.attrs, format });
+                return true;
+              }).run();
+            }
+          },
+          onModeChange: (mode) => {
+            if (typeof getPos === "function") {
+              const pos = getPos() as number;
+              const newIso = mode === "live" ? todayIso() : node.attrs.isoDate;
+              editor.chain().focus().command(({ tr }) => {
+                tr.setNodeMarkup(pos, undefined, { ...node.attrs, mode, isoDate: newIso });
+                return true;
+              }).run();
+            }
+          },
+          onClose: destroyActivePopover,
+        });
+      });
+
+      return {
+        dom,
+        update(updatedNode) {
+          if (updatedNode.type.name !== "inlineTimestamp") return false;
+          // Keep node ref in sync for click handler closure
+          (node as any) = updatedNode;
+          render();
+          return true;
+        },
+        destroy() {
+          destroyActivePopover();
+        },
+      };
+    };
+  },
+
+  addCommands() {
+    return {
+      insertInlineTimestamp:
+        (attrs?: { format?: TimestampFormat; mode?: TimestampMode }) =>
+        ({ commands }: { commands: { insertContent: (c: unknown) => boolean } }) => {
+          return commands.insertContent({
+            type: "inlineTimestamp",
+            attrs: {
+              isoDate: todayIso(),
+              format: attrs?.format ?? "MMMM D, YYYY",
+              mode: attrs?.mode ?? "frozen",
+            },
+          });
+        },
+    } as Partial<RawCommands>;
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("inlineTimestampEscClose"),
+        props: {
+          handleKeyDown(_view, event) {
+            if (event.key === "Escape") {
+              destroyActivePopover();
+            }
+            return false;
+          },
+        },
+      }),
+    ];
+  },
+});
+
+// ─── Server-safe version ─────────────────────────────────────────────────────
+
+export const ServerInlineTimestamp = Node.create({
+  name: "inlineTimestamp",
+  group: "inline",
+  inline: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      isoDate: {
+        default: "",
+        parseHTML: (el) => el.getAttribute("data-iso-date") || "",
+        renderHTML: (attrs) => ({ "data-iso-date": attrs.isoDate }),
+      },
+      format: {
+        default: "MMMM D, YYYY" as TimestampFormat,
+        parseHTML: (el) => (el.getAttribute("data-format") || "MMMM D, YYYY") as TimestampFormat,
+        renderHTML: (attrs) => ({ "data-format": attrs.format }),
+      },
+      mode: {
+        default: "frozen" as TimestampMode,
+        parseHTML: (el) => (el.getAttribute("data-mode") || "frozen") as TimestampMode,
+        renderHTML: (attrs) => ({ "data-mode": attrs.mode }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'time[data-inline-timestamp]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const isoDate = String(HTMLAttributes["data-iso-date"] || "");
+    const format = (HTMLAttributes["data-format"] || "MMMM D, YYYY") as TimestampFormat;
+    const text = formatTimestampDate(isoDate, format);
+    return [
+      "time",
+      mergeAttributes(HTMLAttributes, {
+        "data-inline-timestamp": "",
+        class: "inline-timestamp",
+        datetime: isoDate,
+      }),
+      text || isoDate,
+    ];
+  },
+});

--- a/lib/domain/editor/extensions/inline-timestamp.ts
+++ b/lib/domain/editor/extensions/inline-timestamp.ts
@@ -641,6 +641,11 @@ export const ServerInlineTimestamp = Node.create({
         parseHTML: (el) => (el.getAttribute("data-mode") || "frozen") as TimestampMode,
         renderHTML: (attrs) => ({ "data-mode": attrs.mode }),
       },
+      customIso: {
+        default: "",
+        parseHTML: (el) => el.getAttribute("data-custom-iso") || "",
+        renderHTML: (attrs) => attrs.customIso ? { "data-custom-iso": attrs.customIso } : {},
+      },
     };
   },
 
@@ -649,17 +654,22 @@ export const ServerInlineTimestamp = Node.create({
   },
 
   renderHTML({ HTMLAttributes }) {
-    const isoDate = String(HTMLAttributes["data-iso-date"] || "");
+    const attrs = {
+      isoDate: String(HTMLAttributes["data-iso-date"] || ""),
+      mode: (HTMLAttributes["data-mode"] || "frozen") as TimestampMode,
+      customIso: String(HTMLAttributes["data-custom-iso"] || ""),
+    };
     const format = (HTMLAttributes["data-format"] || "MMMM D, YYYY") as TimestampFormat;
-    const text = formatTimestampDate(isoDate, format);
+    const resolvedIso = resolveIso(attrs);
+    const text = formatTimestampWithTime(resolvedIso, format);
     return [
       "time",
       mergeAttributes(HTMLAttributes, {
         "data-inline-timestamp": "",
         class: "inline-timestamp",
-        datetime: isoDate,
+        datetime: resolvedIso,
       }),
-      text || isoDate,
+      text || resolvedIso,
     ];
   },
 });

--- a/lib/domain/editor/extensions/inline-timestamp.ts
+++ b/lib/domain/editor/extensions/inline-timestamp.ts
@@ -3,8 +3,9 @@
  *
  * An inline atom node that flows inside paragraphs like text.
  * Clicking opens a popover (portaled to document.body) to set:
- *   - format  — per-node display format (e.g. "MMMM D, YYYY")
- *   - mode    — frozen | document-date | live
+ *   - format       — per-node display format (e.g. "MMMM D, YYYY")
+ *   - mode         — frozen | document-date | content-updated | custom | live
+ *   - customIso    — user-selected date/time (ISO, may include T hh:mm) for custom mode
  *
  * Inherits paragraph-level formatting (bold, italic, headings) naturally
  * since it lives inside those nodes. Does NOT use the block factory chrome.
@@ -15,6 +16,19 @@
 import { Node, mergeAttributes, type RawCommands } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { FORMAT_PRESETS, type TimestampFormat, type TimestampMode } from "@/state/timestamp-format-store";
+
+// ─── Document-level date context ─────────────────────────────────────────────
+// Set by MainPanelContent when a document is opened so that
+// "Content Creation" and "Content Updated" modes resolve correctly.
+
+let documentCreatedAt = "";
+let documentUpdatedAt = "";
+
+/** Called from MainPanelContent whenever a content node is loaded. */
+export function setDocumentDates(createdAt: string, updatedAt: string) {
+  documentCreatedAt = createdAt;
+  documentUpdatedAt = updatedAt;
+}
 
 // ─── Date formatting ─────────────────────────────────────────────────────────
 
@@ -43,9 +57,32 @@ export function formatTimestampDate(isoDate: string, format: TimestampFormat): s
   }
 }
 
+/** Format an ISO string with optional time suffix (12h, e.g. "3:45 PM"). */
+export function formatTimestampWithTime(iso: string, format: TimestampFormat): string {
+  const datePart = formatTimestampDate(iso, format);
+  const timeMatch = iso.match(/T(\d{2}):(\d{2})/);
+  if (!timeMatch) return datePart;
+  const h24 = parseInt(timeMatch[1], 10);
+  const mins = timeMatch[2];
+  const ampm = h24 >= 12 ? "PM" : "AM";
+  const h12 = h24 % 12 || 12;
+  return datePart ? `${datePart}, ${h12}:${mins} ${ampm}` : `${h12}:${mins} ${ampm}`;
+}
+
 function todayIso(): string {
   const d = new Date();
   return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+/** Resolve the effective ISO string based on mode. */
+function resolveIso(attrs: { mode: string; isoDate: string; customIso?: string }): string {
+  switch (attrs.mode) {
+    case "live":            return todayIso();
+    case "document-date":   return documentCreatedAt || attrs.isoDate;
+    case "content-updated": return documentUpdatedAt || attrs.isoDate;
+    case "custom":          return attrs.customIso || attrs.isoDate;
+    default:                return attrs.isoDate; // frozen
+  }
 }
 
 // ─── Popover ─────────────────────────────────────────────────────────────────
@@ -65,13 +102,24 @@ function createTimestampPopover(opts: {
   anchorRect: DOMRect;
   currentFormat: TimestampFormat;
   currentMode: TimestampMode;
+  currentCustomIso: string;
+  resolvedIso: string;
   onFormatChange: (f: TimestampFormat) => void;
   onModeChange: (m: TimestampMode) => void;
+  onCustomIsoChange: (iso: string) => void;
   onClose: () => void;
 }) {
   destroyActivePopover();
 
-  const { anchorRect, currentFormat, currentMode, onFormatChange, onModeChange, onClose } = opts;
+  const {
+    anchorRect, currentFormat, currentMode, currentCustomIso, resolvedIso,
+    onFormatChange, onModeChange, onCustomIsoChange, onClose,
+  } = opts;
+
+  // Track mutable state within popover lifetime
+  let activeMode = currentMode;
+  let activeFormat = currentFormat;
+  let activeCustomIso = currentCustomIso || todayIso();
 
   // Portal container
   const portal = document.createElement("div");
@@ -84,7 +132,7 @@ function createTimestampPopover(opts: {
     border-radius: 10px;
     box-shadow: 0 4px 16px rgba(0,0,0,0.12), 0 1px 4px rgba(0,0,0,0.06);
     padding: 12px;
-    min-width: 220px;
+    min-width: 240px;
     font-family: inherit;
     font-size: 13px;
     color: var(--foreground, #1a1a1a);
@@ -93,75 +141,186 @@ function createTimestampPopover(opts: {
     gap: 10px;
   `;
 
-  // ── Mode row ──
+  // ── SVG icons ──
+  const LOCK_SVG    = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>`;
+  const CREATED_SVG = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>`;
+  const UPDATED_SVG = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><polyline points="9 15 12 12 15 15"/></svg>`;
+  const CUSTOM_SVG  = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="8" y1="14" x2="10" y2="14"/><line x1="12" y1="14" x2="14" y2="14"/></svg>`;
+  const LIVE_SVG    = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
+  const COPY_SVG    = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
+
+  const MODES: { key: TimestampMode; label: string; icon: string; title: string }[] = [
+    { key: "frozen",          label: "Frozen",    icon: LOCK_SVG,    title: "Date is set at insertion and never changes" },
+    { key: "document-date",   label: "Created",   icon: CREATED_SVG, title: "Resolves to the document's creation date — useful in templates" },
+    { key: "content-updated", label: "Updated",   icon: UPDATED_SVG, title: "Resolves to the document's last-saved date" },
+    { key: "custom",          label: "Custom",    icon: CUSTOM_SVG,  title: "Pick any date (and optional time)" },
+    { key: "live",            label: "Live",      icon: LIVE_SVG,    title: "Always shows today's date" },
+  ];
+
+  // ── Mode label ──
   const modeLabel = document.createElement("div");
   modeLabel.textContent = "Mode";
   modeLabel.style.cssText = "font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted-foreground, #888); margin-bottom: 2px;";
 
-  const modeRow = document.createElement("div");
-  modeRow.style.cssText = "display: flex; gap: 6px;";
+  // ── Mode grid (3 columns auto-wrap) ──
+  const modeGrid = document.createElement("div");
+  modeGrid.style.cssText = "display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px;";
 
-  // Inline SVG icons — matches the project's server-component icon pattern
-  const LOCK_SVG = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>`;
-  const DOC_SVG  = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>`;
-  const LIVE_SVG = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
+  const modeButtons: HTMLButtonElement[] = [];
 
-  const MODES: { key: TimestampMode; label: string; icon: string; title: string }[] = [
-    { key: "frozen",        label: "Frozen",   icon: LOCK_SVG, title: "Date is set at insertion and never changes" },
-    { key: "document-date", label: "Doc date", icon: DOC_SVG,  title: "Resolves to the document's creation date — useful in templates" },
-    { key: "live",          label: "Live",     icon: LIVE_SVG, title: "Always shows today's date" },
-  ];
+  function applyModeButtonStyle(btn: HTMLButtonElement, active: boolean) {
+    btn.style.border = `1px solid ${active ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.08)"}`;
+    btn.style.background = active ? "rgba(201,168,108,0.12)" : "rgba(0,0,0,0.02)";
+    btn.style.color = active ? "var(--gold-primary, #c9a86c)" : "var(--muted-foreground, #888)";
+    btn.style.fontWeight = active ? "600" : "400";
+  }
+
+  // ── Custom date/time picker (hidden until custom mode active) ──
+  const customSection = document.createElement("div");
+  customSection.style.cssText = `
+    display: ${currentMode === "custom" ? "flex" : "none"};
+    flex-direction: column;
+    gap: 6px;
+  `;
+
+  function parseCustomParts(iso: string): { date: string; time: string } {
+    const dateMatch = iso.match(/^(\d{4}-\d{2}-\d{2})/);
+    const timeMatch = iso.match(/T(\d{2}:\d{2})/);
+    return {
+      date: dateMatch ? dateMatch[1] : todayIso(),
+      time: timeMatch ? timeMatch[1] : "",
+    };
+  }
+
+  const parts = parseCustomParts(activeCustomIso);
+
+  const dateInput = document.createElement("input");
+  dateInput.type = "date";
+  dateInput.value = parts.date;
+  dateInput.style.cssText = `
+    width: 100%;
+    padding: 5px 8px;
+    border-radius: 6px;
+    border: 1px solid rgba(0,0,0,0.12);
+    background: rgba(0,0,0,0.02);
+    color: var(--foreground, #1a1a1a);
+    font-size: 12px;
+    font-family: inherit;
+    box-sizing: border-box;
+    outline: none;
+  `;
+
+  const timeRow = document.createElement("div");
+  timeRow.style.cssText = "display: flex; align-items: center; gap: 6px;";
+
+  const timeCheckLabel = document.createElement("label");
+  timeCheckLabel.style.cssText = "display: flex; align-items: center; gap: 5px; font-size: 11px; color: var(--muted-foreground, #888); cursor: pointer; white-space: nowrap;";
+  const timeCheckbox = document.createElement("input");
+  timeCheckbox.type = "checkbox";
+  timeCheckbox.checked = Boolean(parts.time);
+  timeCheckbox.style.cssText = "cursor: pointer;";
+  timeCheckLabel.appendChild(timeCheckbox);
+  timeCheckLabel.appendChild(document.createTextNode("Include time"));
+
+  const timeInput = document.createElement("input");
+  timeInput.type = "time";
+  timeInput.value = parts.time || "12:00";
+  timeInput.style.cssText = `
+    flex: 1;
+    padding: 5px 8px;
+    border-radius: 6px;
+    border: 1px solid rgba(0,0,0,0.12);
+    background: rgba(0,0,0,0.02);
+    color: var(--foreground, #1a1a1a);
+    font-size: 12px;
+    font-family: inherit;
+    display: ${parts.time ? "block" : "none"};
+    box-sizing: border-box;
+    outline: none;
+  `;
+
+  function buildCustomIso(): string {
+    const d = dateInput.value || todayIso();
+    if (timeCheckbox.checked && timeInput.value) {
+      return `${d}T${timeInput.value}`;
+    }
+    return d;
+  }
+
+  function emitCustomChange() {
+    const iso = buildCustomIso();
+    activeCustomIso = iso;
+    onCustomIsoChange(iso);
+  }
+
+  timeCheckbox.addEventListener("change", () => {
+    timeInput.style.display = timeCheckbox.checked ? "block" : "none";
+    emitCustomChange();
+  });
+  dateInput.addEventListener("change", emitCustomChange);
+  timeInput.addEventListener("change", emitCustomChange);
+
+  timeRow.appendChild(timeCheckLabel);
+  timeRow.appendChild(timeInput);
+  customSection.appendChild(dateInput);
+  customSection.appendChild(timeRow);
 
   MODES.forEach(({ key, label, icon, title }) => {
     const btn = document.createElement("button");
     btn.type = "button";
     btn.title = title;
-    btn.innerHTML = `${icon}<span style="margin-left:4px">${label}</span>`;
+    btn.innerHTML = `<span style="display:flex;align-items:center;gap:4px;justify-content:center;">${icon}<span>${label}</span></span>`;
     const isActive = currentMode === key;
     btn.style.cssText = `
-      flex: 1;
-      display: inline-flex;
+      display: flex;
       align-items: center;
       justify-content: center;
-      padding: 5px 8px;
+      padding: 5px 6px;
       border-radius: 6px;
       border: 1px solid ${isActive ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.08)"};
       background: ${isActive ? "rgba(201,168,108,0.12)" : "rgba(0,0,0,0.02)"};
       color: ${isActive ? "var(--gold-primary, #c9a86c)" : "var(--muted-foreground, #888)"};
-      font-size: 12px;
+      font-size: 11px;
       font-weight: ${isActive ? "600" : "400"};
       cursor: pointer;
       transition: all 0.1s;
       white-space: nowrap;
-      gap: 4px;
+      font-family: inherit;
     `;
     btn.addEventListener("click", () => {
+      activeMode = key;
       onModeChange(key);
-      modeRow.querySelectorAll("button").forEach((b, i) => {
-        const active = MODES[i].key === key;
-        (b as HTMLButtonElement).style.border = `1px solid ${active ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.08)"}`;
-        (b as HTMLButtonElement).style.background = active ? "rgba(201,168,108,0.12)" : "rgba(0,0,0,0.02)";
-        (b as HTMLButtonElement).style.color = active ? "var(--gold-primary, #c9a86c)" : "var(--muted-foreground, #888)";
-        (b as HTMLButtonElement).style.fontWeight = active ? "600" : "400";
-      });
+      modeButtons.forEach((b, i) => applyModeButtonStyle(b, MODES[i].key === key));
+      // Show/hide custom section
+      customSection.style.display = key === "custom" ? "flex" : "none";
     });
-    modeRow.appendChild(btn);
+    modeGrid.appendChild(btn);
+    modeButtons.push(btn);
   });
 
-  // ── Format row ──
+  // ── Format label ──
   const formatLabel = document.createElement("div");
   formatLabel.textContent = "Format";
   formatLabel.style.cssText = "font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted-foreground, #888); margin-bottom: 2px;";
 
+  // ── Format grid ──
   const formatGrid = document.createElement("div");
   formatGrid.style.cssText = "display: grid; grid-template-columns: 1fr 1fr; gap: 4px;";
 
-  const sampleDate = todayIso();
+  // Use the resolved ISO so the preview shows the actual date (not just today)
+  const previewIso = resolvedIso || todayIso();
+
+  function applyFormatButtonStyle(btn: HTMLButtonElement, active: boolean) {
+    btn.style.border = `1px solid ${active ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.08)"}`;
+    btn.style.background = active ? "rgba(201,168,108,0.12)" : "rgba(0,0,0,0.02)";
+    btn.style.color = active ? "var(--gold-primary, #c9a86c)" : "var(--foreground, #1a1a1a)";
+    btn.style.fontWeight = active ? "600" : "400";
+  }
 
   FORMAT_PRESETS.forEach((preset) => {
     const btn = document.createElement("button");
     btn.type = "button";
-    btn.textContent = formatTimestampDate(sampleDate, preset);
+    btn.textContent = formatTimestampDate(previewIso, preset);
     const isActive = currentFormat === preset;
     btn.style.cssText = `
       padding: 6px 10px;
@@ -175,21 +334,19 @@ function createTimestampPopover(opts: {
       transition: all 0.1s;
       text-align: left;
       letter-spacing: -0.01em;
+      font-family: inherit;
     `;
     btn.addEventListener("mouseenter", () => {
-      if (preset !== currentFormat) btn.style.background = "rgba(0,0,0,0.05)";
+      if (preset !== activeFormat) btn.style.background = "rgba(0,0,0,0.05)";
     });
     btn.addEventListener("mouseleave", () => {
-      if (preset !== currentFormat) btn.style.background = "rgba(0,0,0,0.02)";
+      if (preset !== activeFormat) btn.style.background = "rgba(0,0,0,0.02)";
     });
     btn.addEventListener("click", () => {
+      activeFormat = preset;
       onFormatChange(preset);
       formatGrid.querySelectorAll("button").forEach((b, i) => {
-        const active = FORMAT_PRESETS[i] === preset;
-        (b as HTMLButtonElement).style.border = `1px solid ${active ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.08)"}`;
-        (b as HTMLButtonElement).style.background = active ? "rgba(201,168,108,0.12)" : "rgba(0,0,0,0.02)";
-        (b as HTMLButtonElement).style.color = active ? "var(--gold-primary, #c9a86c)" : "var(--foreground, #1a1a1a)";
-        (b as HTMLButtonElement).style.fontWeight = active ? "600" : "400";
+        applyFormatButtonStyle(b as HTMLButtonElement, FORMAT_PRESETS[i] === preset);
       });
     });
     formatGrid.appendChild(btn);
@@ -199,7 +356,6 @@ function createTimestampPopover(opts: {
   const divider = document.createElement("div");
   divider.style.cssText = "height: 1px; background: rgba(0,0,0,0.06); margin: 2px 0;";
 
-  const COPY_SVG = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
   const copyBtn = document.createElement("button");
   copyBtn.type = "button";
   copyBtn.innerHTML = `${COPY_SVG}<span style="margin-left:6px">Copy date text</span>`;
@@ -216,11 +372,14 @@ function createTimestampPopover(opts: {
     cursor: pointer;
     transition: background 0.1s;
     text-align: left;
+    font-family: inherit;
   `;
   copyBtn.addEventListener("mouseenter", () => { copyBtn.style.background = "rgba(0,0,0,0.04)"; });
   copyBtn.addEventListener("mouseleave", () => { copyBtn.style.background = "transparent"; });
   copyBtn.addEventListener("click", () => {
-    const text = formatTimestampDate(sampleDate, currentFormat);
+    // Resolve the actual displayed date, not just today
+    const iso = resolveIso({ mode: activeMode, isoDate: resolvedIso, customIso: activeCustomIso });
+    const text = formatTimestampWithTime(iso, activeFormat);
     navigator.clipboard.writeText(text).catch(() => {});
     copyBtn.innerHTML = `${COPY_SVG}<span style="margin-left:6px">Copied!</span>`;
     setTimeout(() => {
@@ -229,7 +388,8 @@ function createTimestampPopover(opts: {
   });
 
   portal.appendChild(modeLabel);
-  portal.appendChild(modeRow);
+  portal.appendChild(modeGrid);
+  portal.appendChild(customSection);
   portal.appendChild(formatLabel);
   portal.appendChild(formatGrid);
   portal.appendChild(divider);
@@ -255,7 +415,6 @@ function createTimestampPopover(opts: {
       onClose();
     }
   }
-  // Defer so the triggering click doesn't immediately close
   setTimeout(() => document.addEventListener("mousedown", handleOutside), 10);
 
   function destroy() {
@@ -293,6 +452,11 @@ export const InlineTimestamp = Node.create({
         parseHTML: (el) => (el.getAttribute("data-mode") || "frozen") as TimestampMode,
         renderHTML: (attrs) => ({ "data-mode": attrs.mode }),
       },
+      customIso: {
+        default: "",
+        parseHTML: (el) => el.getAttribute("data-custom-iso") || "",
+        renderHTML: (attrs) => attrs.customIso ? { "data-custom-iso": attrs.customIso } : {},
+      },
     };
   },
 
@@ -304,8 +468,9 @@ export const InlineTimestamp = Node.create({
     const isoDate = String(HTMLAttributes["data-iso-date"] || "");
     const format = (HTMLAttributes["data-format"] || "MMMM D, YYYY") as TimestampFormat;
     const mode = (HTMLAttributes["data-mode"] || "frozen") as TimestampMode;
-    const resolved = mode === "live" ? todayIso() : isoDate;
-    const text = formatTimestampDate(resolved, format);
+    const customIso = String(HTMLAttributes["data-custom-iso"] || "");
+    const resolved = resolveIso({ mode, isoDate, customIso });
+    const text = formatTimestampWithTime(resolved, format);
     return [
       "time",
       mergeAttributes(HTMLAttributes, {
@@ -336,13 +501,18 @@ export const InlineTimestamp = Node.create({
         transition: background 0.1s;
       `;
 
-      function resolvedDate(): string {
-        return node.attrs.mode === "live" ? todayIso() : node.attrs.isoDate;
+      function getResolved(): string {
+        return resolveIso({
+          mode: node.attrs.mode,
+          isoDate: node.attrs.isoDate,
+          customIso: node.attrs.customIso,
+        });
       }
 
       function render() {
-        dom.setAttribute("datetime", resolvedDate());
-        dom.textContent = formatTimestampDate(resolvedDate(), node.attrs.format as TimestampFormat) || resolvedDate();
+        const iso = getResolved();
+        dom.setAttribute("datetime", iso);
+        dom.textContent = formatTimestampWithTime(iso, node.attrs.format as TimestampFormat) || iso;
       }
 
       render();
@@ -364,6 +534,8 @@ export const InlineTimestamp = Node.create({
           anchorRect,
           currentFormat: node.attrs.format as TimestampFormat,
           currentMode: node.attrs.mode as TimestampMode,
+          currentCustomIso: node.attrs.customIso || "",
+          resolvedIso: getResolved(),
           onFormatChange: (format) => {
             if (typeof getPos === "function") {
               const pos = getPos() as number;
@@ -376,9 +548,17 @@ export const InlineTimestamp = Node.create({
           onModeChange: (mode) => {
             if (typeof getPos === "function") {
               const pos = getPos() as number;
-              const newIso = mode === "live" ? todayIso() : node.attrs.isoDate;
               editor.chain().focus().command(({ tr }) => {
-                tr.setNodeMarkup(pos, undefined, { ...node.attrs, mode, isoDate: newIso });
+                tr.setNodeMarkup(pos, undefined, { ...node.attrs, mode });
+                return true;
+              }).run();
+            }
+          },
+          onCustomIsoChange: (customIso) => {
+            if (typeof getPos === "function") {
+              const pos = getPos() as number;
+              editor.chain().focus().command(({ tr }) => {
+                tr.setNodeMarkup(pos, undefined, { ...node.attrs, mode: "custom", customIso });
                 return true;
               }).run();
             }
@@ -391,7 +571,6 @@ export const InlineTimestamp = Node.create({
         dom,
         update(updatedNode) {
           if (updatedNode.type.name !== "inlineTimestamp") return false;
-          // Keep node ref in sync for click handler closure
           (node as any) = updatedNode;
           render();
           return true;

--- a/lib/domain/editor/extensions/inline-timestamp.ts
+++ b/lib/domain/editor/extensions/inline-timestamp.ts
@@ -101,37 +101,48 @@ function createTimestampPopover(opts: {
   const modeRow = document.createElement("div");
   modeRow.style.cssText = "display: flex; gap: 6px;";
 
-  const MODES: { key: TimestampMode; label: string; title: string }[] = [
-    { key: "frozen",        label: "🔒 Frozen",    title: "Date is set at insertion and never changes" },
-    { key: "document-date", label: "📄 Doc date",  title: "Resolves to the document's creation date — useful in templates" },
-    { key: "live",          label: "🔄 Live",      title: "Always shows today's date" },
+  // Inline SVG icons — matches the project's server-component icon pattern
+  const LOCK_SVG = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>`;
+  const DOC_SVG  = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>`;
+  const LIVE_SVG = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`;
+
+  const MODES: { key: TimestampMode; label: string; icon: string; title: string }[] = [
+    { key: "frozen",        label: "Frozen",   icon: LOCK_SVG, title: "Date is set at insertion and never changes" },
+    { key: "document-date", label: "Doc date", icon: DOC_SVG,  title: "Resolves to the document's creation date — useful in templates" },
+    { key: "live",          label: "Live",     icon: LIVE_SVG, title: "Always shows today's date" },
   ];
 
-  MODES.forEach(({ key, label, title }) => {
+  MODES.forEach(({ key, label, icon, title }) => {
     const btn = document.createElement("button");
     btn.type = "button";
-    btn.textContent = label;
     btn.title = title;
+    btn.innerHTML = `${icon}<span style="margin-left:4px">${label}</span>`;
+    const isActive = currentMode === key;
     btn.style.cssText = `
       flex: 1;
-      padding: 4px 6px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 5px 8px;
       border-radius: 6px;
-      border: 1px solid ${currentMode === key ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.1)"};
-      background: ${currentMode === key ? "rgba(201,168,108,0.12)" : "transparent"};
-      color: ${currentMode === key ? "var(--gold-primary, #c9a86c)" : "inherit"};
+      border: 1px solid ${isActive ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.08)"};
+      background: ${isActive ? "rgba(201,168,108,0.12)" : "rgba(0,0,0,0.02)"};
+      color: ${isActive ? "var(--gold-primary, #c9a86c)" : "var(--muted-foreground, #888)"};
       font-size: 12px;
+      font-weight: ${isActive ? "600" : "400"};
       cursor: pointer;
       transition: all 0.1s;
       white-space: nowrap;
+      gap: 4px;
     `;
     btn.addEventListener("click", () => {
       onModeChange(key);
-      // Update active state visually
       modeRow.querySelectorAll("button").forEach((b, i) => {
         const active = MODES[i].key === key;
-        (b as HTMLButtonElement).style.border = `1px solid ${active ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.1)"}`;
-        (b as HTMLButtonElement).style.background = active ? "rgba(201,168,108,0.12)" : "transparent";
-        (b as HTMLButtonElement).style.color = active ? "var(--gold-primary, #c9a86c)" : "inherit";
+        (b as HTMLButtonElement).style.border = `1px solid ${active ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.08)"}`;
+        (b as HTMLButtonElement).style.background = active ? "rgba(201,168,108,0.12)" : "rgba(0,0,0,0.02)";
+        (b as HTMLButtonElement).style.color = active ? "var(--gold-primary, #c9a86c)" : "var(--muted-foreground, #888)";
+        (b as HTMLButtonElement).style.fontWeight = active ? "600" : "400";
       });
     });
     modeRow.appendChild(btn);
@@ -151,33 +162,78 @@ function createTimestampPopover(opts: {
     const btn = document.createElement("button");
     btn.type = "button";
     btn.textContent = formatTimestampDate(sampleDate, preset);
+    const isActive = currentFormat === preset;
     btn.style.cssText = `
-      padding: 5px 8px;
+      padding: 6px 10px;
       border-radius: 6px;
-      border: 1px solid ${currentFormat === preset ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.1)"};
-      background: ${currentFormat === preset ? "rgba(201,168,108,0.12)" : "transparent"};
-      color: ${currentFormat === preset ? "var(--gold-primary, #c9a86c)" : "inherit"};
+      border: 1px solid ${isActive ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.08)"};
+      background: ${isActive ? "rgba(201,168,108,0.12)" : "rgba(0,0,0,0.02)"};
+      color: ${isActive ? "var(--gold-primary, #c9a86c)" : "var(--foreground, #1a1a1a)"};
       font-size: 12px;
+      font-weight: ${isActive ? "600" : "400"};
       cursor: pointer;
       transition: all 0.1s;
       text-align: left;
+      letter-spacing: -0.01em;
     `;
+    btn.addEventListener("mouseenter", () => {
+      if (preset !== currentFormat) btn.style.background = "rgba(0,0,0,0.05)";
+    });
+    btn.addEventListener("mouseleave", () => {
+      if (preset !== currentFormat) btn.style.background = "rgba(0,0,0,0.02)";
+    });
     btn.addEventListener("click", () => {
       onFormatChange(preset);
       formatGrid.querySelectorAll("button").forEach((b, i) => {
         const active = FORMAT_PRESETS[i] === preset;
-        (b as HTMLButtonElement).style.border = `1px solid ${active ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.1)"}`;
-        (b as HTMLButtonElement).style.background = active ? "rgba(201,168,108,0.12)" : "transparent";
-        (b as HTMLButtonElement).style.color = active ? "var(--gold-primary, #c9a86c)" : "inherit";
+        (b as HTMLButtonElement).style.border = `1px solid ${active ? "var(--gold-primary, #c9a86c)" : "rgba(0,0,0,0.08)"}`;
+        (b as HTMLButtonElement).style.background = active ? "rgba(201,168,108,0.12)" : "rgba(0,0,0,0.02)";
+        (b as HTMLButtonElement).style.color = active ? "var(--gold-primary, #c9a86c)" : "var(--foreground, #1a1a1a)";
+        (b as HTMLButtonElement).style.fontWeight = active ? "600" : "400";
       });
     });
     formatGrid.appendChild(btn);
+  });
+
+  // ── Divider + Copy date utility ──
+  const divider = document.createElement("div");
+  divider.style.cssText = "height: 1px; background: rgba(0,0,0,0.06); margin: 2px 0;";
+
+  const COPY_SVG = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
+  const copyBtn = document.createElement("button");
+  copyBtn.type = "button";
+  copyBtn.innerHTML = `${COPY_SVG}<span style="margin-left:6px">Copy date text</span>`;
+  copyBtn.style.cssText = `
+    display: inline-flex;
+    align-items: center;
+    width: 100%;
+    padding: 5px 8px;
+    border-radius: 6px;
+    border: none;
+    background: transparent;
+    color: var(--muted-foreground, #888);
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 0.1s;
+    text-align: left;
+  `;
+  copyBtn.addEventListener("mouseenter", () => { copyBtn.style.background = "rgba(0,0,0,0.04)"; });
+  copyBtn.addEventListener("mouseleave", () => { copyBtn.style.background = "transparent"; });
+  copyBtn.addEventListener("click", () => {
+    const text = formatTimestampDate(sampleDate, currentFormat);
+    navigator.clipboard.writeText(text).catch(() => {});
+    copyBtn.innerHTML = `${COPY_SVG}<span style="margin-left:6px">Copied!</span>`;
+    setTimeout(() => {
+      copyBtn.innerHTML = `${COPY_SVG}<span style="margin-left:6px">Copy date text</span>`;
+    }, 1500);
   });
 
   portal.appendChild(modeLabel);
   portal.appendChild(modeRow);
   portal.appendChild(formatLabel);
   portal.appendChild(formatGrid);
+  portal.appendChild(divider);
+  portal.appendChild(copyBtn);
   document.body.appendChild(portal);
 
   // ── Position: below anchor, flip up if needed ──

--- a/state/navigation-history-store.ts
+++ b/state/navigation-history-store.ts
@@ -15,6 +15,8 @@ const CURRENT_VERSION = 3;
 export interface NavigationHistoryItem {
   contentId: string | null;
   timestamp: number;
+  title?: string;
+  contentType?: string;
 }
 
 export interface PaneHistoryState {
@@ -24,7 +26,7 @@ export interface PaneHistoryState {
 
 interface NavigationHistoryStore {
   byPaneId: Record<string, PaneHistoryState>;
-  addToHistory: (contentId: string | null, paneId?: string | null) => void;
+  addToHistory: (contentId: string | null, paneId?: string | null, meta?: { title?: string; contentType?: string }) => void;
   goBack: (paneId?: string | null) => string | null;
   goForward: (paneId?: string | null) => string | null;
   getPaneHistory: (paneId?: string | null) => PaneHistoryState;
@@ -77,7 +79,7 @@ export const useNavigationHistoryStore = create<NavigationHistoryStore>()(
     (set, get) => ({
       byPaneId: {},
 
-      addToHistory: (contentId, paneId) => {
+      addToHistory: (contentId, paneId, meta) => {
         if (!contentId) {
           return;
         }
@@ -99,6 +101,8 @@ export const useNavigationHistoryStore = create<NavigationHistoryStore>()(
             updatedHistory[paneState.currentIndex] = {
               contentId,
               timestamp: Date.now(),
+              title: meta?.title ?? paneState.history[paneState.currentIndex]?.title,
+              contentType: meta?.contentType ?? paneState.history[paneState.currentIndex]?.contentType,
             };
 
             return {
@@ -117,7 +121,7 @@ export const useNavigationHistoryStore = create<NavigationHistoryStore>()(
           );
           const nextHistory = [
             ...deduplicated,
-            { contentId, timestamp: Date.now() },
+            { contentId, timestamp: Date.now(), title: meta?.title, contentType: meta?.contentType },
           ];
           const limitedHistory =
             nextHistory.length > MAX_HISTORY_ITEMS

--- a/state/timestamp-format-store.ts
+++ b/state/timestamp-format-store.ts
@@ -1,0 +1,42 @@
+/**
+ * Timestamp Format Store
+ *
+ * Persists the user's default format preference for new inline timestamps.
+ * Individual timestamp nodes carry their own format attr — this store only
+ * determines what format is pre-selected when the slash command fires.
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const FORMAT_PRESETS = [
+  "MMMM D, YYYY",
+  "MMM D, YYYY",
+  "D MMMM YYYY",
+  "MM/DD/YYYY",
+  "DD/MM/YYYY",
+  "YYYY-MM-DD",
+] as const;
+
+export type TimestampFormat = (typeof FORMAT_PRESETS)[number];
+
+export type TimestampMode = "frozen" | "document-date" | "live";
+
+interface TimestampFormatState {
+  defaultFormat: TimestampFormat;
+  defaultMode: TimestampMode;
+  setDefaultFormat: (format: TimestampFormat) => void;
+  setDefaultMode: (mode: TimestampMode) => void;
+}
+
+export const useTimestampFormatStore = create<TimestampFormatState>()(
+  persist(
+    (set) => ({
+      defaultFormat: "MMMM D, YYYY",
+      defaultMode: "frozen",
+      setDefaultFormat: (defaultFormat) => set({ defaultFormat }),
+      setDefaultMode: (defaultMode) => set({ defaultMode }),
+    }),
+    { name: "timestamp-format", version: 1 }
+  )
+);

--- a/state/timestamp-format-store.ts
+++ b/state/timestamp-format-store.ts
@@ -20,7 +20,7 @@ export const FORMAT_PRESETS = [
 
 export type TimestampFormat = (typeof FORMAT_PRESETS)[number];
 
-export type TimestampMode = "frozen" | "document-date" | "live";
+export type TimestampMode = "frozen" | "document-date" | "content-updated" | "custom" | "live";
 
 interface TimestampFormatState {
   defaultFormat: TimestampFormat;


### PR DESCRIPTION
## Summary

- **Navigation history**: Titles now stored in each history entry at navigation time — dropdown shows real file names instantly with no API round-trip. Also fixes an infinite render loop caused by an object-returning Zustand selector
- **ExpandableEditor scroll**: Attached notes panel now scrolls independently (max 35vh, overflow-y-auto); main content area scrolls separately
- **Inline timestamp modes**: Added "Created" (doc creation date), "Updated" (last saved), and "Custom" (date + optional time picker) modes; copy-date now copies the resolved date for the active mode
- **People context menu icons**: Added icons to Add Contact, Add Subgroup, Edit Contact, Rename, Delete
- **File upload dialog**: Wires the `FileUploadDialog` for file-type creation in the sidebar instead of showing a "not implemented" error

## Test plan
- [x] Hold back button — history dropdown shows real file names, correct icons
- [x] Navigate between 5+ files and verify all titles appear correctly in history
- [x] Open a file with a long attached note — note area should scroll within ~35vh cap
- [x] Open a folder/Excalidraw/PDF with an attached note — both areas scroll independently
- [x] Insert inline timestamp, click it — verify Created/Updated/Custom/Live modes all work; Custom shows date + time picker; Copy date copies the resolved text
- [x] Right-click in People panel — all menu items should have icons
- [x] Click "Add File" in sidebar file tree — upload dialog should open

🤖 Generated with [Claude Code](https://claude.com/claude-code)