### PR TITLE
AI Chat polish: token capture, gateway image-gen, hydration races, settings UX

### DIFF
--- a/app/(authenticated)/content/loading.tsx
+++ b/app/(authenticated)/content/loading.tsx
@@ -24,7 +24,7 @@ export default function NotesLoading() {
       <div className="flex flex-1 overflow-hidden">
         {/* Left Sidebar */}
         <div
-          className="flex h-full flex-col overflow-hidden border-r border-white/10"
+          className="flex h-full flex-col overflow-hidden border-r border-border"
           style={{
             width: `${leftWidth}px`,
             minWidth: `${leftWidth}px`,
@@ -33,11 +33,11 @@ export default function NotesLoading() {
           }}
         >
           {/* Header */}
-          <div className="flex h-12 shrink-0 items-center justify-between border-b border-white/10 px-4">
+          <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
             <div className="flex items-center gap-2">
               {/* Folder icon */}
               <svg
-                className="h-4 w-4 text-gray-400"
+                className="h-4 w-4 text-muted-foreground"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -91,45 +91,17 @@ export default function NotesLoading() {
 
         {/* Main Content */}
         <div className="flex h-full flex-1 flex-col overflow-hidden">
-          {/* Tab bar */}
+          {/* Tab bar — neutral skeleton (no fake filename to avoid title flicker on hydrate) */}
           <div
-            className="flex shrink-0 items-center border-b border-white/10"
+            className="flex h-9 shrink-0 items-center border-b border-border"
             style={{
               background: glass1.background,
               backdropFilter: glass1.backdropFilter,
             }}
           >
-            <div className="flex items-center gap-1 border-r border-white/10 px-3 py-2 text-sm">
-              {/* FileText icon */}
-              <svg
-                className="h-4 w-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                />
-              </svg>
-              <span>Welcome.md</span>
-              <button className="ml-2 rounded p-0.5">
-                <svg
-                  className="h-3 w-3"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
+            <div className="flex items-center gap-2 border-r border-border px-3 py-2">
+              <div className="h-4 w-4 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-24 animate-pulse rounded bg-muted" />
             </div>
           </div>
 
@@ -139,7 +111,7 @@ export default function NotesLoading() {
 
         {/* Right Sidebar */}
         <div
-          className="flex h-full flex-col overflow-hidden border-l border-white/10"
+          className="flex h-full flex-col overflow-hidden border-l border-border"
           style={{
             width: `${rightWidth}px`,
             minWidth: `${rightWidth}px`,
@@ -148,7 +120,7 @@ export default function NotesLoading() {
           }}
         >
           {/* Header */}
-          <div className="flex h-12 shrink-0 items-center justify-between border-b border-white/10 px-4">
+          <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
             <div className="flex items-center gap-2">
               <button className="rounded p-1">
                 {/* List icon */}
@@ -223,13 +195,13 @@ export default function NotesLoading() {
 
       {/* Status bar */}
       <div
-        className="h-6 border-t border-white/10 px-4 py-1 text-xs"
+        className="h-6 border-t border-border px-4 py-1 text-xs"
         style={{
           background: glass0.background,
           backdropFilter: glass0.backdropFilter,
         }}
       >
-        <div className="flex items-center justify-between text-gray-400">
+        <div className="flex items-center justify-between text-muted-foreground">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-1">
               <svg
@@ -265,7 +237,7 @@ export default function NotesLoading() {
             </div>
           </div>
           <div className="flex items-center gap-4">
-            <div className="h-3 w-16 animate-pulse rounded bg-white/5" />
+            <div className="h-3 w-16 animate-pulse rounded bg-muted" />
             <div className="flex items-center gap-1">
               <svg
                 className="h-3 w-3"

--- a/app/(authenticated)/content/loading.tsx
+++ b/app/(authenticated)/content/loading.tsx
@@ -1,22 +1,26 @@
 /**
  * Notes Loading State
  *
- * Shows panel structure with skeletons while page loads.
- * Reads panel widths from localStorage to maintain layout consistency.
+ * Shows panel structure with skeletons while the route segment renders.
+ *
+ * Right-panel intentionally omitted: its default persisted state is
+ * `isCollapsed: true` (see state/right-panel-collapse-store.ts), so
+ * painting a fake 300px right sidebar here would visibly collapse
+ * on hydration. The main panel claims that space; if the user has the
+ * right panel expanded, it slides in once on hydration — a single
+ * one-directional appearance, not a double layout swap.
  */
 
 import { getSurfaceStyles } from "@/lib/design/system";
 import { FileTreeSkeleton } from "@/components/content/skeletons/FileTreeSkeleton";
-import { OutlineSkeleton } from "@/components/content/skeletons/OutlineSkeleton";
 import { EditorSkeleton } from "@/components/content/skeletons/EditorSkeleton";
 
 export default function NotesLoading() {
   const glass0 = getSurfaceStyles("glass-0");
   const glass1 = getSurfaceStyles("glass-1");
 
-  // Default widths (will be overridden by client-side hydration)
+  // Default left width — matches left-panel-collapse-store's "full" default.
   const leftWidth = 200;
-  const rightWidth = 300;
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
@@ -109,88 +113,7 @@ export default function NotesLoading() {
           <EditorSkeleton />
         </div>
 
-        {/* Right Sidebar */}
-        <div
-          className="flex h-full flex-col overflow-hidden border-l border-border"
-          style={{
-            width: `${rightWidth}px`,
-            minWidth: `${rightWidth}px`,
-            background: glass0.background,
-            backdropFilter: glass0.backdropFilter,
-          }}
-        >
-          {/* Header */}
-          <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
-            <div className="flex items-center gap-2">
-              <button className="rounded p-1">
-                {/* List icon */}
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4 6h16M4 12h16M4 18h16"
-                  />
-                </svg>
-              </button>
-              <button className="rounded p-1">
-                {/* Link icon */}
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-                  />
-                </svg>
-              </button>
-              <button className="rounded p-1">
-                {/* MessageSquare icon */}
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
-                  />
-                </svg>
-              </button>
-            </div>
-            <button className="rounded p-1">
-              <svg
-                className="h-4 w-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"
-                />
-              </svg>
-            </button>
-          </div>
-
-          {/* Skeleton */}
-          <OutlineSkeleton />
-        </div>
+        {/* Right sidebar intentionally omitted — see file-level comment. */}
       </div>
 
       {/* Status bar */}

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -517,6 +517,7 @@ When you generate an image, the user can insert it into the document at their cu
             // TEMP DIAGNOSTIC (A1-DEBUG): plain console so attrs print
             // unambiguously to stdout regardless of the structured
             // logger's formatting. Remove once Phase 2 verified.
+            // eslint-disable-next-line no-console -- TODO(A1-debug): remove with diagnostic
             console.log("[A1-DEBUG-SERVER] finish part", {
               has_total_usage: part.totalUsage != null,
               input_tokens: part.totalUsage?.inputTokens ?? null,
@@ -533,6 +534,7 @@ When you generate an image, the user can insert it into the document at their cu
               },
               finishReason: part.finishReason,
             };
+            // eslint-disable-next-line no-console -- TODO(A1-debug): remove with diagnostic
             console.log("[A1-DEBUG-SERVER] returning messageMetadata", out);
             return out;
           }

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -514,19 +514,7 @@ When you generate an image, the user can insert it into the document at their cu
         sendReasoning: true,
         messageMetadata: ({ part }) => {
           if (part.type === "finish") {
-            // TEMP DIAGNOSTIC (A1-DEBUG): plain console so attrs print
-            // unambiguously to stdout regardless of the structured
-            // logger's formatting. Remove once Phase 2 verified.
-            // eslint-disable-next-line no-console -- TODO(A1-debug): remove with diagnostic
-            console.log("[A1-DEBUG-SERVER] finish part", {
-              has_total_usage: part.totalUsage != null,
-              input_tokens: part.totalUsage?.inputTokens ?? null,
-              output_tokens: part.totalUsage?.outputTokens ?? null,
-              total_tokens: part.totalUsage?.totalTokens ?? null,
-              finish_reason: part.finishReason,
-              raw_totalUsage: part.totalUsage,
-            });
-            const out = {
+            return {
               usage: {
                 inputTokens: part.totalUsage?.inputTokens,
                 outputTokens: part.totalUsage?.outputTokens,
@@ -534,9 +522,6 @@ When you generate an image, the user can insert it into the document at their cu
               },
               finishReason: part.finishReason,
             };
-            // eslint-disable-next-line no-console -- TODO(A1-debug): remove with diagnostic
-            console.log("[A1-DEBUG-SERVER] returning messageMetadata", out);
-            return out;
           }
           return undefined;
         },

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -504,7 +504,28 @@ When you generate an image, the user can insert it into the document at their cu
       // AI SDK v6 strips them — Anthropic extended thinking, OpenAI
       // o-series, and Google thinking-* models all emit reasoning that
       // we want the ReasoningRouter to render. Session 6.
-      return result.toUIMessageStreamResponse({ sendReasoning: true });
+      //
+      // Also forward token usage + finish reason via `messageMetadata`,
+      // which AI SDK v6 surfaces on `UIMessage.metadata` on the client.
+      // The client's persist-on-finish path forwards it to the message
+      // row, which the per-Connection usage meters read back for $
+      // figures. Without this hop, telemetry is request-counts-only.
+      return result.toUIMessageStreamResponse({
+        sendReasoning: true,
+        messageMetadata: ({ part }) => {
+          if (part.type === "finish") {
+            return {
+              usage: {
+                inputTokens: part.totalUsage.inputTokens,
+                outputTokens: part.totalUsage.outputTokens,
+                totalTokens: part.totalUsage.totalTokens,
+              },
+              finishReason: part.finishReason,
+            };
+          }
+          return undefined;
+        },
+      });
     } catch (error) {
       if (
         error instanceof Error &&

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -514,22 +514,18 @@ When you generate an image, the user can insert it into the document at their cu
         sendReasoning: true,
         messageMetadata: ({ part }) => {
           if (part.type === "finish") {
-            // TEMP DIAGNOSTIC (A1-DEBUG): log totalUsage shape per turn
-            // so we can see whether the gateway-routed path is actually
-            // returning usage. Remove once Phase 2 is verified working.
-            logger.info({
-              layer: "ai",
-              event: "chat.message_metadata",
-              summary: `[A1-DEBUG] finish part usage`,
-              attrs: {
-                input_tokens: part.totalUsage?.inputTokens ?? null,
-                output_tokens: part.totalUsage?.outputTokens ?? null,
-                total_tokens: part.totalUsage?.totalTokens ?? null,
-                finish_reason: part.finishReason,
-                has_total_usage: part.totalUsage != null,
-              },
+            // TEMP DIAGNOSTIC (A1-DEBUG): plain console so attrs print
+            // unambiguously to stdout regardless of the structured
+            // logger's formatting. Remove once Phase 2 verified.
+            console.log("[A1-DEBUG-SERVER] finish part", {
+              has_total_usage: part.totalUsage != null,
+              input_tokens: part.totalUsage?.inputTokens ?? null,
+              output_tokens: part.totalUsage?.outputTokens ?? null,
+              total_tokens: part.totalUsage?.totalTokens ?? null,
+              finish_reason: part.finishReason,
+              raw_totalUsage: part.totalUsage,
             });
-            return {
+            const out = {
               usage: {
                 inputTokens: part.totalUsage?.inputTokens,
                 outputTokens: part.totalUsage?.outputTokens,
@@ -537,6 +533,8 @@ When you generate an image, the user can insert it into the document at their cu
               },
               finishReason: part.finishReason,
             };
+            console.log("[A1-DEBUG-SERVER] returning messageMetadata", out);
+            return out;
           }
           return undefined;
         },

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -514,11 +514,26 @@ When you generate an image, the user can insert it into the document at their cu
         sendReasoning: true,
         messageMetadata: ({ part }) => {
           if (part.type === "finish") {
+            // TEMP DIAGNOSTIC (A1-DEBUG): log totalUsage shape per turn
+            // so we can see whether the gateway-routed path is actually
+            // returning usage. Remove once Phase 2 is verified working.
+            logger.info({
+              layer: "ai",
+              event: "chat.message_metadata",
+              summary: `[A1-DEBUG] finish part usage`,
+              attrs: {
+                input_tokens: part.totalUsage?.inputTokens ?? null,
+                output_tokens: part.totalUsage?.outputTokens ?? null,
+                total_tokens: part.totalUsage?.totalTokens ?? null,
+                finish_reason: part.finishReason,
+                has_total_usage: part.totalUsage != null,
+              },
+            });
             return {
               usage: {
-                inputTokens: part.totalUsage.inputTokens,
-                outputTokens: part.totalUsage.outputTokens,
-                totalTokens: part.totalUsage.totalTokens,
+                inputTokens: part.totalUsage?.inputTokens,
+                outputTokens: part.totalUsage?.outputTokens,
+                totalTokens: part.totalUsage?.totalTokens,
               },
               finishReason: part.finishReason,
             };

--- a/app/api/ai/image/route.ts
+++ b/app/api/ai/image/route.ts
@@ -14,6 +14,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/infrastructure/auth/middleware";
 import { generateImage } from "@/lib/domain/ai/image/generate";
+import { generateImageViaGateway } from "@/lib/domain/ai/image/generate-via-gateway";
 import { getUserStorageProvider } from "@/lib/infrastructure/storage";
 import { generateUniqueSlug } from "@/lib/domain/content";
 import {
@@ -95,20 +96,31 @@ export async function POST(request: NextRequest) {
           },
         },
         async (span) => {
-          const generated = await generateImage(
-            {
-              prompt,
-              providerId,
-              modelId,
-              size,
-              quality,
-              style,
-              apiKey: routing?.apiKey,
-              apiBaseURL: routing?.baseURL,
-              upstreamModelId: routing?.upstreamModelId,
-            },
-            session.user.id
-          );
+          // Gateway path: AI SDK knows the gateway's curated catalog
+          // + per-model response shapes. Direct path: our raw-fetch
+          // dispatchers per provider.
+          const generated =
+            routing?.routeKind === "gateway"
+              ? await generateImageViaGateway({
+                  prompt,
+                  modelId: routing.upstreamModelId ?? `${providerId}/${modelId}`,
+                  apiKey: routing.apiKey,
+                  size,
+                  providerId,
+                  canonicalModelId: modelId,
+                })
+              : await generateImage(
+                  {
+                    prompt,
+                    providerId,
+                    modelId,
+                    size,
+                    quality,
+                    style,
+                    apiKey: routing?.apiKey,
+                  },
+                  session.user.id,
+                );
           span
             .attr("mime", generated.mimeType)
             .attr("width", generated.width ?? 0)

--- a/app/api/ai/image/route.ts
+++ b/app/api/ai/image/route.ts
@@ -67,14 +67,18 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // ─── Resolve BYOK key via Connection ─────────────────────
+      // ─── Resolve BYOK key + routing via Connection ───────────
       // Match the requested image-gen provider against the user's
-      // Connections by presetId. First direct match wins. If no
-      // Connection covers this provider, generateImage falls through to
-      // the env-var fallback.
-      const apiKey = await resolveImageProviderKey(
+      // Connections. Tries direct match by presetId first; falls back
+      // to namespaced-model match in any Connection (catches the
+      // gateway case where the user has `openai/dall-e-3` in a Vercel
+      // Gateway Connection rather than a direct OpenAI Connection).
+      // Returns the api key plus optional base URL + upstream model id
+      // when routing through a gateway.
+      const routing = await resolveImageProviderRouting(
         session.user.id,
         providerId,
+        modelId,
       );
 
       // ─── Generate Image ──────────────────────────────────────
@@ -83,10 +87,26 @@ export async function POST(request: NextRequest) {
       // the request appears in spans.
       const result = await withSpan(
         { layer: "ai", name: "generate_image" },
-        { attrs: { provider: providerId, model: modelId, byok: apiKey ? "connection" : "env" } },
+        {
+          attrs: {
+            provider: providerId,
+            model: modelId,
+            byok: routing ? (routing.routeKind === "gateway" ? "connection-gateway" : "connection-direct") : "env",
+          },
+        },
         async (span) => {
           const generated = await generateImage(
-            { prompt, providerId, modelId, size, quality, style, apiKey },
+            {
+              prompt,
+              providerId,
+              modelId,
+              size,
+              quality,
+              style,
+              apiKey: routing?.apiKey,
+              apiBaseURL: routing?.baseURL,
+              upstreamModelId: routing?.upstreamModelId,
+            },
             session.user.id
           );
           span
@@ -241,22 +261,71 @@ export async function POST(request: NextRequest) {
 }
 
 /**
- * Resolve a BYOK key for an image-gen provider from the user's
- * Connections. We match by `presetId` only (image generation has no
- * gateway routing concept like chat does) and skip Connections without
- * a usable preset. Returns `undefined` so callers fall through to the
- * env-var resolver in `generateImage`.
+ * Routing info resolved for an image-gen request: api key + optional
+ * gateway base URL + the model id to send upstream.
+ *
+ * Two paths:
+ *   - **direct**: Connection.presetId matches the requested
+ *     `providerId`. Use the Connection's key, hit the provider's
+ *     canonical endpoint, send `modelId` as-is.
+ *   - **gateway**: a gateway Connection has the namespaced
+ *     `${providerId}/${modelId}` in its models[]. Use the
+ *     Connection's key + gateway base URL, send the namespaced id
+ *     in the upstream request body.
  */
-async function resolveImageProviderKey(
+interface ImageProviderRouting {
+  routeKind: "direct" | "gateway";
+  apiKey: string;
+  baseURL?: string;
+  upstreamModelId?: string;
+}
+
+/**
+ * Per-adapter gateway base URLs for image generation. The endpoint is
+ * OpenAI-compatible (`POST /v1/images/generations`) for the gateways
+ * listed here.
+ */
+const GATEWAY_BASE_URL_BY_ADAPTER: Record<string, string> = {
+  "vercel-gateway": "https://ai-gateway.vercel.sh/v1",
+};
+
+async function resolveImageProviderRouting(
   userId: string,
   providerId: ImageProviderId,
-): Promise<string | undefined> {
+  modelId: string,
+): Promise<ImageProviderRouting | undefined> {
   try {
     const all = await listConnections(userId);
-    const match = all.find((c) => c.presetId === providerId);
-    if (!match) return undefined;
-    const withKey = await getConnectionWithKey(userId, match.id);
-    return withKey.apiKey;
+
+    // Path 1: direct provider match.
+    const direct = all.find((c) => c.presetId === providerId);
+    if (direct) {
+      const withKey = await getConnectionWithKey(userId, direct.id);
+      return { routeKind: "direct", apiKey: withKey.apiKey };
+    }
+
+    // Path 2: gateway with a namespaced model that matches the
+    // requested provider/model.
+    const namespaced = `${providerId}/${modelId}`;
+    const gateway = all.find((c) => {
+      if (!c.adapterKind || !GATEWAY_BASE_URL_BY_ADAPTER[c.adapterKind]) {
+        return false;
+      }
+      return c.models.some((m) => m.id === namespaced);
+    });
+    if (gateway) {
+      const withKey = await getConnectionWithKey(userId, gateway.id);
+      return {
+        routeKind: "gateway",
+        apiKey: withKey.apiKey,
+        baseURL:
+          gateway.baseURL ??
+          GATEWAY_BASE_URL_BY_ADAPTER[gateway.adapterKind],
+        upstreamModelId: namespaced,
+      };
+    }
+
+    return undefined;
   } catch (err) {
     logger.warn({
       layer: "ai",

--- a/app/api/conversations/[id]/messages/route.ts
+++ b/app/api/conversations/[id]/messages/route.ts
@@ -95,22 +95,17 @@ export async function POST(request: NextRequest, context: RouteContext) {
           typeof body.parentId === "string" ? body.parentId : null,
       };
 
-      // TEMP DIAGNOSTIC (A1-DEBUG): log what the client sent so we can
-      // verify the chain. Remove once token capture is confirmed.
+      // TEMP DIAGNOSTIC (A1-DEBUG): plain console so attrs print
+      // unambiguously to stdout. Remove once Phase 2 verified.
       const dbgUsage = (input.metadata as { usage?: Record<string, unknown> } | null)?.usage;
-      logger.info({
-        layer: "ai",
-        event: "conversation.message.append",
-        summary: `[A1-DEBUG] persist ${input.role}`,
-        attrs: {
-          role: input.role,
-          provider: input.providerId ?? null,
-          model: input.modelId ?? null,
-          has_metadata: input.metadata != null,
-          has_usage: dbgUsage != null,
-          input_tokens: (dbgUsage as { inputTokens?: number } | undefined)?.inputTokens ?? null,
-          output_tokens: (dbgUsage as { outputTokens?: number } | undefined)?.outputTokens ?? null,
-        },
+      console.log("[A1-DEBUG-PERSIST]", input.role, {
+        provider: input.providerId ?? null,
+        model: input.modelId ?? null,
+        has_metadata: input.metadata != null,
+        has_usage: dbgUsage != null,
+        input_tokens: (dbgUsage as { inputTokens?: number } | undefined)?.inputTokens ?? null,
+        output_tokens: (dbgUsage as { outputTokens?: number } | undefined)?.outputTokens ?? null,
+        raw_metadata: input.metadata,
       });
 
       const message = await appendMessage(

--- a/app/api/conversations/[id]/messages/route.ts
+++ b/app/api/conversations/[id]/messages/route.ts
@@ -95,18 +95,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
           typeof body.parentId === "string" ? body.parentId : null,
       };
 
-      // TEMP DIAGNOSTIC (A1-DEBUG): plain console so attrs print
-      // unambiguously to stdout. Remove once Phase 2 verified.
-      const dbgUsage = (input.metadata as { usage?: Record<string, unknown> } | null)?.usage;
-      console.log("[A1-DEBUG-PERSIST]", input.role, {
-        provider: input.providerId ?? null,
-        model: input.modelId ?? null,
-        has_metadata: input.metadata != null,
-        has_usage: dbgUsage != null,
-        input_tokens: (dbgUsage as { inputTokens?: number } | undefined)?.inputTokens ?? null,
-        output_tokens: (dbgUsage as { outputTokens?: number } | undefined)?.outputTokens ?? null,
-        raw_metadata: input.metadata,
-      });
 
       const message = await appendMessage(
         session.user.id,

--- a/app/api/conversations/[id]/messages/route.ts
+++ b/app/api/conversations/[id]/messages/route.ts
@@ -95,6 +95,24 @@ export async function POST(request: NextRequest, context: RouteContext) {
           typeof body.parentId === "string" ? body.parentId : null,
       };
 
+      // TEMP DIAGNOSTIC (A1-DEBUG): log what the client sent so we can
+      // verify the chain. Remove once token capture is confirmed.
+      const dbgUsage = (input.metadata as { usage?: Record<string, unknown> } | null)?.usage;
+      logger.info({
+        layer: "ai",
+        event: "conversation.message.append",
+        summary: `[A1-DEBUG] persist ${input.role}`,
+        attrs: {
+          role: input.role,
+          provider: input.providerId ?? null,
+          model: input.modelId ?? null,
+          has_metadata: input.metadata != null,
+          has_usage: dbgUsage != null,
+          input_tokens: (dbgUsage as { inputTokens?: number } | undefined)?.inputTokens ?? null,
+          output_tokens: (dbgUsage as { outputTokens?: number } | undefined)?.outputTokens ?? null,
+        },
+      });
+
       const message = await appendMessage(
         session.user.id,
         conversationId,

--- a/components/content/NotesLayoutMarker.tsx
+++ b/components/content/NotesLayoutMarker.tsx
@@ -1,6 +1,13 @@
 "use client";
 
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+/** sessionStorage key for the last non-settings route the user visited.
+ * Read by the Settings sidebar's back button so "Back" returns to where
+ * the user actually came from, instead of stepping through internal
+ * settings navigation history. */
+export const LAST_CONTENT_ROUTE_KEY = "dg:last-content-route";
 
 /**
  * NotesLayoutMarker - Marks the body element when in notes layout
@@ -8,8 +15,15 @@ import { useEffect } from "react";
  * This component adds a data attribute to the body tag to signal
  * that we're in the notes layout, which triggers CSS to hide the
  * default navbar and adjust padding.
+ *
+ * Also: tracks the last non-settings pathname in sessionStorage so the
+ * settings "Back" button can return the user to whatever content they
+ * were viewing (a note, the home page, etc.) regardless of how many
+ * settings sub-routes they navigated through.
  */
 export function NotesLayoutMarker() {
+  const pathname = usePathname();
+
   useEffect(() => {
     // Add data attribute to body when notes layout mounts
     document.body.setAttribute("data-notes-route", "true");
@@ -19,6 +33,20 @@ export function NotesLayoutMarker() {
       document.body.removeAttribute("data-notes-route");
     };
   }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !pathname) return;
+    // Only record routes outside the settings tree. The settings sidebar
+    // back button reads this to return to the previous content view
+    // rather than walking back through settings sub-pages.
+    if (pathname.startsWith("/settings")) return;
+    try {
+      window.sessionStorage.setItem(LAST_CONTENT_ROUTE_KEY, pathname);
+    } catch {
+      // sessionStorage can throw in private mode / quota — silent OK,
+      // we just fall back to `/` on next read.
+    }
+  }, [pathname]);
 
   return null; // This component doesn't render anything
 }

--- a/components/content/RightSidebar.tsx
+++ b/components/content/RightSidebar.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { RightSidebarHeader } from "./headers/RightSidebarHeader";
 import { RightSidebarContent } from "./content/RightSidebarContent";
 import { useContentStore } from "@/state/content-store";
@@ -22,6 +22,42 @@ import {
 } from "@/state/right-sidebar-state-store";
 import type { RightSidebarTab } from "@/state/right-sidebar-state-store";
 
+/**
+ * Track when the persisted right-sidebar state store has finished
+ * hydrating from localStorage. Effects that write to the store MUST
+ * gate on this — writes during the hydration window get overwritten by
+ * the persisted state's shallow merge AND corrupt localStorage by
+ * persisting the default-plus-write intermediate.
+ *
+ * Zustand exposes hasHydrated() on the store's persist API. We
+ * subscribe via onFinishHydration so React re-renders once it flips
+ * true.
+ */
+function useRightSidebarStoreHydrated(): boolean {
+  const [hydrated, setHydrated] = useState(() =>
+    useRightSidebarStateStore.persist?.hasHydrated() ?? false,
+  );
+  useEffect(() => {
+    const persistApi = useRightSidebarStateStore.persist;
+    if (!persistApi) return;
+    // Hydration may have completed between the useState lazy init
+    // (which sampled `hasHydrated()`) and this effect mounting — a
+    // narrow race we close by re-checking. The setState here is guarded
+    // by a single boolean transition (false → true) and is exactly
+    // the pattern Zustand's docs prescribe for "wait for hydration"
+    // surfaces, so the React Compiler "setState in effect" warning is
+    // a false positive here.
+    if (persistApi.hasHydrated()) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot hydration sync; see comment above
+      setHydrated(true);
+      return;
+    }
+    const unsub = persistApi.onFinishHydration(() => setHydrated(true));
+    return unsub;
+  }, []);
+  return hydrated;
+}
+
 export function RightSidebar() {
   const selectedContentId = useContentStore((state) => state.selectedContentId);
   const selectedContentType = useContentStore((state) => state.selectedContentType);
@@ -29,6 +65,8 @@ export function RightSidebar() {
   const activeView = useLeftPanelViewStore((state) => state.activeView);
   const prevBlockIdRef = useRef<string | null>(null);
   const extensionManifest = getExtensionManifestForView(activeView);
+
+  const storeHydrated = useRightSidebarStoreHydrated();
 
   const savedTab = useRightSidebarStateStore((state) =>
     selectedContentId
@@ -63,22 +101,56 @@ export function RightSidebar() {
     return resolveRightSidebarTab(savedTab, availableTabs);
   }, [availableTabs, extensionManifest, savedTab, selectedBlockId]);
 
+  // Auto-correct effect: if the resolver chose a tab different from
+  // the persisted savedTab, write the corrected value back. Gated on
+  // store hydration so we don't overwrite the user's saved tab with a
+  // fallback computed against an empty/transient availableTabs list.
+  // Additionally requires a non-null selectedContentType — the
+  // resolver's fallback choice isn't trustworthy without it.
   useEffect(() => {
+    if (!storeHydrated) return;
     if (activeTab === "extension") return;
-    if (!selectedContentId || savedTab === activeTab) return;
+    if (!selectedContentId || !selectedContentType || savedTab === activeTab) return;
     setActiveTab(selectedContentId, activeTab);
-  }, [activeTab, savedTab, selectedContentId, setActiveTab]);
+  }, [
+    storeHydrated,
+    activeTab,
+    savedTab,
+    selectedContentId,
+    selectedContentType,
+    setActiveTab,
+  ]);
 
-  // Auto-switch to properties tab when a block is selected
+  // Auto-switch to properties tab when a block is selected. Two
+  // guards to prevent stale block selections from clobbering the
+  // saved tab on initial mount:
+  //   1. storeHydrated — don't write before the persisted tab loads.
+  //   2. prevBlockIdRef is seeded with the initial selectedBlockId on
+  //      first run AFTER hydration, so we only treat *changes* as
+  //      user-initiated selections. A block that's selected at mount
+  //      time (from some legacy / cached path) won't trigger a write.
+  const hasSeededBlockRef = useRef(false);
   useEffect(() => {
+    if (!storeHydrated) return;
     if (!selectedContentId) return;
+
+    // First post-hydration run: just record the initial state without
+    // writing. Any selectedBlockId at this point came from a non-user
+    // path (editor mount, stale extension state, etc.) and should not
+    // be treated as a "user clicked a block" event.
+    if (!hasSeededBlockRef.current) {
+      prevBlockIdRef.current = selectedBlockId;
+      hasSeededBlockRef.current = true;
+      return;
+    }
+
     if (selectedBlockId && selectedBlockId !== prevBlockIdRef.current) {
       setActiveTab(selectedContentId, "properties");
     } else if (!selectedBlockId && prevBlockIdRef.current && savedTab === "properties") {
       setActiveTab(selectedContentId, "backlinks");
     }
     prevBlockIdRef.current = selectedBlockId;
-  }, [selectedBlockId, selectedContentId, savedTab, setActiveTab]);
+  }, [storeHydrated, selectedBlockId, selectedContentId, savedTab, setActiveTab]);
 
   const handleTabChange = (tab: RightSidebarTab) => {
     if (tab === "extension") return;

--- a/components/content/ai/AiImageGenDialog.tsx
+++ b/components/content/ai/AiImageGenDialog.tsx
@@ -1,5 +1,6 @@
 /**
- * AiImageGenDialog — modal launched from `+ AI → Image Generation`.
+ * AiImageGenDialog — modal launched from `+ AI → Image Generation`
+ * and from the editor's /ai-image slash command.
  *
  * Collects a prompt + provider/model + size, POSTs to `/api/ai/image`
  * with `role: "primary"` so the generated image lands as a first-class
@@ -7,23 +8,51 @@
  * the new node (the parent passes a callback). On failure: inline
  * error banner with the upstream's message.
  *
- * Provider/model source is `IMAGE_PROVIDER_CATALOG` — the image-gen
- * catalog distinct from chat. Connection-key resolution happens
- * server-side via the existing `resolveImageGenRoute` helper.
+ * Model list is the **union of** IMAGE_PROVIDER_CATALOG (well-known
+ * defaults: DALL·E 3, GPT Image 1, Imagen 3, FLUX, etc.) and any
+ * image-capable model the user has saved on a Connection (detected
+ * via the same capability inference the feature router uses). So
+ * gateway-only models like `openai/gpt-image-1` and Nano Banana
+ * (`google/gemini-2.5-flash-image`) surface in the picker alongside
+ * the catalog defaults.
+ *
+ * Connection-key resolution happens server-side via the route's
+ * `resolveImageProviderRouting` helper — the dialog doesn't pick a
+ * Connection, just sends (providerId, modelId).
  */
 
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Loader2, Sparkles, X, AlertCircle } from "lucide-react";
 import { IMAGE_PROVIDER_CATALOG } from "@/lib/domain/ai/image/catalog";
-import type {
-  ImageProviderId,
-  ImageModelId,
-  ImageSize,
-} from "@/lib/domain/ai/image/types";
+import type { ImageSize } from "@/lib/domain/ai/image/types";
+import { effectiveCapabilities } from "@/lib/domain/ai/features/capabilities";
 import { Button } from "@/components/ui/glass/button";
 import { getSurfaceStyles } from "@/lib/design/system";
+
+/** Provider id (catalog or user-added) shown in the dialog. */
+type ProviderId = string;
+/** Model id (catalog or user-added) shown in the dialog. */
+type ModelId = string;
+
+interface PickerProvider {
+  id: ProviderId;
+  name: string;
+  models: PickerModel[];
+}
+
+interface PickerModel {
+  id: ModelId;
+  /** Display name — falls back to id when user added without naming. */
+  name: string;
+  supportedSizes: ImageSize[];
+  defaultSize: ImageSize;
+  /** Where this model came from — purely informational for the UI. */
+  source: "catalog" | "connection";
+  /** Connection that surfaced this entry (for the Connection-source case). */
+  via?: string;
+}
 
 interface AiImageGenDialogProps {
   /** Folder to create the file under; null = root. */
@@ -49,31 +78,135 @@ export function AiImageGenDialog({
 }: AiImageGenDialogProps) {
   const glass0 = getSurfaceStyles("glass-0");
 
-  // Form state
-  const [providerId, setProviderId] = useState<ImageProviderId>("openai");
-  const [modelId, setModelId] = useState<ImageModelId>("dall-e-3");
+  // Form state — provider/model are plain strings now since the picker
+  // can include user-added models that aren't in the static ImageModelId
+  // union (e.g. Nano Banana, gpt-image-1.5, flux-2-max).
+  const [providerId, setProviderId] = useState<ProviderId>("openai");
+  const [modelId, setModelId] = useState<ModelId>("dall-e-3");
   const [prompt, setPrompt] = useState("");
   const [size, setSize] = useState<ImageSize>("1024x1024");
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Derive currently-available models from the selected provider.
-  const activeProvider = IMAGE_PROVIDER_CATALOG.find((p) => p.id === providerId);
-  const activeModel = activeProvider?.models.find((m) => m.id === modelId);
-
-  // When provider changes, snap modelId + size to that provider's first
-  // valid option. Avoids invalid combinations (e.g., DALL-E size on Imagen).
-  const handleProviderChange = useCallback((nextId: ImageProviderId) => {
-    const next = IMAGE_PROVIDER_CATALOG.find((p) => p.id === nextId);
-    if (!next || next.models.length === 0) return;
-    setProviderId(nextId);
-    setModelId(next.models[0].id);
-    setSize(next.models[0].defaultSize);
+  // User's Connections — loaded on mount so we can surface their
+  // image-capable models alongside the static catalog.
+  interface ConnSummary {
+    id: string;
+    label: string;
+    presetId: string | null;
+    adapterKind: string;
+    models: Array<{ id: string; name?: string; capabilities?: string[] }>;
+  }
+  const [connections, setConnections] = useState<ConnSummary[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/ai/connections", { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((body) => {
+        if (cancelled) return;
+        const items = (body?.data?.items ?? []) as ConnSummary[];
+        setConnections(items);
+      })
+      .catch(() => {
+        // Silent — fall back to catalog-only picker.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
+  // Unified provider/model list: catalog defaults + every image-capable
+  // model surfaced by any Connection. Dedup by id, with catalog metadata
+  // (supported sizes, etc.) winning when overlapping.
+  const allProviders = useMemo<PickerProvider[]>(() => {
+    // Step 1: seed from the catalog.
+    const byProvider = new Map<string, PickerProvider>();
+    for (const p of IMAGE_PROVIDER_CATALOG) {
+      byProvider.set(p.id, {
+        id: p.id,
+        name: p.name,
+        models: p.models.map((m) => ({
+          id: m.id,
+          name: m.name,
+          supportedSizes: m.supportedSizes,
+          defaultSize: m.defaultSize,
+          source: "catalog" as const,
+        })),
+      });
+    }
+
+    // Step 2: merge in Connection-surfaced image models. The picker
+    // shows everything image-capable the user owns even when our
+    // catalog doesn't know about it — Nano Banana, gpt-image-1.5,
+    // FLUX 2, etc.
+    for (const c of connections) {
+      for (const m of c.models) {
+        if (!effectiveCapabilities(m).has("image-generation")) continue;
+
+        // Decide which "provider" group this model goes under.
+        const slash = m.id.indexOf("/");
+        const provId =
+          slash > 0
+            ? m.id.slice(0, slash)
+            : c.presetId ?? c.adapterKind ?? "custom";
+        const modelDisplayId = slash > 0 ? m.id.slice(slash + 1) : m.id;
+        const provNameDefault =
+          IMAGE_PROVIDER_CATALOG.find((p) => p.id === provId)?.name ??
+          provId.charAt(0).toUpperCase() + provId.slice(1);
+
+        let group = byProvider.get(provId);
+        if (!group) {
+          group = { id: provId, name: provNameDefault, models: [] };
+          byProvider.set(provId, group);
+        }
+
+        // Skip if already in the group by display id (catalog wins).
+        if (group.models.some((existing) => existing.id === modelDisplayId)) {
+          continue;
+        }
+        group.models.push({
+          id: modelDisplayId,
+          name: m.name && m.name.length > 0 ? m.name : modelDisplayId,
+          // Connection-added models lack size metadata — default to a
+          // single common size. Most providers accept 1024x1024.
+          supportedSizes: ["1024x1024"],
+          defaultSize: "1024x1024",
+          source: "connection",
+          via: c.label,
+        });
+      }
+    }
+
+    return Array.from(byProvider.values())
+      .filter((p) => p.models.length > 0)
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [connections]);
+
+  // Currently-selected provider + model resolved against the unified
+  // list. Falls back to first available if state points at something
+  // that's gone (e.g. Connection deleted).
+  const activeProvider =
+    allProviders.find((p) => p.id === providerId) ?? allProviders[0];
+  const activeModel =
+    activeProvider?.models.find((m) => m.id === modelId) ??
+    activeProvider?.models[0];
+
+  // When provider changes, snap modelId + size to the new provider's
+  // first valid option. Avoids invalid combinations.
+  const handleProviderChange = useCallback(
+    (nextId: ProviderId) => {
+      const next = allProviders.find((p) => p.id === nextId);
+      if (!next || next.models.length === 0) return;
+      setProviderId(nextId);
+      setModelId(next.models[0].id);
+      setSize(next.models[0].defaultSize);
+    },
+    [allProviders],
+  );
+
   const handleModelChange = useCallback(
-    (nextId: ImageModelId) => {
+    (nextId: ModelId) => {
       const next = activeProvider?.models.find((m) => m.id === nextId);
       if (!next) return;
       setModelId(nextId);
@@ -173,14 +306,12 @@ export function AiImageGenDialog({
                 Provider
               </label>
               <select
-                value={providerId}
-                onChange={(e) =>
-                  handleProviderChange(e.target.value as ImageProviderId)
-                }
-                disabled={submitting}
+                value={activeProvider?.id ?? ""}
+                onChange={(e) => handleProviderChange(e.target.value)}
+                disabled={submitting || allProviders.length === 0}
                 className="w-full rounded-md border border-white/10 bg-black/30 px-2 py-1.5 text-sm text-white focus:outline-none focus:border-white/30 disabled:opacity-50"
               >
-                {IMAGE_PROVIDER_CATALOG.map((p) => (
+                {allProviders.map((p) => (
                   <option key={p.id} value={p.id}>
                     {p.name}
                   </option>
@@ -192,14 +323,15 @@ export function AiImageGenDialog({
                 Model
               </label>
               <select
-                value={modelId}
-                onChange={(e) => handleModelChange(e.target.value as ImageModelId)}
+                value={activeModel?.id ?? ""}
+                onChange={(e) => handleModelChange(e.target.value)}
                 disabled={submitting || !activeProvider}
                 className="w-full rounded-md border border-white/10 bg-black/30 px-2 py-1.5 text-sm text-white focus:outline-none focus:border-white/30 disabled:opacity-50"
               >
                 {activeProvider?.models.map((m) => (
                   <option key={m.id} value={m.id}>
                     {m.name}
+                    {m.source === "connection" && m.via ? ` — via ${m.via}` : ""}
                   </option>
                 ))}
               </select>

--- a/components/content/ai/AiImageGenDialog.tsx
+++ b/components/content/ai/AiImageGenDialog.tsx
@@ -32,12 +32,20 @@ interface AiImageGenDialogProps {
   onClose: () => void;
   /** Fired with the new ContentNode id after a successful save. */
   onCreated?: (contentId: string) => void;
+  /**
+   * Fired with the full result (id + URL + alt) so the caller can do
+   * an inline insertion in addition to (or instead of) the standalone
+   * file. Used by the in-doc slash command path so the image lands
+   * inline in the open document.
+   */
+  onCreatedFull?: (result: { contentId: string; url: string; prompt: string }) => void;
 }
 
 export function AiImageGenDialog({
   parentId,
   onClose,
   onCreated,
+  onCreatedFull,
 }: AiImageGenDialogProps) {
   const glass0 = getSurfaceStyles("glass-0");
 
@@ -98,14 +106,18 @@ export function AiImageGenDialog({
         return;
       }
       const contentId = body.data?.contentId as string | undefined;
+      const url = body.data?.url as string | undefined;
       if (contentId && onCreated) onCreated(contentId);
+      if (contentId && url && onCreatedFull) {
+        onCreatedFull({ contentId, url, prompt: prompt.trim() });
+      }
       onClose();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Network error");
     } finally {
       setSubmitting(false);
     }
-  }, [prompt, submitting, providerId, modelId, size, parentId, onCreated, onClose]);
+  }, [prompt, submitting, providerId, modelId, size, parentId, onCreated, onCreatedFull, onClose]);
 
   // Escape to dismiss; Cmd/Ctrl+Enter to submit.
   useEffect(() => {

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -250,6 +250,18 @@ export const ChatMessage = memo(function ChatMessage({
 
   return (
     <div
+      // Assistant turns get aria-live="polite" so screen-reader users
+      // hear streaming progress without interrupting other speech.
+      // User turns are static (no SR announcement needed). aria-busy
+      // on streaming so SR doesn't try to re-announce on every chunk.
+      role={isAssistant ? "article" : undefined}
+      aria-live={isAssistant && isStreaming ? "polite" : undefined}
+      aria-busy={isAssistant && isStreaming ? true : undefined}
+      aria-label={
+        isAssistant
+          ? `Assistant message${isStreaming ? ", in progress" : ""}`
+          : "Your message"
+      }
       className={cn(
         "group flex gap-3 px-4 py-3",
         isUser && "flex-row-reverse"
@@ -474,8 +486,12 @@ export const ChatMessage = memo(function ChatMessage({
             (assistant). Hidden until row hover; suppressed while streaming. */}
         {!isStreaming && messageText && (
           <div
+            // `focus-within` keeps the action bar visible when a button
+            // inside it has keyboard focus — without this, keyboard users
+            // tab into invisible (opacity-0) buttons that they can't
+            // see they've focused.
             className={cn(
-              "flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity text-gray-500",
+              "flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity text-gray-500",
               isUser ? "justify-end" : "justify-start",
             )}
           >
@@ -549,7 +565,7 @@ function MessageActionButton({
       disabled={disabled}
       title={label}
       aria-label={label}
-      className="inline-flex items-center justify-center rounded-md p-1 hover:text-gray-200 hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-default"
+      className="inline-flex items-center justify-center rounded-md p-1 hover:text-gray-200 hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/60"
     >
       {children}
     </button>

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -300,12 +300,17 @@ export const ChatMessage = memo(function ChatMessage({
                   setEditing(false);
                 }
               }}
-              rows={Math.min(8, Math.max(2, draft.split("\n").length))}
-              // Visually mirror the view-mode bubble (same bg/border)
-              // so the bubble appears to become editable in place
-              // rather than turning into a different-looking control.
-              // Focus-ring still distinguishes editing state.
-              className="w-full resize-y rounded-xl border border-blue-500/20 bg-blue-600/30 px-3.5 py-2.5 text-sm leading-relaxed text-blue-100 outline-none focus:border-blue-400/60 focus:ring-2 focus:ring-blue-400/30"
+              rows={Math.min(8, Math.max(1, draft.split("\n").length))}
+              // Visually mirror the view-mode bubble. Three pieces:
+              //   - matching bg / border / padding / radius (so the
+              //     bubble appears to become editable in place);
+              //   - `field-sizing: content` lets the textarea shrink
+              //     to its text width like the view's `inline-block`
+              //     bubble (Chromium 123+, Firefox 124+); fallback is
+              //     `w-full` which is still legible just wider;
+              //   - `max-w-full` keeps it from overflowing the column.
+              style={{ fieldSizing: "content" } as React.CSSProperties}
+              className="w-full max-w-full resize-y rounded-xl border border-blue-500/20 bg-blue-600/30 px-3.5 py-2.5 text-sm leading-relaxed text-blue-100 outline-none focus:border-blue-400/60 focus:ring-2 focus:ring-blue-400/30 align-top"
             />
             <div className="flex items-center justify-end gap-1.5">
               <button

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -301,7 +301,11 @@ export const ChatMessage = memo(function ChatMessage({
                 }
               }}
               rows={Math.min(8, Math.max(2, draft.split("\n").length))}
-              className="w-full resize-y rounded-xl border border-blue-500/30 bg-blue-600/10 px-3.5 py-2.5 text-sm leading-relaxed text-blue-100 outline-none focus:border-blue-400/50"
+              // Visually mirror the view-mode bubble (same bg/border)
+              // so the bubble appears to become editable in place
+              // rather than turning into a different-looking control.
+              // Focus-ring still distinguishes editing state.
+              className="w-full resize-y rounded-xl border border-blue-500/20 bg-blue-600/30 px-3.5 py-2.5 text-sm leading-relaxed text-blue-100 outline-none focus:border-blue-400/60 focus:ring-2 focus:ring-blue-400/30"
             />
             <div className="flex items-center justify-end gap-1.5">
               <button

--- a/components/content/ai/ChatPanel.tsx
+++ b/components/content/ai/ChatPanel.tsx
@@ -27,7 +27,10 @@ import { FollowUpsStrip } from "./FollowUpsStrip";
 import { ChatErrorBanner } from "./ChatErrorBanner";
 import { MakeAndModelPicker } from "./MakeAndModelPicker";
 import { useConversationEngine } from "@/lib/domain/ai/use-conversation-engine";
-import { useConversationBinding } from "@/lib/domain/ai/use-conversation-binding";
+import {
+  useConversationBinding,
+  type PersistFinishPayload,
+} from "@/lib/domain/ai/use-conversation-binding";
 import { useContentStore } from "@/state/content-store";
 import { detectMixedProvider } from "@/lib/design/system/ai-providers";
 import type { AIProviderId } from "@/lib/domain/ai/types";
@@ -80,7 +83,7 @@ export function ChatPanel({
     : "sidebar-chat";
 
   // Persist-on-finish for conversation-bound mode (ChatViewer-pattern).
-  const persistRef = useRef<() => void>(() => {});
+  const persistRef = useRef<(payload?: PersistFinishPayload) => void>(() => {});
   // Edit/regenerate supersession — populated by the binding hook.
   const truncateRef = useRef<(clientId: string, inclusive: boolean) => Promise<void>>(
     async () => {},
@@ -121,7 +124,22 @@ export function ChatPanel({
     conversationKey,
     contentId,
     conversationId,
-    onFinish: conversationId ? () => persistRef.current() : undefined,
+    onFinish: conversationId
+      ? (event) => {
+          // Forward the SDK's fresh assistant message so persistTurns
+          // can read its metadata directly (bypasses React closure
+          // staleness — the SDK mutates state.message.metadata just
+          // before this fires, but our `messages` array may not have
+          // flushed yet).
+          const fresh = event.message
+            ? {
+                id: event.message.id,
+                metadata: (event.message as { metadata?: unknown }).metadata,
+              }
+            : undefined;
+          persistRef.current({ freshAssistant: fresh });
+        }
+      : undefined,
     truncateRef,
     pendingUserPartsRef,
   });

--- a/components/content/ai/MakeAndModelPicker.tsx
+++ b/components/content/ai/MakeAndModelPicker.tsx
@@ -39,7 +39,10 @@ interface ConnSummary {
   name: string;
   presetId: string | null;
   adapterKind: string;
-  models: Array<{ id: string }>;
+  // model.name is needed to display user-added models in the picker
+  // dropdown alongside catalog entries — the catalog provides display
+  // names for its models; Connection-added ones bring their own.
+  models: Array<{ id: string; name?: string }>;
 }
 
 /**
@@ -202,8 +205,11 @@ export function MakeAndModelPicker({
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [connections]);
 
-  // Unified provider list — static catalog first, then any dynamic
-  // entries the user's Connections expose.
+  // Unified provider list — static catalog first (rich metadata),
+  // augmented with user-added Connection models the catalog doesn't
+  // know about (e.g. fresh OpenAI releases, snapshot versions, models
+  // accessed via a gateway). Then any fully-dynamic providers (those
+  // whose prefix isn't a catalog entry at all, like Perplexity).
   type PickerProvider = {
     id: string;
     name: string;
@@ -214,17 +220,72 @@ export function MakeAndModelPicker({
     }>;
   };
   const allProviders = useMemo<PickerProvider[]>(() => {
-    const fromCatalog: PickerProvider[] = PROVIDER_CATALOG.map((p) => ({
-      id: p.id,
-      name: p.name,
-      models: p.models.map((m) => ({
-        id: m.id,
-        name: m.name,
-        costTier: m.costTier,
-      })),
-    }));
+    // Index user-added Connection models by provider id. Two storage
+    // shapes both contribute:
+    //   1. Gateway-namespaced: `openai/gpt-5.2` — prefix becomes the
+    //      provider id, bare suffix becomes the displayed model id.
+    //   2. Direct provider: Connection.presetId === provider id and
+    //      Connection.models[] holds bare ids (e.g. `gpt-4o-2024-08-06`
+    //      from a direct OpenAI Connection).
+    const userModelsByProvider = new Map<
+      string,
+      Map<string, { id: string; name: string }>
+    >();
+    const remember = (prov: string, id: string, name: string) => {
+      if (!userModelsByProvider.has(prov)) {
+        userModelsByProvider.set(prov, new Map());
+      }
+      const map = userModelsByProvider.get(prov)!;
+      if (!map.has(id)) map.set(id, { id, name });
+    };
+    for (const c of connections) {
+      for (const m of c.models) {
+        const slash = m.id.indexOf("/");
+        if (slash > 0) {
+          // Gateway namespaced form.
+          const prefix = m.id.slice(0, slash);
+          const bare = m.id.slice(slash + 1);
+          if (prefix && bare) remember(prefix, bare, m.name || bare);
+        } else if (c.presetId) {
+          // Direct form — provider id comes from the Connection preset.
+          remember(c.presetId, m.id, m.name || m.id);
+        }
+      }
+    }
+
+    const fromCatalog: PickerProvider[] = PROVIDER_CATALOG.map((p) => {
+      // Widen to plain string Set so user-added model ids (plain strings)
+      // can dedupe against catalog ids (branded `AIModelId`).
+      const catalogIds = new Set<string>(p.models.map((m) => m.id));
+      const userAdds = userModelsByProvider.get(p.id);
+      const userModelEntries = userAdds
+        ? Array.from(userAdds.values())
+            .filter((m) => !catalogIds.has(m.id))
+            .sort((a, b) => a.id.localeCompare(b.id))
+            .map((m) => ({
+              id: m.id,
+              name: m.name,
+              // User-added models lack rich metadata; "medium" is the
+              // safest default — better than guessing low (would hide
+              // the budget signal) or high (would scare users off).
+              costTier: "medium" as const,
+            }))
+        : [];
+      return {
+        id: p.id,
+        name: p.name,
+        models: [
+          ...p.models.map((m) => ({
+            id: m.id,
+            name: m.name,
+            costTier: m.costTier,
+          })),
+          ...userModelEntries,
+        ],
+      };
+    });
     return [...fromCatalog, ...dynamicProviders];
-  }, [dynamicProviders]);
+  }, [connections, dynamicProviders]);
 
   const activeProvider = allProviders.find((p) => p.id === providerId);
   const activeRouting = useMemo(

--- a/components/content/ai/SidebarChatTabs.tsx
+++ b/components/content/ai/SidebarChatTabs.tsx
@@ -72,6 +72,34 @@ export function SidebarChatTabs({
   const overflow = tabs.slice(maxVisible);
   const [overflowOpen, setOverflowOpen] = useState(false);
 
+  // A11y: arrow-key nav across the visible tab strip. Left/Right move
+  // focus *and* activate (chat tabs are inexpensive to switch into);
+  // Home/End jump to the ends. The strip itself carries role="tablist"
+  // so screen readers announce position ("tab 3 of 5"). Per WAI-ARIA's
+  // tab pattern, only the active tab is in the tab order — others are
+  // tabIndex=-1 and focusable only via the arrow keys.
+  const handleStripKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (visible.length === 0) return;
+    const activeIdx = visible.findIndex((t) => t.conversationId === activeConversationId);
+    const move = (next: number) => {
+      const wrapped = ((next % visible.length) + visible.length) % visible.length;
+      onActivate(visible[wrapped].conversationId);
+    };
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      move(activeIdx === -1 ? 0 : activeIdx + 1);
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      move(activeIdx === -1 ? visible.length - 1 : activeIdx - 1);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      move(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      move(visible.length - 1);
+    }
+  };
+
   return (
     <div className="flex shrink-0 items-end border-b border-black/10 dark:border-white/10 px-2 pt-1.5 gap-2">
       {/* Scrollable tab list — fills available width, scrolls horizontally
@@ -83,6 +111,9 @@ export function SidebarChatTabs({
           wheel/trackpad gestures. */}
       <div
         className="scrollbar-hide flex items-end gap-px flex-1 min-w-0 overflow-x-auto overflow-y-hidden"
+        role="tablist"
+        aria-label="Conversations"
+        onKeyDown={handleStripKeyDown}
       >
         {visible.map((t) => (
           <TabButton
@@ -264,9 +295,15 @@ function TabButton({
   // text input; Enter/blur commits, Escape cancels.
   return (
     <div
+      role="tab"
+      aria-selected={active}
+      tabIndex={active ? 0 : -1}
+      aria-label={`Conversation: ${label}${active ? " (active)" : ""}`}
       className={cn(
         "group/tab relative inline-flex items-center gap-1 px-2.5 py-1.5",
         "rounded-t-md border border-b-0 text-[11px] transition-colors max-w-[180px] shrink-0",
+        // Visible keyboard-focus ring for SR/keyboard users.
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/60",
         active
           ? "z-10"
           : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-300 hover:bg-white/[0.04]",

--- a/components/content/content/LeftSidebarContent.tsx
+++ b/components/content/content/LeftSidebarContent.tsx
@@ -247,7 +247,14 @@ export function LeftSidebarContent({
   // Search store - conditionally show search panel
   const isSearchOpen = useSearchStore((state) => state.isSearchOpen);
 
-  // Active workspace — used to scope the file tree when workspace is a view
+  // Active workspace — used to scope the file tree when workspace is a view.
+  // `workspaceStoreReady` gates the FIRST fetchTree fire so we don't
+  // burn a request on stale defaults (activeWorkspaceId=null,
+  // activeViewRootContentId=null) only to immediately re-fetch when
+  // the store hydrates from /api/content/workspaces. Pre-hydration the
+  // tree shows skeleton; post-hydration it fetches once with the right
+  // workspace context. Tracked via the store's hasLoadedOnce flag.
+  const workspaceStoreReady = useWorkspaceStore((state) => state.hasLoadedOnce);
   const activeWorkspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
   const activeWorkspaceIsView = useWorkspaceStore((state) => {
     const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
@@ -315,10 +322,15 @@ export function LeftSidebarContent({
     }
   }, [activeWorkspaceId, activeWorkspaceIsView, activeViewRootContentId, showReferencedContent]);
 
-  // Initial load and refresh when trigger or active workspace changes
+  // Initial load and refresh when trigger or active workspace changes.
+  // Gated on `workspaceStoreReady` so we don't double-fetch (once for
+  // the pre-hydration null workspace, once for the real one). The tree
+  // skeleton stays up while we wait for hydration, which is typically
+  // <500ms and overlaps with other in-flight requests.
   useEffect(() => {
+    if (!workspaceStoreReady) return;
     fetchTree();
-  }, [fetchTree, refreshTrigger]);
+  }, [fetchTree, refreshTrigger, workspaceStoreReady]);
 
   // Check if user has Google authentication
   useEffect(() => {

--- a/components/content/editor/MarkdownEditor.tsx
+++ b/components/content/editor/MarkdownEditor.tsx
@@ -17,6 +17,7 @@ import { usePathname } from "next/navigation";
 import { getEditorExtensions, getViewerExtensions } from "@/lib/domain/editor/extensions-client";
 import type { JSONContent } from "@tiptap/core";
 import { LinkDialog } from "./LinkDialog";
+import { AiImageGenDialog } from "@/components/content/ai/AiImageGenDialog";
 import { BubbleMenu } from "./BubbleMenu";
 import { TemplatePicker } from "./TemplatePicker";
 import { SnippetPicker } from "./SnippetPicker";
@@ -208,6 +209,10 @@ export function MarkdownEditor({
   const [, setIsSaving] = useState(false);
   const [, setHasUnsavedChanges] = useState(false);
   const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
+  // In-document AI image gen dialog — opens via the /ai-image slash
+  // command. On creation, fires the existing `insert-ai-image` event
+  // which the editor already handles for chat-tool-generated images.
+  const [aiImageDialogOpen, setAiImageDialogOpen] = useState(false);
   const [remoteCollaborators, setRemoteCollaborators] = useState<RemoteCollaborator[]>([]);
   const [cursorLabels, setCursorLabels] = useState<CollaborationCursorLabel[]>([]);
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -869,6 +874,16 @@ export function MarkdownEditor({
     return () => window.removeEventListener("editor-image-upload", handleImageUpload);
   }, []);
 
+  // /ai-image slash command opens the AiImageGenDialog. On success the
+  // dialog calls onCreatedFull, which dispatches the same
+  // `insert-ai-image` event the chat-tool flow uses so the image lands
+  // inline at the cursor.
+  useEffect(() => {
+    const handleOpenAiImage = () => setAiImageDialogOpen(true);
+    window.addEventListener("editor-open-ai-image", handleOpenAiImage);
+    return () => window.removeEventListener("editor-open-ai-image", handleOpenAiImage);
+  }, []);
+
   // Embedded diagram blocks (ExcalidrawBlock, MermaidBlock): when a block
   // without a contentId is clicked, it fires this event so we can create the
   // visualization ContentNode via the API and write the new id back into attrs.
@@ -1334,6 +1349,29 @@ export function MarkdownEditor({
       {/* Template / Snippet pickers — event-driven, no props needed */}
       <TemplatePicker />
       <SnippetPicker />
+
+      {/* /ai-image slash command target — mounted only when triggered.
+          The new image becomes "referenced" (hidden behind the
+          show-referenced toggle) and is auto-inserted inline at the
+          cursor via the existing insert-ai-image event listener. */}
+      {aiImageDialogOpen && (
+        <AiImageGenDialog
+          parentId={null}
+          onClose={() => setAiImageDialogOpen(false)}
+          onCreatedFull={({ contentId: imgId, url, prompt }) => {
+            window.dispatchEvent(
+              new CustomEvent("insert-ai-image", {
+                detail: {
+                  src: url,
+                  alt: prompt || "AI generated image",
+                  contentId: imgId,
+                  source: "ai-generated",
+                },
+              }),
+            );
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/components/content/viewer/ChatViewer.tsx
+++ b/components/content/viewer/ChatViewer.tsx
@@ -19,7 +19,10 @@ import { ChatErrorBanner } from "../ai/ChatErrorBanner";
 import { MakeAndModelPicker } from "../ai/MakeAndModelPicker";
 import { AssociatedContentChips } from "../ai/AssociatedContentChips";
 import { useConversationEngine } from "@/lib/domain/ai/use-conversation-engine";
-import { useConversationBinding } from "@/lib/domain/ai/use-conversation-binding";
+import {
+  useConversationBinding,
+  type PersistFinishPayload,
+} from "@/lib/domain/ai/use-conversation-binding";
 import { useContentStore } from "@/state/content-store";
 import { toast } from "sonner";
 import {
@@ -184,7 +187,7 @@ function ChatViewerInner({
   // Stable onFinish that delegates to the ref-tracked persist function.
   // Bound mode → the binding hook claims this ref (Conversation persist).
   // Legacy mode → the ChatPayload debounced persist claims it below.
-  const persistRef = useRef<() => void>(() => {});
+  const persistRef = useRef<(payload?: PersistFinishPayload) => void>(() => {});
   // Edit/regenerate supersession — populated by the binding hook in bound
   // mode; a no-op in legacy mode (edits there just re-save the ChatPayload).
   const truncateRef = useRef<(clientId: string, inclusive: boolean) => Promise<void>>(
@@ -227,7 +230,20 @@ function ChatViewerInner({
     contentId,
     conversationId: conversationId ?? undefined,
     initialMessages,
-    onFinish: () => persistRef.current(),
+    onFinish: (event) => {
+      // Forward the SDK's fresh assistant message (with metadata) so
+      // persistTurns can read it directly rather than from a stale
+      // React closure. The SDK mutates state.message.metadata just
+      // before firing onFinish; our `messages` array may not have
+      // flushed yet at this synchronous call site.
+      const fresh = event.message
+        ? {
+            id: event.message.id,
+            metadata: (event.message as { metadata?: unknown }).metadata,
+          }
+        : undefined;
+      persistRef.current({ freshAssistant: fresh });
+    },
     truncateRef,
     pendingUserPartsRef,
   });

--- a/components/settings/AIFeatureRoutingPage.tsx
+++ b/components/settings/AIFeatureRoutingPage.tsx
@@ -19,7 +19,7 @@ import { Button } from "@/components/ui/glass/button";
 import { getSurfaceStyles } from "@/lib/design/system";
 import { ProviderIcon } from "@/components/content/ai/ProviderIcon";
 import { FEATURE_REGISTRY, type FeatureSpec, type CapabilityFlag } from "@/lib/domain/ai/features/registry";
-import { effectiveCapabilities } from "@/lib/domain/ai/features/router";
+import { effectiveCapabilities } from "@/lib/domain/ai/features/capabilities";
 import type { ConnectionView } from "@/lib/features/ai-connections/types";
 
 interface RouteEntry {

--- a/components/settings/AIFeatureRoutingPage.tsx
+++ b/components/settings/AIFeatureRoutingPage.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/glass/button";
 import { getSurfaceStyles } from "@/lib/design/system";
 import { ProviderIcon } from "@/components/content/ai/ProviderIcon";
 import { FEATURE_REGISTRY, type FeatureSpec, type CapabilityFlag } from "@/lib/domain/ai/features/registry";
+import { effectiveCapabilities } from "@/lib/domain/ai/features/router";
 import type { ConnectionView } from "@/lib/features/ai-connections/types";
 
 interface RouteEntry {
@@ -161,11 +162,15 @@ function FeatureRow({
   const dirty = localKey !== entriesKey;
 
   // Connection+model pairs that satisfy the required capabilities.
+  // Uses `effectiveCapabilities` (explicit + inferred from id pattern)
+  // so older entries saved without the explicit `image-generation`
+  // flag — e.g. dall-e-3 added before catalog augmentation existed —
+  // still surface as compatible pairs.
   const compatibleOptions = useMemo(() => {
     const opts: Array<{ connectionId: string; modelId: string; label: string }> = [];
     for (const c of connections) {
       for (const m of c.models) {
-        const have = new Set<string>(m.capabilities ?? []);
+        const have = effectiveCapabilities(m);
         const ok = feature.requiredCapabilities.every((cap) => have.has(cap));
         if (ok) opts.push({ connectionId: c.id, modelId: m.id, label: `${c.label} • ${m.name}` });
       }

--- a/components/settings/SettingsSidebar.tsx
+++ b/components/settings/SettingsSidebar.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback } from "react";
 import { getSurfaceStyles } from "@/lib/design/system";
+import { LAST_CONTENT_ROUTE_KEY } from "@/components/content/NotesLayoutMarker";
 import {
   renderExtensionIcon,
 } from "@/lib/extensions";
@@ -266,17 +267,24 @@ export function SettingsSidebar() {
   );
   const allItems = [...navItems, ...extensionSettingsItems];
 
-  // Back to wherever the user was before entering settings. Uses the
-  // browser's history stack when available; falls back to `/` when the
-  // settings route was the entry point (direct link, hard refresh).
-  // `window.history.length > 1` is the most reliable signal we can read
-  // in the browser without maintaining our own referrer state.
+  // Back to the last content route the user visited, not the previous
+  // settings sub-page. NotesLayoutMarker writes the user's pathname to
+  // sessionStorage on every non-settings render; we read that here so
+  // "Back" jumps cleanly out of settings instead of walking through
+  // internal settings history. Falls back to `/` (direct link / first-
+  // visit / private-browsing edge cases).
   const handleBack = useCallback(() => {
-    if (typeof window !== "undefined" && window.history.length > 1) {
-      router.back();
-    } else {
+    if (typeof window === "undefined") {
       router.push("/");
+      return;
     }
+    let target: string | null = null;
+    try {
+      target = window.sessionStorage.getItem(LAST_CONTENT_ROUTE_KEY);
+    } catch {
+      target = null;
+    }
+    router.push(target && !target.startsWith("/settings") ? target : "/");
   }, [router]);
 
   return (

--- a/components/settings/SettingsSidebar.tsx
+++ b/components/settings/SettingsSidebar.tsx
@@ -8,7 +8,8 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { useCallback } from "react";
 import { getSurfaceStyles } from "@/lib/design/system";
 import {
   renderExtensionIcon,
@@ -254,6 +255,7 @@ const navItems: NavItem[] = [
 
 export function SettingsSidebar() {
   const pathname = usePathname();
+  const router = useRouter();
   const glass1 = getSurfaceStyles("glass-1");
   const extensionSettingsItems: NavItem[] = useExtensionSettingsEntries().map(
     (entry) => ({
@@ -264,8 +266,44 @@ export function SettingsSidebar() {
   );
   const allItems = [...navItems, ...extensionSettingsItems];
 
+  // Back to wherever the user was before entering settings. Uses the
+  // browser's history stack when available; falls back to `/` when the
+  // settings route was the entry point (direct link, hard refresh).
+  // `window.history.length > 1` is the most reliable signal we can read
+  // in the browser without maintaining our own referrer state.
+  const handleBack = useCallback(() => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push("/");
+    }
+  }, [router]);
+
   return (
     <div className="p-4 space-y-2">
+      <button
+        type="button"
+        onClick={handleBack}
+        title="Back to where you were"
+        aria-label="Back"
+        className="flex w-full items-center gap-2 px-3 py-2 mb-2 rounded-lg text-sm text-gray-400 hover:text-gray-100 hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/60"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="19" y1="12" x2="5" y2="12" />
+          <polyline points="12 19 5 12 12 5" />
+        </svg>
+        <span>Back</span>
+      </button>
       <div className="px-3 py-2 mb-4">
         <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide">
           Settings

--- a/extensions/workplaces/state/workspace-store.ts
+++ b/extensions/workplaces/state/workspace-store.ts
@@ -253,6 +253,12 @@ function isWorkspaceNotFoundError(error: unknown) {
   );
 }
 
+function readContentIdFromUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  const value = new URLSearchParams(window.location.search).get("content");
+  return value && value.length > 0 ? value : null;
+}
+
 function restoreContentWorkspace(workspace: ContentWorkspaceResponse) {
   const paneTabContentIds = Object.fromEntries(
     Object.entries(workspace.paneState.paneTabContentIds).map(
@@ -260,10 +266,26 @@ function restoreContentWorkspace(workspace: ContentWorkspaceResponse) {
     ),
   );
 
+  // Cold-load race: the workspace API can resolve before
+  // MainPanelWorkspace's URL parser runs. If the URL specifies a
+  // content id that belongs to this workspace, it must win as the
+  // active tab — otherwise the user deep-links to a tab but watches
+  // it load LAST while the persisted active tab loads first. Gating
+  // on workspace membership avoids regressing the manual workspace
+  // switch path, where `syncWorkspaceUrl` leaves a stale `content=`
+  // in the URL from the previous workspace.
+  const contentIdFromUrl = readContentIdFromUrl();
+  const urlContentBelongsToWorkspace =
+    contentIdFromUrl !== null &&
+    workspace.items.some((item) => item.contentId === contentIdFromUrl);
+  const activeContentId = urlContentBelongsToWorkspace
+    ? contentIdFromUrl
+    : workspace.paneState.activeContentId;
+
   isBypassingWorkspaceGuard = true;
   try {
     useContentStore.getState().restoreWorkspace({
-      activeContentId: workspace.paneState.activeContentId,
+      activeContentId,
       activePaneId: workspace.paneState.activePaneId,
       layoutMode: workspace.paneState.layoutMode,
       paneTabContentIds,

--- a/extensions/workplaces/state/workspace-store.ts
+++ b/extensions/workplaces/state/workspace-store.ts
@@ -36,6 +36,15 @@ interface WorkspaceState {
   workspaces: ContentWorkspaceResponse[];
   activeWorkspaceId: string | null;
   isLoading: boolean;
+  /**
+   * True once loadWorkspaces has completed at least once (success or
+   * failure). Use this as a one-shot "store is ready" signal to gate
+   * downstream fetches whose URL depends on activeWorkspaceId — they
+   * would otherwise double-fetch (once for the initial null id, once
+   * after the store hydrates with the real id). Stays true for the
+   * rest of the session.
+   */
+  hasLoadedOnce: boolean;
   conflict: WorkspaceOpenConflict | null;
   pendingOpenIntent: PendingOpenIntent | null;
   loadWorkspaces: (initialWorkspaceId?: string | null) => Promise<void>;
@@ -428,6 +437,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   workspaces: [],
   activeWorkspaceId: null,
   isLoading: false,
+  hasLoadedOnce: false,
   conflict: null,
   pendingOpenIntent: null,
 
@@ -456,6 +466,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         workspaces,
         activeWorkspaceId: activeWorkspace?.id ?? null,
         isLoading: false,
+        hasLoadedOnce: true,
       });
 
       warmContentSummaryCache(
@@ -472,7 +483,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       }
     } catch (error) {
       console.error("[Workspace Store] Failed to load workspaces:", error);
-      set({ isLoading: false });
+      // hasLoadedOnce flips even on failure — the gate is "did we
+      // attempt", not "did we succeed". Downstream fetches that need
+      // workspace context will run with whatever defaults the store
+      // settles on, rather than waiting forever.
+      set({ isLoading: false, hasLoadedOnce: true });
     }
   },
 

--- a/lib/domain/ai/features/capabilities.ts
+++ b/lib/domain/ai/features/capabilities.ts
@@ -30,14 +30,27 @@ export function inferCapabilities(modelId: string): string[] {
   const bare = slash >= 0 ? modelId.slice(slash + 1) : modelId;
   const out: string[] = [];
 
-  // Image generation models. These ids are stable across providers and
-  // gateways — DALL·E + GPT Image (OpenAI), Imagen (Google), FLUX
-  // (fal.ai / Together / Fireworks), Stable Diffusion variants.
+  // Image generation models. Patterns cover canonical id stems across
+  // providers and gateways:
+  //   - DALL·E + GPT Image families (OpenAI direct + via gateway)
+  //   - Imagen series (Google direct)
+  //   - Google's image-output Gemini variants — Nano Banana
+  //     (`gemini-2.5-flash-image`), Nano Banana Pro
+  //     (`gemini-3-pro-image`), and preview channels — all end in
+  //     `-image` or `-image-preview`. Caught by the suffix rule.
+  //   - FLUX (BFL direct + via gateway, fal.ai, Together, Fireworks)
+  //   - Recraft + Seedream (gateway only as of writing)
+  //   - xAI's grok-imagine
+  //   - Stable Diffusion / SDXL variants
   if (
     /^dall-e/i.test(bare) ||
     /^gpt-image/i.test(bare) ||
     /^imagen/i.test(bare) ||
+    /-image(-preview)?$/i.test(bare) ||
     /\bflux\b/i.test(bare) ||
+    /^recraft/i.test(bare) ||
+    /^seedream/i.test(bare) ||
+    /\bgrok-imagine\b/i.test(bare) ||
     /^stable-diffusion/i.test(bare) ||
     /^sdxl/i.test(bare)
   ) {

--- a/lib/domain/ai/features/capabilities.ts
+++ b/lib/domain/ai/features/capabilities.ts
@@ -1,0 +1,62 @@
+/**
+ * Client-safe capability helpers.
+ *
+ * Lives separately from `router.ts` because router.ts imports
+ * `server-only` (for the feature-route resolution path that hits
+ * Prisma). The helpers here are pure functions over a model object
+ * and can be imported by client components — specifically the
+ * AIFeatureRoutingPage compatibility filter.
+ */
+
+/**
+ * Infer capability flags from a model's id when the saved
+ * `capabilities` array is missing or incomplete.
+ *
+ * Safety net for Connection entries saved before the fetcher's
+ * catalog augmentation existed (or for entries the user added
+ * manually via the "Model ID" input, which has no capability
+ * field). Lets feature routing find them as compatible pairs without
+ * forcing the user to re-add their models.
+ *
+ * Only adds capabilities — never removes — so explicit `capabilities`
+ * on the model still win. Patterns are deliberately conservative; we
+ * recognize widely-documented model id stems rather than every
+ * variant.
+ */
+export function inferCapabilities(modelId: string): string[] {
+  // Strip a namespace prefix so `openai/dall-e-3` matches the same
+  // patterns as `dall-e-3`.
+  const slash = modelId.indexOf("/");
+  const bare = slash >= 0 ? modelId.slice(slash + 1) : modelId;
+  const out: string[] = [];
+
+  // Image generation models. These ids are stable across providers and
+  // gateways — DALL·E + GPT Image (OpenAI), Imagen (Google), FLUX
+  // (fal.ai / Together / Fireworks), Stable Diffusion variants.
+  if (
+    /^dall-e/i.test(bare) ||
+    /^gpt-image/i.test(bare) ||
+    /^imagen/i.test(bare) ||
+    /\bflux\b/i.test(bare) ||
+    /^stable-diffusion/i.test(bare) ||
+    /^sdxl/i.test(bare)
+  ) {
+    out.push("image-generation");
+  }
+
+  return out;
+}
+
+/**
+ * Effective capability set for a saved model: union of the explicit
+ * `capabilities` array (catalog/fetcher-derived) and any flags
+ * inferred from the model id. Use this anywhere a feature-routing
+ * filter wants to know what a model can do.
+ */
+export function effectiveCapabilities(
+  model: { id: string; capabilities?: string[] },
+): Set<string> {
+  const have = new Set<string>(model.capabilities ?? []);
+  for (const inferred of inferCapabilities(model.id)) have.add(inferred);
+  return have;
+}

--- a/lib/domain/ai/features/router.ts
+++ b/lib/domain/ai/features/router.ts
@@ -106,6 +106,59 @@ export async function resolvePrimaryRoute(
   return all[0] ?? null;
 }
 
+/**
+ * Infer capability flags from a model's id when the saved
+ * `capabilities` array is missing or incomplete.
+ *
+ * Safety net for older Connection entries that were saved before the
+ * fetcher's catalog augmentation existed (or for entries the user
+ * added manually via the "Model ID" input, which has no capability
+ * field). Lets feature routing find them as compatible pairs without
+ * forcing the user to re-add their models.
+ *
+ * Only adds capabilities — never removes — so explicit `capabilities`
+ * on the model still win. Patterns are deliberately conservative; we
+ * recognize widely-documented model id stems rather than every
+ * variant.
+ */
+export function inferCapabilities(modelId: string): string[] {
+  // Strip a namespace prefix so `openai/dall-e-3` matches the same
+  // patterns as `dall-e-3`.
+  const slash = modelId.indexOf("/");
+  const bare = slash >= 0 ? modelId.slice(slash + 1) : modelId;
+  const out: string[] = [];
+
+  // Image generation models. These ids are stable across providers and
+  // gateways — DALL·E + GPT Image (OpenAI), Imagen (Google), FLUX
+  // (fal.ai / Together / Fireworks).
+  if (
+    /^dall-e/i.test(bare) ||
+    /^gpt-image/i.test(bare) ||
+    /^imagen/i.test(bare) ||
+    /\bflux\b/i.test(bare) ||
+    /^stable-diffusion/i.test(bare) ||
+    /^sdxl/i.test(bare)
+  ) {
+    out.push("image-generation");
+  }
+
+  return out;
+}
+
+/**
+ * Effective capability set for a saved model: union of the explicit
+ * `capabilities` array (catalog/fetcher-derived) and any flags
+ * inferred from the model id. Use this anywhere a feature-routing
+ * filter wants to know what a model can do.
+ */
+export function effectiveCapabilities(
+  model: { id: string; capabilities?: string[] },
+): Set<string> {
+  const have = new Set<string>(model.capabilities ?? []);
+  for (const inferred of inferCapabilities(model.id)) have.add(inferred);
+  return have;
+}
+
 function modelSatisfiesCapabilities(
   connection: ConnectionView,
   modelId: string,
@@ -114,7 +167,7 @@ function modelSatisfiesCapabilities(
   if (required.length === 0) return true;
   const model = connection.models.find((m) => m.id === modelId);
   if (!model) return false;
-  const have = new Set<string>(model.capabilities ?? []);
+  const have = effectiveCapabilities(model);
   return required.every((cap) => have.has(cap));
 }
 
@@ -124,7 +177,7 @@ export function listCompatibleModels(
   required: CapabilityFlag[],
 ): ConnectionModel[] {
   return connection.models.filter((m) => {
-    const have = new Set<string>(m.capabilities ?? []);
+    const have = effectiveCapabilities(m);
     return required.every((cap) => have.has(cap));
   });
 }

--- a/lib/domain/ai/features/router.ts
+++ b/lib/domain/ai/features/router.ts
@@ -106,58 +106,11 @@ export async function resolvePrimaryRoute(
   return all[0] ?? null;
 }
 
-/**
- * Infer capability flags from a model's id when the saved
- * `capabilities` array is missing or incomplete.
- *
- * Safety net for older Connection entries that were saved before the
- * fetcher's catalog augmentation existed (or for entries the user
- * added manually via the "Model ID" input, which has no capability
- * field). Lets feature routing find them as compatible pairs without
- * forcing the user to re-add their models.
- *
- * Only adds capabilities — never removes — so explicit `capabilities`
- * on the model still win. Patterns are deliberately conservative; we
- * recognize widely-documented model id stems rather than every
- * variant.
- */
-export function inferCapabilities(modelId: string): string[] {
-  // Strip a namespace prefix so `openai/dall-e-3` matches the same
-  // patterns as `dall-e-3`.
-  const slash = modelId.indexOf("/");
-  const bare = slash >= 0 ? modelId.slice(slash + 1) : modelId;
-  const out: string[] = [];
-
-  // Image generation models. These ids are stable across providers and
-  // gateways — DALL·E + GPT Image (OpenAI), Imagen (Google), FLUX
-  // (fal.ai / Together / Fireworks).
-  if (
-    /^dall-e/i.test(bare) ||
-    /^gpt-image/i.test(bare) ||
-    /^imagen/i.test(bare) ||
-    /\bflux\b/i.test(bare) ||
-    /^stable-diffusion/i.test(bare) ||
-    /^sdxl/i.test(bare)
-  ) {
-    out.push("image-generation");
-  }
-
-  return out;
-}
-
-/**
- * Effective capability set for a saved model: union of the explicit
- * `capabilities` array (catalog/fetcher-derived) and any flags
- * inferred from the model id. Use this anywhere a feature-routing
- * filter wants to know what a model can do.
- */
-export function effectiveCapabilities(
-  model: { id: string; capabilities?: string[] },
-): Set<string> {
-  const have = new Set<string>(model.capabilities ?? []);
-  for (const inferred of inferCapabilities(model.id)) have.add(inferred);
-  return have;
-}
+// Capability helpers live in `./capabilities.ts` so client components
+// can import them without dragging server-only deps through this file.
+// Re-export here so existing server-side callers keep working.
+export { inferCapabilities, effectiveCapabilities } from "./capabilities";
+import { effectiveCapabilities } from "./capabilities";
 
 function modelSatisfiesCapabilities(
   connection: ConnectionView,

--- a/lib/domain/ai/follow-ups.ts
+++ b/lib/domain/ai/follow-ups.ts
@@ -16,6 +16,11 @@ import { z } from "zod/v4";
 import { resolveChatModel } from "@/lib/domain/ai/providers/registry";
 import { resolvePrimaryRoute } from "@/lib/domain/ai/features/router";
 import { resolveChatModelFromConnection } from "@/lib/domain/ai/providers/registry";
+import {
+  getConnectionWithKey,
+  listConnections,
+} from "@/lib/features/ai-connections";
+import { logger } from "@/lib/core/logger";
 
 /** Zod schema for the generator's structured output. */
 const FollowUpsSchema = z.object({
@@ -51,18 +56,45 @@ export async function generateFollowUps(
 
   try {
     const route = await resolvePrimaryRoute(userId, "follow-ups");
-    const model = route
-      ? await resolveChatModelFromConnection(route.connection, route.modelId)
-      : await resolveChatModel({
-          providerId: (args.fallbackProviderId ?? "anthropic") as
+    let model;
+    if (route) {
+      // Configured Feature Route wins.
+      model = await resolveChatModelFromConnection(
+        route.connection,
+        route.modelId,
+      );
+    } else {
+      // Try Connection-based fallback first: look up any of the user's
+      // active Connections whose presetId matches the active chat's
+      // provider. This keeps follow-ups working even without an
+      // explicit Feature Route, AND avoids the legacy `resolveChatModel`
+      // path (which still references the deleted AIProviderKey table).
+      const fallbackProvider = args.fallbackProviderId ?? null;
+      const fallbackModel = args.fallbackModelId ?? null;
+      const all = await listConnections(userId);
+      const conn =
+        (fallbackProvider &&
+          all.find((c) => c.presetId === fallbackProvider)) ||
+        all[0];
+      if (conn && fallbackModel) {
+        // resolveChatModelFromConnection needs the decrypted key.
+        const withKey = await getConnectionWithKey(userId, conn.id);
+        model = await resolveChatModelFromConnection(withKey, fallbackModel);
+      } else {
+        // Last-resort legacy path. May throw if the AIProviderKey
+        // table is gone — caller catches and renders no suggestions.
+        model = await resolveChatModel({
+          providerId: (fallbackProvider ?? "anthropic") as
             | "anthropic"
             | "openai"
             | "google"
             | "xai"
             | "mistral"
             | "groq",
-          modelId: args.fallbackModelId ?? "claude-haiku-3-5",
+          modelId: fallbackModel ?? "claude-haiku-3-5",
         });
+      }
+    }
 
     const result = await generateObject({
       // resolveChat* returns the right language-model shape but the
@@ -84,7 +116,19 @@ export async function generateFollowUps(
     });
 
     return result.object.suggestions;
-  } catch {
+  } catch (err) {
+    // Log the actual failure so the silent return-[] doesn't hide
+    // real bugs (e.g. resolver broken, schema validation failing).
+    logger.warn({
+      layer: "ai",
+      event: "follow_ups.generate.failed",
+      summary: "follow-up generation failed; returning empty list",
+      error: err,
+      attrs: {
+        fallback_provider: args.fallbackProviderId ?? null,
+        fallback_model: args.fallbackModelId ?? null,
+      },
+    });
     return [];
   }
 }

--- a/lib/domain/ai/image/generate-via-gateway.ts
+++ b/lib/domain/ai/image/generate-via-gateway.ts
@@ -1,0 +1,81 @@
+/**
+ * Vercel AI Gateway image generation.
+ *
+ * The gateway's image API isn't a 1:1 OpenAI clone — it has its own
+ * curated model catalog (gpt-image-1 family, FLUX, Imagen-4, Recraft,
+ * Seedream, grok-imagine) and its own request/response shape per
+ * model. Raw fetch against /v1/images/generations works for some
+ * models but breaks for others.
+ *
+ * AI SDK's `experimental_generateImage` with `@ai-sdk/gateway` knows
+ * the catalog and normalizes the per-model response. Use it for any
+ * gateway-routed image request.
+ */
+
+import "server-only";
+import type {
+  ImageGenResult,
+  ImageProviderId,
+  ImageModelId,
+  ImageSize,
+} from "./types";
+
+interface GatewayImageGenInput {
+  prompt: string;
+  /** Namespaced gateway model id, e.g. "openai/gpt-image-1" */
+  modelId: string;
+  apiKey: string;
+  size?: ImageSize;
+  /** Canonical request providerId, used in the result for symmetry */
+  providerId: ImageProviderId;
+  /** Canonical request modelId, used in the result for symmetry */
+  canonicalModelId: ImageModelId;
+}
+
+export async function generateImageViaGateway(
+  input: GatewayImageGenInput,
+): Promise<ImageGenResult> {
+  // Dynamic imports keep the gateway SDK out of the bundle for any
+  // caller that doesn't actually hit this path.
+  const [{ createGatewayProvider }, { experimental_generateImage }] =
+    await Promise.all([
+      import("@ai-sdk/gateway"),
+      import("ai"),
+    ]);
+
+  const provider = createGatewayProvider({ apiKey: input.apiKey });
+  // imageModel accepts the gateway's GatewayImageModelId union — we
+  // cast because we validate the id existence by storing it via the
+  // catalog-augmented fetcher (`catalogImageModelsFor("vercel-gateway")`).
+  // The cast keeps the call site honest about the boundary.
+  const model = provider.imageModel(
+    input.modelId as Parameters<typeof provider.imageModel>[0],
+  );
+
+  const sized = input.size ?? "1024x1024";
+  const result = await experimental_generateImage({
+    model,
+    prompt: input.prompt,
+    n: 1,
+    size: sized,
+  });
+
+  // experimental_generateImage returns a GeneratedFile (or array). We
+  // pick the first image and surface its base64. Width/height parsed
+  // from the size string when the file doesn't carry them.
+  const file = result.image ?? result.images?.[0];
+  if (!file) {
+    throw new Error("Vercel AI Gateway returned no image data.");
+  }
+  const [w, h] = sized.split("x").map(Number);
+
+  return {
+    base64: file.base64,
+    url: "",
+    width: w,
+    height: h,
+    mimeType: file.mediaType ?? "image/png",
+    providerId: input.providerId,
+    modelId: input.canonicalModelId,
+  };
+}

--- a/lib/domain/ai/image/generate-via-gateway.ts
+++ b/lib/domain/ai/image/generate-via-gateway.ts
@@ -32,28 +32,75 @@ interface GatewayImageGenInput {
   canonicalModelId: ImageModelId;
 }
 
+/**
+ * Pattern matcher for models the gateway classifies as language models
+ * that happen to *output* images. They live behind `/v1/chat/completions`
+ * (not `/v1/images/generations`), so we have to use generateText and
+ * read result.files instead of experimental_generateImage.
+ *
+ * Currently covers Google's Gemini image-output channels: Nano Banana
+ * (`gemini-2.5-flash-image`), Nano Banana Pro (`gemini-3-pro-image`),
+ * and the various preview channels. xAI's grok-imagine also lives in
+ * this bucket on some routes; we let experimental_generateImage try
+ * first there and fall through on the typed error.
+ */
+function isLanguageAsImageModel(modelId: string): boolean {
+  return /^google\/gemini.*image/i.test(modelId);
+}
+
 export async function generateImageViaGateway(
   input: GatewayImageGenInput,
 ): Promise<ImageGenResult> {
   // Dynamic imports keep the gateway SDK out of the bundle for any
   // caller that doesn't actually hit this path.
-  const [{ createGatewayProvider }, { experimental_generateImage }] =
-    await Promise.all([
-      import("@ai-sdk/gateway"),
-      import("ai"),
-    ]);
+  const [{ createGatewayProvider }, ai] = await Promise.all([
+    import("@ai-sdk/gateway"),
+    import("ai"),
+  ]);
 
   const provider = createGatewayProvider({ apiKey: input.apiKey });
+  const sized = input.size ?? "1024x1024";
+  const [w, h] = sized.split("x").map(Number);
+
+  // ── Language-as-image route (Gemini image channels) ───────────
+  // The gateway rejects these on /v1/images/generations with a typed
+  // error; they only work via /v1/chat/completions. AI SDK's
+  // generateText returns the resulting image binaries on `result.files`.
+  if (isLanguageAsImageModel(input.modelId)) {
+    const model = provider.languageModel(
+      input.modelId as Parameters<typeof provider.languageModel>[0],
+    );
+    const result = await ai.generateText({
+      model,
+      prompt: input.prompt,
+    });
+    const file = result.files?.find((f) =>
+      (f.mediaType ?? "").startsWith("image/"),
+    );
+    if (!file) {
+      throw new Error(
+        `Model ${input.modelId} did not return an image (got ${result.files?.length ?? 0} files, ${result.text?.length ?? 0} text chars).`,
+      );
+    }
+    return {
+      base64: file.base64,
+      url: "",
+      width: w,
+      height: h,
+      mimeType: file.mediaType ?? "image/png",
+      providerId: input.providerId,
+      modelId: input.canonicalModelId,
+    };
+  }
+
+  // ── Standard image-API route ──────────────────────────────────
   // imageModel accepts the gateway's GatewayImageModelId union — we
   // cast because we validate the id existence by storing it via the
   // catalog-augmented fetcher (`catalogImageModelsFor("vercel-gateway")`).
-  // The cast keeps the call site honest about the boundary.
   const model = provider.imageModel(
     input.modelId as Parameters<typeof provider.imageModel>[0],
   );
-
-  const sized = input.size ?? "1024x1024";
-  const result = await experimental_generateImage({
+  const result = await ai.experimental_generateImage({
     model,
     prompt: input.prompt,
     n: 1,
@@ -67,7 +114,6 @@ export async function generateImageViaGateway(
   if (!file) {
     throw new Error("Vercel AI Gateway returned no image data.");
   }
-  const [w, h] = sized.split("x").map(Number);
 
   return {
     base64: file.base64,

--- a/lib/domain/ai/image/generate.ts
+++ b/lib/domain/ai/image/generate.ts
@@ -131,28 +131,42 @@ async function dispatchToProvider(
 // ─── OpenAI (DALL-E 3 / GPT Image 1) ──────────────────────────
 
 async function generateOpenAI(req: ResolvedRequest): Promise<ImageGenResult> {
+  // Gateway routing path: `upstreamModelId` is the namespaced form
+  // (e.g. `openai/dall-e-3`) that the gateway expects. Direct path:
+  // fall back to canonical model id via the bare-id map. The
+  // `bareModelId` is used for capability flag decisions (quality /
+  // style apply to dall-e-3 regardless of namespace).
   const modelMap: Record<string, string> = {
     "dall-e-3": "dall-e-3",
     "gpt-image-1": "gpt-image-1",
   };
-  const model = modelMap[req.modelId] ?? "dall-e-3";
+  const upstreamModel =
+    req.upstreamModelId ?? modelMap[req.modelId] ?? "dall-e-3";
+  const bareModelId = upstreamModel.includes("/")
+    ? upstreamModel.slice(upstreamModel.indexOf("/") + 1)
+    : upstreamModel;
 
   const body: Record<string, unknown> = {
-    model,
+    model: upstreamModel,
     prompt: req.prompt,
     n: 1,
     size: req.size,
   };
 
-  if (req.quality && model === "dall-e-3") body.quality = req.quality;
-  if (req.style && model === "dall-e-3") body.style = req.style;
+  if (req.quality && bareModelId === "dall-e-3") body.quality = req.quality;
+  if (req.style && bareModelId === "dall-e-3") body.style = req.style;
 
   // gpt-image-1 returns base64 by default
-  if (model === "gpt-image-1") {
+  if (bareModelId === "gpt-image-1") {
     body.output_format = "png";
   }
 
-  const res = await fetch("https://api.openai.com/v1/images/generations", {
+  // Endpoint: direct OpenAI by default, override when routing through a
+  // gateway (Vercel AI Gateway uses the same path under its own host).
+  const baseURL = req.apiBaseURL ?? "https://api.openai.com/v1";
+  const url = `${baseURL.replace(/\/$/, "")}/images/generations`;
+
+  const res = await fetch(url, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${req.apiKey}`,

--- a/lib/domain/ai/image/types.ts
+++ b/lib/domain/ai/image/types.ts
@@ -64,6 +64,24 @@ export interface ImageGenRequest {
   size?: ImageSize;
   /** BYOK API key (optional — falls back to stored key or env var) */
   apiKey?: string;
+  /**
+   * Optional base URL override. When set, the OpenAI dispatcher sends
+   * the request to `${apiBaseURL}/images/generations` instead of the
+   * provider's default endpoint. Used when routing image generation
+   * through a gateway (e.g. Vercel AI Gateway) whose API is
+   * OpenAI-compatible but lives at a different URL.
+   *
+   * The caller is responsible for ensuring `modelId` is the right
+   * form for the destination (`dall-e-3` for direct, `openai/dall-e-3`
+   * for namespaced gateway routing).
+   */
+  apiBaseURL?: string;
+  /**
+   * Resolved model id to send in the upstream request body. When
+   * gateway routing is active this differs from the request's
+   * canonical `modelId`. Defaults to `modelId` when omitted.
+   */
+  upstreamModelId?: string;
   /** Quality setting (provider-dependent) */
   quality?: "standard" | "hd";
   /** Style hint (provider-dependent) */

--- a/lib/domain/ai/use-conversation-binding.ts
+++ b/lib/domain/ai/use-conversation-binding.ts
@@ -263,6 +263,12 @@ export function useConversationBinding({
         partsToSave = pendingUserPartsRef.current;
         pendingUserPartsRef.current = null;
       }
+      // Forward UIMessage.metadata when present. The chat route's
+      // `messageMetadata` callback in toUIMessageStreamResponse populates
+      // `metadata.usage` (input/output/total tokens) + `finishReason` on
+      // the assistant message — the meter adapter reads those back for
+      // per-Connection $ figures.
+      const metadata = (m as { metadata?: Record<string, unknown> | undefined }).metadata;
       try {
         const res = await fetch(
           `/api/conversations/${encodeURIComponent(conversationId)}/messages`,
@@ -276,6 +282,7 @@ export function useConversationBinding({
               providerId: stamp.providerId,
               modelId: stamp.modelId,
               parts: partsToSave,
+              metadata: metadata ?? undefined,
             }),
           },
         );

--- a/lib/domain/ai/use-conversation-binding.ts
+++ b/lib/domain/ai/use-conversation-binding.ts
@@ -30,6 +30,22 @@ import { clientLogger } from "@/lib/core/logger/client";
 import { useAIChatStore } from "@/state/ai-chat-store";
 import { useSettingsStore } from "@/state/settings-store";
 
+/**
+ * Optional payload that flows through `persistRef.current(...)` to
+ * give persistTurns access to the SDK's onFinish snapshot — specifically
+ * the fresh assistant message with its `metadata` already populated.
+ * React's useCallback closure for persistTurns can capture a stale
+ * `messages` array when the SDK fires onFinish before React commits
+ * its metadata update; reading from this payload bypasses that race.
+ */
+export interface PersistFinishPayload {
+  /** Fresh assistant UIMessage from the AI SDK's onFinish event. */
+  freshAssistant?: {
+    id: string;
+    metadata?: Record<string, unknown> | unknown;
+  };
+}
+
 interface MessageLike {
   id: string;
   role: string;
@@ -57,7 +73,7 @@ interface UseConversationBindingParams {
   providerId: string;
   modelId: string;
   /** Stable ref the engine's onFinish closes over; we populate `.current`. */
-  persistRef: RefObject<() => void>;
+  persistRef: RefObject<(payload?: PersistFinishPayload) => void>;
   /**
    * Stable ref the engine's edit/regenerate handlers call to supersede
    * messages server-side (reconcile model). We populate `.current` with
@@ -249,7 +265,7 @@ export function useConversationBinding({
   }, [conversationId, setMessages, setActiveModelSelection, seedMessageStamps]);
 
   // ─── Persist-on-finish ───
-  const persistTurns = useCallback(async () => {
+  const persistTurns = useCallback(async (payload?: PersistFinishPayload) => {
     if (!conversationId || messages.length === 0) return;
     for (const m of messages) {
       if (m.role !== "user" && m.role !== "assistant") continue;
@@ -268,7 +284,25 @@ export function useConversationBinding({
       // `metadata.usage` (input/output/total tokens) + `finishReason` on
       // the assistant message — the meter adapter reads those back for
       // per-Connection $ figures.
-      const metadata = (m as { metadata?: Record<string, unknown> | undefined }).metadata;
+      //
+      // Read order:
+      //   1. The fresh assistant from the SDK's onFinish event (when
+      //      this is the assistant turn AND payload.freshAssistant
+      //      matches by id). The SDK applies metadata to its internal
+      //      state object just before firing onFinish, but the React
+      //      `messages` array we close over may not have flushed the
+      //      change yet. The event payload is fresher.
+      //   2. The closure UIMessage's own metadata field as a fallback.
+      let metadata =
+        (m as { metadata?: Record<string, unknown> | undefined }).metadata;
+      if (
+        m.role === "assistant" &&
+        payload?.freshAssistant &&
+        payload.freshAssistant.id === m.id &&
+        payload.freshAssistant.metadata != null
+      ) {
+        metadata = payload.freshAssistant.metadata as Record<string, unknown>;
+      }
       try {
         const res = await fetch(
           `/api/conversations/${encodeURIComponent(conversationId)}/messages`,

--- a/lib/domain/ai/use-conversation-engine.ts
+++ b/lib/domain/ai/use-conversation-engine.ts
@@ -377,24 +377,6 @@ export function useConversationEngine({
       };
       const finalMessages = e.messages ?? [];
 
-      // TEMP DIAGNOSTIC (A1-DEBUG): mirror what the SDK hands us so we
-      // can see whether the fresh assistant message has metadata at
-      // this seam. Remove once Phase 2 verified.
-      if (typeof window !== "undefined") {
-        const m = e.message as { id?: string; role?: string; metadata?: unknown } | undefined;
-        // eslint-disable-next-line no-console -- TODO(A1-debug): remove with diagnostic
-        console.log("[A1-DEBUG-CLIENT-ENGINE] onFinish", {
-          has_event_message: m != null,
-          event_message_id: m?.id ?? null,
-          event_message_metadata: m?.metadata ?? null,
-          messages_count: finalMessages.length,
-          last_message_metadata:
-            finalMessages.length > 0
-              ? (finalMessages[finalMessages.length - 1] as { metadata?: unknown }).metadata ?? null
-              : null,
-        });
-      }
-
       // Forward to the consumer's onFinish (persistence, etc.) first.
       if (onFinish) {
         onFinish({

--- a/lib/domain/ai/use-conversation-engine.ts
+++ b/lib/domain/ai/use-conversation-engine.ts
@@ -68,6 +68,14 @@ const chatTransport = new DefaultChatTransport({
  */
 export interface ConversationEngineFinishEvent {
   messages: UIMessage[];
+  /**
+   * The fresh final assistant message from the AI SDK's onFinish event.
+   * Carries `metadata` (token usage, finishReason) applied *just before*
+   * onFinish fired — typically not yet reflected in `messages` because
+   * the SDK mutates `state.message.metadata` directly without a
+   * setMessages flush. Use this when you need the latest metadata.
+   */
+  message?: UIMessage;
   finishReason?: string;
 }
 
@@ -363,15 +371,35 @@ export function useConversationEngine({
     },
     onFinish: (event) => {
       const e = event as {
+        message?: UIMessage;
         messages?: UIMessage[];
         finishReason?: string;
       };
       const finalMessages = e.messages ?? [];
 
+      // TEMP DIAGNOSTIC (A1-DEBUG): mirror what the SDK hands us so we
+      // can see whether the fresh assistant message has metadata at
+      // this seam. Remove once Phase 2 verified.
+      if (typeof window !== "undefined") {
+        const m = e.message as { id?: string; role?: string; metadata?: unknown } | undefined;
+        // eslint-disable-next-line no-console -- TODO(A1-debug): remove with diagnostic
+        console.log("[A1-DEBUG-CLIENT-ENGINE] onFinish", {
+          has_event_message: m != null,
+          event_message_id: m?.id ?? null,
+          event_message_metadata: m?.metadata ?? null,
+          messages_count: finalMessages.length,
+          last_message_metadata:
+            finalMessages.length > 0
+              ? (finalMessages[finalMessages.length - 1] as { metadata?: unknown }).metadata ?? null
+              : null,
+        });
+      }
+
       // Forward to the consumer's onFinish (persistence, etc.) first.
       if (onFinish) {
         onFinish({
           messages: finalMessages,
+          message: e.message,
           finishReason: e.finishReason,
         });
       }

--- a/lib/domain/ai/use-conversation-engine.ts
+++ b/lib/domain/ai/use-conversation-engine.ts
@@ -256,7 +256,6 @@ export function useConversationEngine({
   pendingUserPartsRef,
 }: UseConversationEngineParams): UseConversationEngineResult {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [input, setInput] = useState("");
 
   // ── Sticky drafts ──
   // Persist the in-progress prompt per chat to localStorage so users
@@ -266,19 +265,47 @@ export function useConversationEngine({
   //     drafts in multi-conversation notes;
   //   - contentId in transient mode (pre-Conversation) so a draft typed
   //     before sending the first message survives a quick reload.
-  // Cleared on send via the existing setInput("") (the persistence
-  // effect deletes the storage key when input is empty).
+  // Cleared on send via the existing setInput("") — the persistence
+  // effect deletes the storage key when input is empty.
   const draftStorageKey = conversationId
     ? `dg:chat-draft:conv:${conversationId}`
     : contentId
       ? `dg:chat-draft:content:${contentId}`
       : null;
-  const lastHydratedKeyRef = useRef<string | null>(null);
 
-  // Hydrate on key change. Setting input here also primes the
-  // lastHydratedKeyRef so the persistence effect below knows we're now
-  // synced and can start writing for this key.
+  /**
+   * Hydrate from localStorage at useState init time — NOT in a
+   * post-render useEffect. The useEffect-hydrate approach raced with
+   * the persistence effect on mount: hydrate queued setInput(saved),
+   * but the persistence effect ran in the same commit with input="",
+   * matched the gate (lastHydratedKeyRef was just set), and wrote ""
+   * to localStorage — wiping the draft before the setInput re-render
+   * had a chance to write it back.
+   *
+   * Lazy init runs once per mount BEFORE the first render, so input's
+   * initial value already reflects what's in localStorage. The
+   * persistence effect's first fire sees the correct value.
+   */
+  const [input, setInput] = useState<string>(() => {
+    if (typeof window === "undefined" || !draftStorageKey) return "";
+    try {
+      return window.localStorage.getItem(draftStorageKey) ?? "";
+    } catch {
+      return "";
+    }
+  });
+  // Initialize with the key we just hydrated from so the persistence
+  // effect can write immediately for that key without re-running
+  // hydrate.
+  const lastHydratedKeyRef = useRef<string | null>(draftStorageKey);
+
+  // Re-hydrate when the draft key changes WITHOUT a full remount
+  // (rare — most consumers re-key the surrounding component on chat
+  // switch). Gated to only fire when the key actually differs from
+  // the last hydrated one so the initial mount doesn't trigger this
+  // (useState lazy init already handled mount).
   useEffect(() => {
+    if (lastHydratedKeyRef.current === draftStorageKey) return;
     if (typeof window === "undefined" || !draftStorageKey) {
       lastHydratedKeyRef.current = null;
       return;
@@ -288,15 +315,14 @@ export function useConversationEngine({
       setInput(saved ?? "");
       lastHydratedKeyRef.current = draftStorageKey;
     } catch {
-      // localStorage unavailable (private mode / quota / disabled).
-      // Drafts gracefully degrade to in-memory only.
       lastHydratedKeyRef.current = draftStorageKey;
     }
   }, [draftStorageKey]);
 
-  // Persist on input change. The guard prevents writing the previous
-  // key's value into the new key during the brief gap between
-  // draftStorageKey changing and the hydrate effect running.
+  // Persist on input change. Gate prevents writing the previous key's
+  // value into the new key during the brief gap between draftStorageKey
+  // changing and the hydrate effect catching up (in the no-remount
+  // case).
   useEffect(() => {
     if (typeof window === "undefined" || !draftStorageKey) return;
     if (lastHydratedKeyRef.current !== draftStorageKey) return;

--- a/lib/domain/ai/use-conversation-engine.ts
+++ b/lib/domain/ai/use-conversation-engine.ts
@@ -258,6 +258,60 @@ export function useConversationEngine({
   const scrollRef = useRef<HTMLDivElement>(null);
   const [input, setInput] = useState("");
 
+  // ── Sticky drafts ──
+  // Persist the in-progress prompt per chat to localStorage so users
+  // returning to the same conversation (in the same browser) find what
+  // they were typing. Scope:
+  //   - conversationId when bound — finer-grained, supports per-chat
+  //     drafts in multi-conversation notes;
+  //   - contentId in transient mode (pre-Conversation) so a draft typed
+  //     before sending the first message survives a quick reload.
+  // Cleared on send via the existing setInput("") (the persistence
+  // effect deletes the storage key when input is empty).
+  const draftStorageKey = conversationId
+    ? `dg:chat-draft:conv:${conversationId}`
+    : contentId
+      ? `dg:chat-draft:content:${contentId}`
+      : null;
+  const lastHydratedKeyRef = useRef<string | null>(null);
+
+  // Hydrate on key change. Setting input here also primes the
+  // lastHydratedKeyRef so the persistence effect below knows we're now
+  // synced and can start writing for this key.
+  useEffect(() => {
+    if (typeof window === "undefined" || !draftStorageKey) {
+      lastHydratedKeyRef.current = null;
+      return;
+    }
+    try {
+      const saved = window.localStorage.getItem(draftStorageKey);
+      setInput(saved ?? "");
+      lastHydratedKeyRef.current = draftStorageKey;
+    } catch {
+      // localStorage unavailable (private mode / quota / disabled).
+      // Drafts gracefully degrade to in-memory only.
+      lastHydratedKeyRef.current = draftStorageKey;
+    }
+  }, [draftStorageKey]);
+
+  // Persist on input change. The guard prevents writing the previous
+  // key's value into the new key during the brief gap between
+  // draftStorageKey changing and the hydrate effect running.
+  useEffect(() => {
+    if (typeof window === "undefined" || !draftStorageKey) return;
+    if (lastHydratedKeyRef.current !== draftStorageKey) return;
+    try {
+      if (input.length > 0) {
+        window.localStorage.setItem(draftStorageKey, input);
+      } else {
+        window.localStorage.removeItem(draftStorageKey);
+      }
+    } catch {
+      // localStorage write failures are non-blocking — drafts stay
+      // in-memory until next key change or page reload.
+    }
+  }, [input, draftStorageKey]);
+
   const { providerId, modelId, handleChange: handleModelChange } =
     useModelSelection();
 

--- a/lib/domain/editor/commands/slash-commands.tsx
+++ b/lib/domain/editor/commands/slash-commands.tsx
@@ -634,6 +634,20 @@ export function getSlashCommands(): SlashCommand[] {
       },
       aliases: ["img", "picture", "photo"],
     },
+    // AI image generation — opens the same AiImageGenDialog used by the
+    // file-tree right-click flow, but on success dispatches the existing
+    // `insert-ai-image` event so the image lands inline at the cursor.
+    // MarkdownEditor mounts the dialog in response to this event.
+    {
+      title: "AI Image",
+      description: "Generate an image with AI and insert at cursor",
+      icon: "✨",
+      command: ({ editor, range }) => {
+        editor.chain().focus().deleteRange(range).run();
+        window.dispatchEvent(new CustomEvent("editor-open-ai-image"));
+      },
+      aliases: ["ai-image", "generate image", "dalle", "imagen", "ai picture"],
+    },
     // M6: Tag insertion
     {
       title: "Tag",

--- a/lib/features/ai-connections/fetch-models.ts
+++ b/lib/features/ai-connections/fetch-models.ts
@@ -224,17 +224,28 @@ export async function fetchUpstreamModels(
 }
 
 /**
- * Return image-gen model entries from `IMAGE_PROVIDER_CATALOG` whose
- * provider matches this Connection's adapter, normalized to the
- * `FetchedModel` shape with `image-generation` capability set.
+ * Return image-gen model entries from `IMAGE_PROVIDER_CATALOG` for
+ * this Connection's adapter, normalized to `FetchedModel` with
+ * `image-generation` capability set.
  *
- * Returns empty for adapters that don't have a corresponding image
- * provider in the catalog (xai, mistral, groq, openai-compat, etc.).
+ * Two patterns:
+ *
+ *   1. **Direct adapter** (openai, google, together, fireworks): the
+ *      Connection's models[] holds bare ids like `dall-e-3`. The chat
+ *      route's direct-match resolver routes by Connection.presetId.
+ *
+ *   2. **Gateway adapter** (vercel-gateway): the Connection's models[]
+ *      holds namespaced ids like `openai/dall-e-3`. The chat route's
+ *      namespaced-fallback resolver routes by the prefix. Vercel AI
+ *      Gateway proxies image generation for several labs, so we emit
+ *      the cartesian: every catalog provider's models, each prefixed
+ *      with the provider id.
+ *
+ * Returns empty for adapters with no image-gen surface (xai, mistral,
+ * groq, openai-compat, openrouter).
  */
 function catalogImageModelsFor(adapterKind: string): FetchedModel[] {
-  // adapter kind → image catalog provider id. They mostly line up
-  // 1:1; this map exists so we can adjust without re-keying the
-  // catalog.
+  // Direct: 1:1 mapping from adapter → image catalog provider id.
   const adapterToCatalog: Record<string, string> = {
     openai: "openai",
     google: "google",
@@ -242,14 +253,36 @@ function catalogImageModelsFor(adapterKind: string): FetchedModel[] {
     fireworks: "fireworks",
   };
   const catalogId = adapterToCatalog[adapterKind];
-  if (!catalogId) return [];
-  const provider = IMAGE_PROVIDER_CATALOG.find((p) => p.id === catalogId);
-  if (!provider) return [];
-  return provider.models.map((m) => ({
-    id: m.id,
-    name: m.name,
-    capabilities: ["image-generation"],
-  }));
+  if (catalogId) {
+    const provider = IMAGE_PROVIDER_CATALOG.find((p) => p.id === catalogId);
+    if (!provider) return [];
+    return provider.models.map((m) => ({
+      id: m.id,
+      name: m.name,
+      capabilities: ["image-generation"],
+    }));
+  }
+
+  // Gateway: emit namespaced entries for providers the gateway proxies.
+  // Vercel AI Gateway covers the full big-three labs; OpenRouter is
+  // chat-only and intentionally excluded.
+  if (adapterKind === "vercel-gateway") {
+    const gatewayProxiedProviders = new Set(["openai", "google"]);
+    const out: FetchedModel[] = [];
+    for (const provider of IMAGE_PROVIDER_CATALOG) {
+      if (!gatewayProxiedProviders.has(provider.id)) continue;
+      for (const m of provider.models) {
+        out.push({
+          id: `${provider.id}/${m.id}`,
+          name: m.name,
+          capabilities: ["image-generation"],
+        });
+      }
+    }
+    return out;
+  }
+
+  return [];
 }
 
 /** Parse OpenAI-shaped responses: `{ data: [...] }` or bare `[...]`. */

--- a/lib/features/ai-connections/fetch-models.ts
+++ b/lib/features/ai-connections/fetch-models.ts
@@ -276,6 +276,7 @@ function catalogImageModelsFor(adapterKind: string): FetchedModel[] {
   // ids the gateway is known to accept.
   if (adapterKind === "vercel-gateway") {
     const VERCEL_GATEWAY_IMAGE_MODELS: Array<{ id: string; name: string }> = [
+      // Classical image API (POST /v1/images/generations)
       { id: "openai/gpt-image-1", name: "GPT Image 1" },
       { id: "openai/gpt-image-1-mini", name: "GPT Image 1 Mini" },
       { id: "google/imagen-4.0-generate-001", name: "Imagen 4" },
@@ -288,6 +289,12 @@ function catalogImageModelsFor(adapterKind: string): FetchedModel[] {
       { id: "bytedance/seedream-4.0", name: "Seedream 4.0" },
       { id: "recraft/recraft-v3", name: "Recraft v3" },
       { id: "xai/grok-imagine-image", name: "Grok Imagine" },
+      // Language-as-image: gateway classifies these as language models
+      // but they emit image binaries via /v1/chat/completions. Route
+      // dispatches to `generateText` + `result.files` for these.
+      { id: "google/gemini-2.5-flash-image", name: "Nano Banana (Gemini 2.5 Flash Image)" },
+      { id: "google/gemini-3-pro-image", name: "Nano Banana Pro (Gemini 3 Pro Image)" },
+      { id: "google/gemini-3.1-flash-image-preview", name: "Gemini 3.1 Flash Image (Preview)" },
     ];
     return VERCEL_GATEWAY_IMAGE_MODELS.map((m) => ({
       ...m,

--- a/lib/features/ai-connections/fetch-models.ts
+++ b/lib/features/ai-connections/fetch-models.ts
@@ -263,23 +263,36 @@ function catalogImageModelsFor(adapterKind: string): FetchedModel[] {
     }));
   }
 
-  // Gateway: emit namespaced entries for providers the gateway proxies.
-  // Vercel AI Gateway covers the full big-three labs; OpenRouter is
-  // chat-only and intentionally excluded.
+  // Vercel AI Gateway: its image-model catalog is curated and does NOT
+  // simply mirror OpenAI's direct list. DALL·E 3 is not proxied (you
+  // get gpt-image-1 instead); Google offers Imagen 4 (not Imagen 3);
+  // and the gateway adds BFL FLUX, Recraft, Bytedance Seedream, and
+  // xAI grok-imagine alongside.
+  //
+  // The ids below come from `@ai-sdk/gateway`'s `GatewayImageModelId`
+  // type (introspected 2026-05-30). Update when the SDK ships an
+  // updated catalog. Emitting bogus ids breaks generation downstream
+  // because the gateway returns "Model not found" — so we only ship
+  // ids the gateway is known to accept.
   if (adapterKind === "vercel-gateway") {
-    const gatewayProxiedProviders = new Set(["openai", "google"]);
-    const out: FetchedModel[] = [];
-    for (const provider of IMAGE_PROVIDER_CATALOG) {
-      if (!gatewayProxiedProviders.has(provider.id)) continue;
-      for (const m of provider.models) {
-        out.push({
-          id: `${provider.id}/${m.id}`,
-          name: m.name,
-          capabilities: ["image-generation"],
-        });
-      }
-    }
-    return out;
+    const VERCEL_GATEWAY_IMAGE_MODELS: Array<{ id: string; name: string }> = [
+      { id: "openai/gpt-image-1", name: "GPT Image 1" },
+      { id: "openai/gpt-image-1-mini", name: "GPT Image 1 Mini" },
+      { id: "google/imagen-4.0-generate-001", name: "Imagen 4" },
+      { id: "google/imagen-4.0-fast-generate-001", name: "Imagen 4 Fast" },
+      { id: "google/imagen-4.0-ultra-generate-001", name: "Imagen 4 Ultra" },
+      { id: "bfl/flux-2-pro", name: "FLUX 2 Pro" },
+      { id: "bfl/flux-2-max", name: "FLUX 2 Max" },
+      { id: "bfl/flux-pro-1.1", name: "FLUX Pro 1.1" },
+      { id: "bfl/flux-pro-1.1-ultra", name: "FLUX Pro 1.1 Ultra" },
+      { id: "bytedance/seedream-4.0", name: "Seedream 4.0" },
+      { id: "recraft/recraft-v3", name: "Recraft v3" },
+      { id: "xai/grok-imagine-image", name: "Grok Imagine" },
+    ];
+    return VERCEL_GATEWAY_IMAGE_MODELS.map((m) => ({
+      ...m,
+      capabilities: ["image-generation"],
+    }));
   }
 
   return [];

--- a/lib/features/ai-connections/usage/gateway.ts
+++ b/lib/features/ai-connections/usage/gateway.ts
@@ -1,7 +1,7 @@
 /**
- * Gateway-specific real-usage adapters.
+ * Provider-specific real-usage adapters.
  *
- * Currently:
+ * **Working adapters (real per-key endpoints):**
  *   - **OpenRouter** — `GET /api/v1/key` returns the gateway's own
  *     accounting: total credits used (USD), remaining limit, label.
  *     Authoritative for cost; we don't need to maintain a price table
@@ -11,9 +11,19 @@
  *     the upstream cooperates; otherwise we throw and fall through to
  *     telemetry.
  *
- * Both adapters return `null` when the upstream call fails — the
- * caller falls through to the telemetry-only path so the user still
- * sees *something*.
+ * **Documented null adapters (no per-key endpoint exists):**
+ *   - **Anthropic** — usage is org-scoped via the Anthropic Console.
+ *     There is no `GET /v1/keys/<key>/usage` style endpoint. Adapter
+ *     returns null unconditionally so the composer falls through to
+ *     telemetry. If Anthropic ships a usage API, replace the body.
+ *   - **Google (Gemini)** — usage flows through Google Cloud billing,
+ *     which is project-scoped, not API-key-scoped. The Generative
+ *     Language API exposes no per-key usage endpoint. Same null
+ *     fallthrough as Anthropic.
+ *
+ * All adapters return `null` when the upstream call fails or when no
+ * endpoint is available — the caller composer falls through to the
+ * telemetry-only path so the user still sees *something*.
  */
 
 import type { ConnectionWithKey } from "../types";
@@ -152,5 +162,37 @@ function pickNumber(
     const v = obj[k];
     if (typeof v === "number" && Number.isFinite(v)) return v;
   }
+  return null;
+}
+
+/**
+ * Anthropic — no public per-API-key usage endpoint exists.
+ *
+ * Usage data is available org-wide in the Anthropic Console UI but is
+ * not exposed via a programmatic API at the key level. This stub
+ * returns null so the composer falls through to telemetry.
+ *
+ * Replace the body if Anthropic ships a per-key usage endpoint.
+ */
+export async function fetchAnthropicUsage(
+  conn: ConnectionWithKey,
+): Promise<UsageReport | null> {
+  void conn;
+  return null;
+}
+
+/**
+ * Google (Gemini) — no per-key usage endpoint.
+ *
+ * Google Cloud billing is project-scoped, not key-scoped. The
+ * Generative Language API doesn't expose per-key usage. This stub
+ * returns null; the composer uses telemetry.
+ *
+ * Replace the body if Google ships a per-key usage endpoint.
+ */
+export async function fetchGoogleUsage(
+  conn: ConnectionWithKey,
+): Promise<UsageReport | null> {
+  void conn;
   return null;
 }

--- a/lib/features/ai-connections/usage/index.ts
+++ b/lib/features/ai-connections/usage/index.ts
@@ -18,6 +18,8 @@ import {
 } from "../service";
 import { buildTelemetryReport } from "./telemetry";
 import {
+  fetchAnthropicUsage,
+  fetchGoogleUsage,
   fetchOpenRouterUsage,
   fetchVercelGatewayUsage,
 } from "./gateway";
@@ -66,10 +68,15 @@ export async function getConnectionUsage(
   });
 
   // Best-effort provider-API call for "real" numbers. Returns null on
-  // any failure (including "this adapter doesn't apply").
+  // any failure (including "this adapter doesn't apply"). The
+  // Anthropic + Google stubs always return null — those providers
+  // don't expose per-key usage endpoints — but are listed here as
+  // documentation that we've considered them.
   const provider =
     (await fetchOpenRouterUsage(conn)) ??
     (await fetchVercelGatewayUsage(conn)) ??
+    (await fetchAnthropicUsage(conn)) ??
+    (await fetchGoogleUsage(conn)) ??
     null;
 
   if (!provider) return telemetry;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:collab": "tsx server/hocuspocus/bootstrap.ts",
     "typecheck": "tsc --noEmit",
     "build": "prisma generate && pnpm build:tokens && tsc --noEmit && pnpm collab:schema:check && pnpm lint && next build --webpack",
-    "vercel-build": "prisma generate && pnpm build:tokens && NODE_OPTIONS='--max-old-space-size=6144' next build --webpack",
+    "vercel-build": "prisma generate && pnpm build:tokens && NODE_OPTIONS='--max-old-space-size=5120' next build --webpack",
     "start": "next start",
     "lint": "eslint --max-warnings 159",
     "lint:publishing": "eslint extensions/publishing/ lib/domain/blocks/ app/api/publishing/ components/public/ lib/domain/editor/commands/slash-commands-menu.tsx lib/domain/editor/commands/slash-commands.tsx lib/domain/editor/extensions/blocks/pull-quote.ts lib/domain/editor/extensions/blocks/table-of-contents.ts components/content/blocks/JsonArrayEditor.tsx components/content/editor/ImageBubbleMenu.tsx",

--- a/prisma/migrations/20260530150000_baseline_ai_chat_tables/migration.sql
+++ b/prisma/migrations/20260530150000_baseline_ai_chat_tables/migration.sql
@@ -1,0 +1,163 @@
+-- Baseline AI Chat Revamp tables.
+--
+-- These tables (AIConnection, AIFeatureRoute, Conversation,
+-- ConversationMessage, ConversationAssociation) were introduced during
+-- the AI Chat Revamp epic but were applied to dev/prod via
+-- `prisma db push` without ever being committed to the migration
+-- history. This migration brings the migration history in line with
+-- what schema.prisma has declared.
+--
+-- Every statement is idempotent — `CREATE TABLE IF NOT EXISTS`, native
+-- where possible; `DO` blocks for enum + constraint creation (Postgres
+-- has no native `IF NOT EXISTS` for those). Safe to apply against:
+--   - dev (tables exist; this is a no-op + immediately marked applied
+--     via `prisma migrate resolve --applied 20260530150000_...`)
+--   - prod (tables exist from earlier `db push` deploys; this is a
+--     no-op + same `migrate resolve` step)
+--   - fresh installs / preview branches (tables don't exist; this
+--     creates them).
+
+-- ─── Enums ──────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  CREATE TYPE "ChatMessageRole" AS ENUM ('user', 'assistant', 'system', 'tool');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "ConversationAssociationSource" AS ENUM ('snapshot', 'manual', 'auto');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "ConnectionKind" AS ENUM ('direct', 'gateway', 'custom');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- ─── Tables ─────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "Conversation" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "ownerId" UUID NOT NULL,
+    "title" VARCHAR(255),
+    "archivedToContentNodeId" UUID,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+    "deletedAt" TIMESTAMPTZ(6),
+
+    CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "ConversationMessage" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "conversationId" UUID NOT NULL,
+    "role" "ChatMessageRole" NOT NULL,
+    "providerId" VARCHAR(50),
+    "modelId" VARCHAR(100),
+    "parts" JSONB NOT NULL,
+    "textCache" TEXT,
+    "parentId" UUID,
+    "isHidden" BOOLEAN NOT NULL DEFAULT false,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ConversationMessage_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "ConversationAssociation" (
+    "conversationId" UUID NOT NULL,
+    "contentNodeId" UUID NOT NULL,
+    "source" "ConversationAssociationSource" NOT NULL,
+    "lastReferencedAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "referenceCount" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ConversationAssociation_pkey" PRIMARY KEY ("conversationId","contentNodeId")
+);
+
+CREATE TABLE IF NOT EXISTS "AIConnection" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "ownerId" UUID NOT NULL,
+    "kind" "ConnectionKind" NOT NULL,
+    "presetId" VARCHAR(50),
+    "label" VARCHAR(120) NOT NULL,
+    "baseURL" VARCHAR(500),
+    "encryptedKey" TEXT NOT NULL,
+    "adapterKind" VARCHAR(50) NOT NULL,
+    "models" JSONB NOT NULL DEFAULT '[]',
+    "isPinned" BOOLEAN NOT NULL DEFAULT false,
+    "pinOrder" INTEGER,
+    "preferRouteVia" UUID,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+    "deletedAt" TIMESTAMPTZ(6),
+
+    CONSTRAINT "AIConnection_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "AIFeatureRoute" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "ownerId" UUID NOT NULL,
+    "featureId" VARCHAR(100) NOT NULL,
+    "position" INTEGER NOT NULL,
+    "connectionId" UUID NOT NULL,
+    "modelId" VARCHAR(100) NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "AIFeatureRoute_pkey" PRIMARY KEY ("id")
+);
+
+-- ─── Indexes ────────────────────────────────────────────────────────
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Conversation_archivedToContentNodeId_key" ON "Conversation"("archivedToContentNodeId");
+CREATE INDEX IF NOT EXISTS "Conversation_ownerId_updatedAt_idx" ON "Conversation"("ownerId", "updatedAt");
+CREATE INDEX IF NOT EXISTS "Conversation_ownerId_deletedAt_idx" ON "Conversation"("ownerId", "deletedAt");
+CREATE INDEX IF NOT EXISTS "ConversationMessage_conversationId_createdAt_idx" ON "ConversationMessage"("conversationId", "createdAt");
+CREATE INDEX IF NOT EXISTS "ConversationMessage_conversationId_parentId_idx" ON "ConversationMessage"("conversationId", "parentId");
+CREATE INDEX IF NOT EXISTS "ConversationAssociation_contentNodeId_idx" ON "ConversationAssociation"("contentNodeId");
+CREATE INDEX IF NOT EXISTS "ConversationAssociation_conversationId_source_lastReference_idx" ON "ConversationAssociation"("conversationId", "source", "lastReferencedAt");
+CREATE INDEX IF NOT EXISTS "AIConnection_ownerId_kind_idx" ON "AIConnection"("ownerId", "kind");
+CREATE INDEX IF NOT EXISTS "AIConnection_ownerId_isPinned_pinOrder_idx" ON "AIConnection"("ownerId", "isPinned", "pinOrder");
+CREATE INDEX IF NOT EXISTS "AIConnection_ownerId_deletedAt_idx" ON "AIConnection"("ownerId", "deletedAt");
+CREATE INDEX IF NOT EXISTS "AIFeatureRoute_ownerId_featureId_idx" ON "AIFeatureRoute"("ownerId", "featureId");
+CREATE INDEX IF NOT EXISTS "AIFeatureRoute_connectionId_idx" ON "AIFeatureRoute"("connectionId");
+CREATE UNIQUE INDEX IF NOT EXISTS "AIFeatureRoute_ownerId_featureId_position_key" ON "AIFeatureRoute"("ownerId", "featureId", "position");
+
+-- ─── Foreign keys ───────────────────────────────────────────────────
+--
+-- Postgres has no `ADD CONSTRAINT IF NOT EXISTS`; we wrap each in a
+-- DO block that checks pg_constraint by name first.
+
+DO $$ BEGIN
+  ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_archivedToContentNodeId_fkey" FOREIGN KEY ("archivedToContentNodeId") REFERENCES "ContentNode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "ConversationMessage" ADD CONSTRAINT "ConversationMessage_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "ConversationMessage" ADD CONSTRAINT "ConversationMessage_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "ConversationMessage"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "ConversationAssociation" ADD CONSTRAINT "ConversationAssociation_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "ConversationAssociation" ADD CONSTRAINT "ConversationAssociation_contentNodeId_fkey" FOREIGN KEY ("contentNodeId") REFERENCES "ContentNode"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "AIConnection" ADD CONSTRAINT "AIConnection_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "AIFeatureRoute" ADD CONSTRAINT "AIFeatureRoute_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "AIFeatureRoute" ADD CONSTRAINT "AIFeatureRoute_connectionId_fkey" FOREIGN KEY ("connectionId") REFERENCES "AIConnection"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;


### PR DESCRIPTION
Follow-up polish on top of #48 (AI Chat Revamp epic). 27 commits, 43 files, +1450/-648. Each fix landed incrementally with smoke-test feedback in development.

## Summary by theme

### Token capture meters (Phase 2)

The per-Connection usage meter never showed `$` figures or token counts because the chain from server `messageMetadata` callback → AI SDK `useChat` state → `persistTurns` was being broken by a React stale-closure: the SDK mutates `state.message.metadata` directly without `setState`, so by the time `persistTurns` fired in `onFinish`, the closure-captured `messages` array still had no metadata, and `""` was persisted.

- `4d1e11f` initial `messageMetadata` wiring on server + client
- `e468f68` baseline migration committing the AI Chat tables to migration history
- `dc91f18` + `d384d85` diagnostic logging (later removed in `72f73e3`)
- `4c2a33c` **the fix**: thread the SDK's `event.message` (fresh assistant w/ metadata) through `persistRef({ freshAssistant })`, bypassing the stale closure
- `c9dcc6a` follow-ups: Connection-aware fallback when no Feature Route configured (the legacy resolver referenced the dropped `AIProviderKey` table)

### Image generation routing

Vercel AI Gateway's image API isn't a 1:1 OpenAI clone — it has its own curated model catalog (gpt-image-1 not DALL·E 3, Imagen 4 not Imagen 3) and segregates language-as-image variants (Nano Banana, gpt-3-pro-image) onto `/v1/chat/completions`. Multiple fixes:

- `788c5e1` resolver also tries namespaced match in gateway Connections (not only `presetId` direct match)
- `eadf87a` route via `@ai-sdk/gateway` + `experimental_generateImage` instead of raw fetch
- `52bcee3` detect Gemini image variants and route through `generateText` with `result.files`
- `12d178c` capability inference recognizes Gemini-`*-image*`, Recraft, Seedream, Grok Imagine patterns
- `ed6b729` capability inference as a safety net for older entries saved without explicit flags
- `7efbfac` client-safe split of capability helpers (the prior commit dragged `next/headers` into a client component)
- `8b96caa` AI Image dialog merges Connection image models with static catalog so user-added entries surface
- `1c35c9f` chat picker dropdown merges Connection models into provider groups (so user-added gateway models like `openai/gpt-5.2` actually appear under OpenAI)
- `2b837b3` Anthropic/Google usage adapter null stubs documenting "no per-key endpoint exists"
- `efb6142` image-gen catalog augmentation for gateway adapter

### Settings UX

- `724d6bc` back button in settings sidebar
- `694e604` back button returns to last *content* route instead of stepping through internal settings history (uses sessionStorage tracker in `NotesLayoutMarker`)

### Editor / chat surface

- `4e45356` `/ai-image` slash command for inline image generation in documents
- `80b7461` a11y: tab strip arrow nav, streaming `aria-live`, focus-visible rings on action bar
- `fba26bf` user-message edit textarea matches view bubble styling
- `3c854d4` edit textarea uses `field-sizing: content` so it shrinks to text width like the view bubble

### Performance + hydration races

- `5984435` file-tree fix: gate first `/api/content/content/tree` fetch on workspace store hydration (was double-fetching on every cold load — once with null workspace context, once after the store hydrated; ~3s wasted per cold load)
- `d473777` right-sidebar hydration race: persisted saved tab was getting clobbered on reload through two mechanisms — auto-correct effect writing fallback before Zustand persistence hydrated, and stale `selectedBlockId` on mount triggering a phantom "user selected block" write. Both effects now gate on `persist.hasHydrated()`.
- `9567695` workspace cold-load race: when the workspace API resolved before `MainPanelWorkspace`'s URL parser ran, `restoreContentWorkspace` populated `openContentIds` with the persisted active tab instead of the URL's `?content=` ID — so deep-linking to tab 3 loaded tabs 1 and 2 first while tab 3 loaded last. URL `content=` now wins as the active tab when that ID belongs to the workspace's items (membership gating preserves the manual workspace-switch path).
- `635bc9b` loading skeleton: replace hardcoded `border-white/10` / `text-gray-400` / `bg-white/5` with theme-aware tokens (`border-border`, `text-muted-foreground`, `bg-muted`), and drop the fake "Welcome.md" tab title in favor of a neutral icon/title skeleton so the title doesn't visibly swap on hydrate.
- `8293b3e` loading skeleton: omit the right sidebar entirely. `useRightPanelCollapseStore` defaults to `isCollapsed: true`, but `loading.tsx` unconditionally painted a 300px right sidebar — producing a "side panel transitioning out of the right side of the viewport" flicker on every cold load. Main panel claims the space; if the user has the right panel expanded it slides in once on hydration (one-directional appearance instead of a two-frame layout swap).

### Sticky drafts (partial)

- `99ff062` initial sticky drafts in localStorage, keyed per conversation
- `9e373f1` move hydration into `useState` lazy init to avoid effect-ordering race

**Status: still not fully working** in user testing. Documented as a known followup for next session.

### Build

- `0807a09` bump Node heap to 6144MB in `vercel-build` (heap was OOM-SIGKILL on Vercel)
- `c54e6d7` add `typescript.ignoreBuildErrors` to skip Next's redundant in-build TS pass (saves ~2 min and reduces memory pressure)
- `ca9fa0b` drop invalid `eslint` config property (Next.js 16 removed it; only `typescript` is supported)
- `ffe7e31` lower Vercel Node heap from 6144→5120MB. The 6144 cap was too aggressive for an 8 GB build container once subprocesses got involved: `NODE_OPTIONS` is inherited by every child Next.js spawns (page-data worker, static-page generator, trace collector), so two of them trying to expand toward 6 GB simultaneously OOM'd the container during "Collecting build traces". 5120 still leaves 1 GB above the original 4 GB default that triggered the first bump, but gives ~3 GB headroom for subprocess overhead.

## Known gaps (followups)

- **Sticky drafts** — implementation lands the value at first render via `useState` init but doesn't survive chat tab switches in the user's testing. Needs deeper investigation into how `ChatPanel`'s `key={activeId}` remount interacts with localStorage timing.
- **Wide loader → sized loader sequence on cold load** — left sidebar skeleton paints at default width before localStorage panel-width is applied. Low priority cosmetic.
- **Brief flash between `loading.tsx` and hydrated content** — addressed by `8293b3e` after a slow-mo recording showed the right sidebar collapsing on hydrate. If a residual flicker remains it's a separate issue (most likely the main-panel SSR/hydration paint sequence — needs DevTools paint capture to confirm).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors, 157 warnings (baseline)
- [x] `NODE_OPTIONS='--max-old-space-size=6144' pnpm build` — green
- [x] Manual: send chat → meter card shows non-zero `$` + tokens for the new turn (older turns stay request-only since they predate the fix)
- [x] Manual: gateway image gen with Nano Banana / Nano Banana Pro / gpt-image-1 — generates successfully
- [x] Manual: right-sidebar tab preference survives hard refresh across multiple content nodes; no flicker through Timeline-block properties or other defaults
- [x] Manual: file tree loads ONCE (verify in DevTools Network — only one `/api/content/content/tree` call per cold load)
- [x] Manual: settings → click around → click Back → returns to the note you were on (not previous settings sub-page)
- [x] Manual: `/ai-image` in any note opens the dialog; submitted images insert inline at cursor
- [x] Manual: keyboard-only navigation through chat tab strip with arrow keys + Home/End

🤖 Generated with [Claude Code](https://claude.com/claude-code)
