### PR TITLE
feat(tenancy): platform gate + Sites UX + reserved slugs + subdomain-only addressing (Phases 13-15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,9 @@ yarn-error.log*
 **/* [0-9].txt
 
 # ── archived apps (not in build) ────────────────────────────────────────────
-archive/
+# Root-scoped — applies only to the top-level /archive directory, not
+# subdirectories named "archive" elsewhere in the tree (e.g. API routes).
+/archive/
 
 # git worktrees (local-only dev artifact)
 .worktrees/

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -85,8 +85,30 @@ export default function SignInPage() {
         </div>
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
-            <div className="rounded-md bg-red-50 dark:bg-red-500/10 p-4">
-              <div className="text-sm text-red-800 dark:text-red-300">{error}</div>
+            <div
+              role="alert"
+              aria-live="polite"
+              className="rounded-md border border-red-400 dark:border-red-500/50 bg-red-50 dark:bg-red-500/15 p-4"
+            >
+              <div className="flex items-start gap-2">
+                <svg
+                  className="w-4 h-4 mt-0.5 shrink-0 text-red-700 dark:text-red-300"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <line x1="12" y1="8" x2="12" y2="12" />
+                  <line x1="12" y1="16" x2="12.01" y2="16" />
+                </svg>
+                <div className="text-sm font-medium text-red-900 dark:text-red-200">
+                  {error}
+                </div>
+              </div>
             </div>
           )}
           <div className="space-y-4 rounded-md shadow-sm">

--- a/app/(authenticated)/settings/sites/page.tsx
+++ b/app/(authenticated)/settings/sites/page.tsx
@@ -195,22 +195,11 @@ export default function SitesSettingsPage() {
         </p>
         {platformDomain && (
           <div className="mt-4 rounded-md border border-sky-500/30 bg-sky-500/5 p-3 text-xs text-sky-100/80">
-            <div className="font-medium text-sky-200 mb-1">
-              Every site you create is reachable at two URLs automatically:
-            </div>
-            <ul className="list-disc list-inside space-y-0.5">
-              <li>
-                <code className="font-mono">your-slug.{platformDomain}</code>{" "}
-                (subdomain)
-              </li>
-              <li>
-                <code className="font-mono">{platformDomain}/u/your-slug</code>{" "}
-                (subpath, works as a fallback)
-              </li>
-            </ul>
-            <div className="mt-2 text-sky-100/60">
-              To use a domain you already own (e.g.{" "}
-              <code className="font-mono">yoursite.com</code>), expand a site
+            <div className="text-sky-200">
+              Every site is reachable at{" "}
+              <code className="font-mono">your-slug.{platformDomain}</code>{" "}
+              automatically. Want to use a domain you already own (e.g.{" "}
+              <code className="font-mono">yoursite.com</code>)? Expand a site
               below and open its <em>Hosts</em> section.
             </div>
           </div>
@@ -341,10 +330,8 @@ export default function SitesSettingsPage() {
                           {site.slug}
                         </div>
                         {platformDomain && (
-                          <div className="text-[11px] text-white/30 font-mono mt-1 space-x-2">
-                            <span>{site.slug}.{platformDomain}</span>
-                            <span className="text-white/15">·</span>
-                            <span>{platformDomain}/u/{site.slug}</span>
+                          <div className="text-[11px] text-white/30 font-mono mt-1">
+                            {site.slug}.{platformDomain}
                           </div>
                         )}
                       </>

--- a/app/(authenticated)/settings/sites/page.tsx
+++ b/app/(authenticated)/settings/sites/page.tsx
@@ -27,6 +27,7 @@ type SiteRow = {
 type SitesResponse = {
   tenants: SiteRow[];
   primaryTenantId: string | null;
+  platformDomain: string | null;
 };
 
 export default function SitesSettingsPage() {
@@ -34,6 +35,7 @@ export default function SitesSettingsPage() {
 
   const [sites, setSites] = useState<SiteRow[]>([]);
   const [primaryId, setPrimaryId] = useState<string | null>(null);
+  const [platformDomain, setPlatformDomain] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   // Create form
@@ -57,6 +59,7 @@ export default function SitesSettingsPage() {
       const data = (await res.json()) as SitesResponse;
       setSites(data.tenants);
       setPrimaryId(data.primaryTenantId);
+      setPlatformDomain(data.platformDomain);
     } catch (err) {
       toast.error("Failed to load sites", {
         description: err instanceof Error ? err.message : "Please try again",
@@ -190,6 +193,28 @@ export default function SitesSettingsPage() {
           project you publish belongs to one site. New items default to your
           primary site.
         </p>
+        {platformDomain && (
+          <div className="mt-4 rounded-md border border-sky-500/30 bg-sky-500/5 p-3 text-xs text-sky-100/80">
+            <div className="font-medium text-sky-200 mb-1">
+              Every site you create is reachable at two URLs automatically:
+            </div>
+            <ul className="list-disc list-inside space-y-0.5">
+              <li>
+                <code className="font-mono">your-slug.{platformDomain}</code>{" "}
+                (subdomain)
+              </li>
+              <li>
+                <code className="font-mono">{platformDomain}/u/your-slug</code>{" "}
+                (subpath, works as a fallback)
+              </li>
+            </ul>
+            <div className="mt-2 text-sky-100/60">
+              To use a domain you already own (e.g.{" "}
+              <code className="font-mono">yoursite.com</code>), expand a site
+              below and open its <em>Hosts</em> section.
+            </div>
+          </div>
+        )}
       </div>
 
       <section
@@ -315,6 +340,13 @@ export default function SitesSettingsPage() {
                         <div className="text-xs text-muted-foreground font-mono mt-0.5">
                           {site.slug}
                         </div>
+                        {platformDomain && (
+                          <div className="text-[11px] text-white/30 font-mono mt-1 space-x-2">
+                            <span>{site.slug}.{platformDomain}</span>
+                            <span className="text-white/15">·</span>
+                            <span>{platformDomain}/u/{site.slug}</span>
+                          </div>
+                        )}
                       </>
                     )}
                   </div>
@@ -382,11 +414,10 @@ export default function SitesSettingsPage() {
       </section>
 
       <p className="text-xs text-muted-foreground">
-        Each site is reachable at <code className="mx-1 font-mono">/u/your-slug</code>{" "}
-        by default. Expand a site&apos;s <em>Hosts</em> section to add a custom
-        domain (e.g. <code className="font-mono">mysite.com</code>). Custom
-        domains require DNS verification — instructions are shown after you add
-        one.
+        Need a custom domain (e.g.{" "}
+        <code className="font-mono">mysite.com</code>)? Expand a site&apos;s{" "}
+        <em>Hosts</em> section to add one. Custom domains require DNS
+        verification — instructions appear after you add one.
       </p>
     </div>
   );

--- a/app/api/publishing/items/[id]/archive/route.ts
+++ b/app/api/publishing/items/[id]/archive/route.ts
@@ -1,0 +1,69 @@
+/**
+ * POST /api/publishing/items/[id]/archive
+ *
+ * Transitions state: * → archived. Stronger than unpublish: signals the
+ * author considers the item retired, not just temporarily dark. Archived
+ * items don't appear in the IDE's working set unless explicitly filtered.
+ * Different from delete — the row stays in the DB and can be restored by
+ * re-publishing.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/infrastructure/auth/middleware";
+import { prisma } from "@/lib/database/client";
+import { logger } from "@/lib/core/logger";
+import { withRouteTrace } from "@/lib/core/logger/route-trace";
+import { withSpan } from "@/lib/core/logger/span";
+import { invalidateTenantCache } from "@/lib/domain/tenancy/cache";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  return withRouteTrace(
+    req,
+    { route: "/api/publishing/items/[id]/archive" },
+    async () => {
+      const session = await requireAuth();
+      const { id } = await params;
+
+      return withSpan(
+        { layer: "content", name: "publishing:archive" },
+        { summary: "publishing item archive", attrs: { public_item_id: id } },
+        async (span) => {
+          const item = await prisma.publicItem.findFirst({
+            where: { id, tenant: { ownerId: session.user.id }, deletedAt: null },
+          });
+
+          if (!item) {
+            logger.warn({
+              layer: "content",
+              event: "publishing_archive:rejected",
+              summary: "public item not found",
+              attrs: { public_item_id: id },
+            });
+            return NextResponse.json({ error: "Not found" }, { status: 404 });
+          }
+
+          if (item.state === "archived") {
+            return NextResponse.json({ ok: true, alreadyArchived: true });
+          }
+
+          await prisma.publicItem.update({
+            where: { id },
+            data: { state: "archived" },
+          });
+
+          span.attr("prev_state", item.state).attr("new_state", "archived");
+
+          // If it was published, the public surface needs invalidation.
+          if (item.state === "published") {
+            await invalidateTenantCache({ type: "item", itemId: id });
+          }
+
+          return NextResponse.json({ ok: true });
+        },
+      );
+    },
+  );
+}

--- a/app/api/publishing/items/[id]/route.ts
+++ b/app/api/publishing/items/[id]/route.ts
@@ -160,3 +160,57 @@ export async function PATCH(
     );
   });
 }
+
+/**
+ * DELETE /api/publishing/items/[id]
+ *
+ * Soft-delete: sets deletedAt. Stronger than archive — archived items can
+ * be re-published; deleted items disappear from the IDE entirely. The row
+ * stays in the DB so referential integrity is preserved (revisions,
+ * audit trail). A future "permanently purge" cron could hard-delete rows
+ * with deletedAt older than N days.
+ */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  return withRouteTrace(req, { route: "/api/publishing/items/[id]" }, async () => {
+    const session = await requireAuth();
+    const { id } = await params;
+
+    return withSpan(
+      { layer: "content", name: "publishing:delete" },
+      { summary: "publishing item delete", attrs: { public_item_id: id } },
+      async (span) => {
+        const item = await prisma.publicItem.findFirst({
+          where: { id, tenant: { ownerId: session.user.id }, deletedAt: null },
+        });
+
+        if (!item) {
+          logger.warn({
+            layer: "content",
+            event: "publishing_delete:rejected",
+            summary: "public item not found",
+            attrs: { public_item_id: id },
+          });
+          return NextResponse.json({ error: "Not found" }, { status: 404 });
+        }
+
+        await prisma.publicItem.update({
+          where: { id },
+          data: { deletedAt: new Date(), state: "archived" },
+        });
+
+        span.attr("prev_state", item.state).attr("was_published",
+          item.state === "published");
+
+        // If it was public, the URL just stopped working. Invalidate.
+        if (item.state === "published") {
+          await invalidateTenantCache({ type: "item", itemId: id });
+        }
+
+        return NextResponse.json({ ok: true });
+      },
+    );
+  });
+}

--- a/app/api/user/tenants/[id]/route.ts
+++ b/app/api/user/tenants/[id]/route.ts
@@ -15,6 +15,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/infrastructure/auth/middleware";
 import { prisma } from "@/lib/database/client";
 import { logger, withRouteTrace, withSpan } from "@/lib/core/logger";
+import { isReservedSlug, RESERVED_SLUG_MESSAGE } from "@/lib/domain/tenancy";
 
 const ROUTE_PATH = "/api/user/tenants/[id]";
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,118}[a-z0-9]$|^[a-z0-9]$/;
@@ -73,6 +74,21 @@ export async function PATCH(
                 error:
                   "Slug must be lowercase alphanumeric and hyphens, 1–120 chars, no leading/trailing hyphen.",
               },
+              { status: 400 },
+            );
+          }
+          // Block rename-into-reserved (mirrors creation gate). Existing
+          // tenants whose current slug happens to BE reserved are not
+          // forced to rename — see reserved-slugs.ts module doc.
+          if (newSlug !== tenant.slug && isReservedSlug(newSlug)) {
+            logger.warn({
+              layer: "auth",
+              event: "user_tenant_update:rejected",
+              summary: "reserved slug",
+              attrs: { tenant_id: id, reason: "reserved_slug", slug: newSlug },
+            });
+            return NextResponse.json(
+              { error: RESERVED_SLUG_MESSAGE },
               { status: 400 },
             );
           }

--- a/app/api/user/tenants/route.ts
+++ b/app/api/user/tenants/route.ts
@@ -49,6 +49,12 @@ export async function GET(req: NextRequest) {
         return NextResponse.json({
           tenants,
           primaryTenantId: user?.primaryTenantId ?? null,
+          // Phase 13: the UI uses this to show "your sites are reachable at
+          // <slug>.<platformDomain>" affordances. Null when the env var
+          // isn't set (legacy single-tenant deployments). The bare value
+          // is non-secret — same info as the public host.
+          platformDomain:
+            process.env.PLATFORM_DOMAIN?.trim().toLowerCase() ?? null,
         });
       },
     );

--- a/app/api/user/tenants/route.ts
+++ b/app/api/user/tenants/route.ts
@@ -12,7 +12,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/infrastructure/auth/middleware";
 import { prisma } from "@/lib/database/client";
 import { logger, withRouteTrace, withSpan } from "@/lib/core/logger";
-import { slugFromUsername } from "@/lib/domain/tenancy";
+import {
+  isReservedSlug,
+  RESERVED_SLUG_MESSAGE,
+  slugFromUsername,
+} from "@/lib/domain/tenancy";
 
 const ROUTE_PATH = "/api/user/tenants";
 
@@ -99,6 +103,22 @@ export async function POST(req: NextRequest) {
           error:
             "Slug must be lowercase alphanumeric and hyphens, 1–120 chars, no leading/trailing hyphen.",
         },
+        { status: 400 },
+      );
+    }
+
+    // Block reserved subdomains (admin, api, www, blog, etc.) — slugs
+    // become subdomains under PLATFORM_DOMAIN automatically, so user-owned
+    // tenants must not shadow system/brand surfaces.
+    if (isReservedSlug(baseSlug)) {
+      logger.warn({
+        layer: "auth",
+        event: "user_tenant_create:rejected",
+        summary: "reserved slug",
+        attrs: { reason: "reserved_slug", slug: baseSlug },
+      });
+      return NextResponse.json(
+        { error: RESERVED_SLUG_MESSAGE },
         { status: 400 },
       );
     }

--- a/app/u/[slug]/[...path]/page.tsx
+++ b/app/u/[slug]/[...path]/page.tsx
@@ -16,6 +16,7 @@ import { notFound, permanentRedirect } from "next/navigation";
 import { prisma } from "@/lib/database/client";
 import { withPageTrace } from "@/lib/core/logger";
 import {
+  assertPlatformHost,
   resolveTenantBySlug,
   resolvePublicItem,
   resolvePublicPath,
@@ -49,6 +50,11 @@ async function renderSubpathContent(
   fullPath: string,
   segments: string[],
 ) {
+  // /u/ routes are platform-only — 404 if called on a custom-host tenant
+  // (e.g. davidvalentine.org/u/anyone/some-path). See app/u/[slug]/page.tsx
+  // for rationale.
+  await assertPlatformHost();
+
   const tenant = await resolveTenantBySlug(slug);
   if (!tenant) {
     notFound();

--- a/app/u/[slug]/page.tsx
+++ b/app/u/[slug]/page.tsx
@@ -15,7 +15,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/database/client";
 import { withPageTrace } from "@/lib/core/logger";
-import { resolveTenantBySlug } from "@/lib/domain/tenancy";
+import { assertPlatformHost, resolveTenantBySlug } from "@/lib/domain/tenancy";
 
 interface Params {
   slug: string;
@@ -36,6 +36,11 @@ export default async function TenantSubpathHome({
 }
 
 async function renderTenantHome(slug: string) {
+  // /u/ routes are platform-only — 404 if called on a custom-host tenant
+  // (e.g. davidvalentine.org/u/anyone). Prevents subpath URLs from
+  // accidentally exposing arbitrary tenants under the wrong domain.
+  await assertPlatformHost();
+
   const tenant = await resolveTenantBySlug(slug);
   if (!tenant) {
     notFound();

--- a/components/settings/sites/HostManagement.tsx
+++ b/components/settings/sites/HostManagement.tsx
@@ -184,27 +184,20 @@ export function HostManagement({ tenantId, tenantSlug }: HostManagementProps) {
   return (
     <div className="mt-4 pl-6 border-l border-white/5 space-y-3">
       {/* Always-shown info card: where this site is reachable for free. */}
-      <div className="rounded-md border border-white/8 bg-white/3 p-3 space-y-1.5">
-        <div className="text-[11px] uppercase tracking-wider text-white/40">
-          Your site is reachable at
-        </div>
-        {platformDomain && (
+      {platformDomain && (
+        <div className="rounded-md border border-white/8 bg-white/3 p-3 space-y-1.5">
+          <div className="text-[11px] uppercase tracking-wider text-white/40">
+            Your site is reachable at
+          </div>
           <div className="flex items-center gap-2 text-xs">
             <Globe className="h-3 w-3 text-white/30 shrink-0" />
             <code className="font-mono text-white/80">
               {tenantSlug}.{platformDomain}
             </code>
-            <span className="text-white/30">— subdomain (free, no setup)</span>
+            <span className="text-white/30">— free, no setup required</span>
           </div>
-        )}
-        <div className="flex items-center gap-2 text-xs">
-          <Globe className="h-3 w-3 text-white/30 shrink-0" />
-          <code className="font-mono text-white/80">
-            {platformDomain ?? "this site"}/u/{tenantSlug}
-          </code>
-          <span className="text-white/30">— subpath (free, no setup)</span>
         </div>
-      </div>
+      )}
 
       {/* Existing hosts list */}
       {isLoading ? (

--- a/docs/notes-feature/work-tracking/BACKLOG.md
+++ b/docs/notes-feature/work-tracking/BACKLOG.md
@@ -10,6 +10,31 @@ last_updated: 2026-05-31
 
 ---
 
+## Context-Menu Unification (2026-06-01)
+
+Three menu surfaces in the publishing UI were restyled in Phase 19 to visually match the file-tree ContextMenu and the People panel header — establishing one consistent affordance pattern across the IDE. The work was cosmetic-only; the underlying components are still three separate implementations:
+
+- **`components/content/context-menu/ContextMenu.tsx`** — file-tree's right-click menu. Tightly coupled to `useContextMenuStore` (global, single-instance). Action-provider pattern with `ContextMenuSection[]`.
+- **`extensions/publishing/components/view-mode/PublishingPathContextMenu.tsx`** — custom positioned menu via `createPortal`. Local state for dialogs.
+- **`extensions/publishing/components/sidebar/PublishItemMenu.tsx`** — Radix `DropdownMenu` with classNames overridden to match.
+
+Followups:
+- [ ] **Extract a shared `MenuPrimitive`** that all three can use — same button/item/divider/section-label classes in one place. Today, if file-tree's visual style changes, the publishing menus drift.
+- [ ] **Decide whether `useContextMenuStore` should generalize** to support transient menus from any source (3-dot dropdowns, popovers), or whether Radix-based dropdowns remain the right tool for click-anchored menus while `ContextMenu` stays for right-click. Probably the latter — they have different positioning semantics.
+
+### Preserved "premium" 3-dot styling
+
+Phases 16-17 originally shipped a different styling for `PublishItemMenu` — gold-tinted text on a deep-glass surface, more design-system "premium" feel than the current file-tree match. The user liked it but chose consistency for now. The pattern is documented here for potential future adoption as the *new* platform-wide context-menu look:
+
+- Container: `rounded-xl border border-amber-200/15 bg-zinc-900/95 shadow-2xl`
+- Item: `text-amber-100/85 hover:bg-white/5 hover:text-amber-50`
+- Destructive: `text-rose-400 hover:bg-rose-500/10`
+- Icon: `opacity-65`
+
+If the design system later moves toward a more distinctive (less generic-shadcn) look for menus, recover this from the git history at commit `d5578cf` and apply it as the new shared primitive.
+
+---
+
 ## Publishing Card Slice C (deferred from 2026-06-01 multi-tenancy work)
 
 Three more 3-dot menu actions on the right-sidebar publishing card. Slice A (breadcrumb + relative time) and Slice B (Copy URL, Edit metadata, Move path, Archive, Delete) shipped in PR #50. Slice C remaining:

--- a/docs/notes-feature/work-tracking/BACKLOG.md
+++ b/docs/notes-feature/work-tracking/BACKLOG.md
@@ -10,6 +10,23 @@ last_updated: 2026-05-31
 
 ---
 
+## Publishing Card Slice C (deferred from 2026-06-01 multi-tenancy work)
+
+Three more 3-dot menu actions on the right-sidebar publishing card. Slice A (breadcrumb + relative time) and Slice B (Copy URL, Edit metadata, Move path, Archive, Delete) shipped in PR #50. Slice C remaining:
+
+- [ ] **Move to a different site** — adds a tenant picker to the move flow. Only visible when the user owns >1 tenant. Backend already supports it via `PATCH /api/publishing/items/[id]` accepting a `tenantId` field (would need to add this field if not present yet — currently only accepts `pathId`). UX consideration: paths are tenant-scoped, so changing the tenant requires also re-picking a path. Probably a two-step flow: pick site → pick path within that site.
+
+- [ ] **Schedule expire (auto-unpublish at a future date)** — datetime picker that sets a `publishedUntil` (or similar). Requires:
+  - New nullable column on `PublicItem`: `publishedUntil DateTime?`
+  - The scheduled-publish cron extended to also check `publishedUntil < now` and transition published → unpublished
+  - UI: show the expire date on the card if set, with a "cancel expire" affordance
+
+- [ ] **Cancel scheduled publish** — visible only when `scheduledFor` is set. One-click clears the schedule. Tiny addition once the menu has somewhere to put it; current Slice B menu doesn't conditionally show items based on item state, so this needs a small refactor to support conditional menu items.
+
+Total estimated effort: ~150 lines + 1 schema field + cron extension.
+
+---
+
 ## Dev Infra Followups
 
 - [ ] **Local Postgres (Docker) for development** — reserve cloud Neon for deployed/preview only, so heavy local dev/testing stops burning Neon metered compute (hit the "exceeded compute time quota" wall during AI-chat-revamp dev, 2026-05). Temporary workaround in place: upgraded Vercel (Neon billed through it). Do this **after** the AI chat revamp scope completes. Deliverable: `docker-compose.yml` for Postgres + a dev `DATABASE_URL` swap (keep the Neon URL for deploys); `npx prisma db push` to seed the local schema.

--- a/extensions/publishing/components/dialogs/CreatePublicPathDialog.tsx
+++ b/extensions/publishing/components/dialogs/CreatePublicPathDialog.tsx
@@ -128,13 +128,13 @@ export function CreatePublicPathDialog({ onClose, onCreated, defaultParentId }: 
 
   return (
     <PublishingDialog
-      title="New publishing path"
+      title="New path"
       onClose={onClose}
       onSubmit={handleSubmit}
     >
         <div className="px-4 py-4 space-y-4">
           <label className="block">
-            <span className="text-xs text-white/40 mb-1 block">Title</span>
+            <span className="text-xs text-white/40 mb-1 block">Name</span>
             <input
               type="text"
               value={title}
@@ -148,7 +148,7 @@ export function CreatePublicPathDialog({ onClose, onCreated, defaultParentId }: 
           {/* Tenant picker — hidden when user owns exactly 1 site. */}
           {!isLoadingTenants && tenants.length > 1 && (
             <label className="block">
-              <span className="text-xs text-white/40 mb-1 block">Create on site</span>
+              <span className="text-xs text-white/40 mb-1 block">Site</span>
               <select
                 value={tenantId}
                 onChange={(e) => setTenantId(e.target.value)}
@@ -166,13 +166,13 @@ export function CreatePublicPathDialog({ onClose, onCreated, defaultParentId }: 
 
           {tenantScopedPathOptions.length > 0 && (
             <label className="block">
-              <span className="text-xs text-white/40 mb-1 block">Parent path (optional)</span>
+              <span className="text-xs text-white/40 mb-1 block">Inside</span>
               <select
                 value={parentId}
                 onChange={(e) => setParentId(e.target.value)}
                 className="w-full rounded-md border border-white/10 bg-zinc-800 px-3 py-2 text-sm text-white focus:border-white/20 focus:outline-none"
               >
-                <option value="">— Root (no parent)</option>
+                <option value="">(top level)</option>
                 {tenantScopedPathOptions.map((opt) => (
                   <option key={opt.id} value={opt.id}>
                     {opt.label}
@@ -183,7 +183,7 @@ export function CreatePublicPathDialog({ onClose, onCreated, defaultParentId }: 
           )}
 
           <label className="block">
-            <span className="text-xs text-white/40 mb-1 block">Slug (URL segment)</span>
+            <span className="text-xs text-white/40 mb-1 block">Slug</span>
             <div className="flex items-center rounded-md border bg-white/5 focus-within:border-white/20 overflow-hidden"
               style={{ borderColor: slugError ? "rgba(239,68,68,.5)" : "rgba(255,255,255,.1)" }}>
               <span className="pl-3 pr-1 text-sm text-white/30 whitespace-nowrap">{slugPrefix}</span>
@@ -199,12 +199,12 @@ export function CreatePublicPathDialog({ onClose, onCreated, defaultParentId }: 
           </label>
 
           <label className="block">
-            <span className="text-xs text-white/40 mb-1 block">Description (optional)</span>
+            <span className="text-xs text-white/40 mb-1 block">Description</span>
             <input
               type="text"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder="Short description"
+              placeholder="Optional"
               className="w-full rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-white/20 focus:border-white/20 focus:outline-none"
             />
           </label>
@@ -219,7 +219,7 @@ export function CreatePublicPathDialog({ onClose, onCreated, defaultParentId }: 
             disabled={!canSubmit}
             className="px-3 py-1.5 rounded-md text-xs font-medium bg-sky-500/20 text-sky-300 hover:bg-sky-500/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            {isSubmitting ? "Creating…" : "Create path"}
+            {isSubmitting ? "Creating…" : "Create"}
           </button>
         </div>
     </PublishingDialog>

--- a/extensions/publishing/components/sidebar/PublishItemMenu.tsx
+++ b/extensions/publishing/components/sidebar/PublishItemMenu.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+/**
+ * 3-dot dropdown menu for a PublishItem row.
+ *
+ * Five actions, in order of frequency:
+ *   - Copy public URL  (pure client-side clipboard write)
+ *   - Edit metadata    (title + slug → PATCH; slug change auto-creates a redirect)
+ *   - Move to path     (pathId → PATCH; picker fetches tenant's paths on open)
+ *   - Archive          (state → archived; reversible by re-publishing)
+ *   - Delete           (soft-delete; sets deletedAt; reversal requires admin work)
+ *
+ * Each destructive action (Archive, Delete) confirms before firing.
+ * Each successful action calls onRefresh() so the parent re-fetches.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  MoreHorizontal,
+  Link as LinkIcon,
+  Pencil,
+  FolderInput,
+  Archive,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/client/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  archiveItem,
+  deleteItem,
+  fetchPublicPaths,
+  updatePublicItem,
+  type PublicPathSummary,
+} from "../../lib/client-api";
+import type { PublishItemSummary } from "../../state/publish-store";
+
+interface PublishItemMenuProps {
+  item: PublishItemSummary;
+  onRefresh: () => void;
+}
+
+type DialogMode = "edit" | "move" | "archive" | "delete" | null;
+
+export function PublishItemMenu({ item, onRefresh }: PublishItemMenuProps) {
+  const [dialog, setDialog] = useState<DialogMode>(null);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-gray-300 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-300"
+            title="More options"
+          >
+            <MoreHorizontal className="w-3.5 h-3.5" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-52">
+          <DropdownMenuItem onSelect={() => handleCopyUrl(item)}>
+            <LinkIcon className="w-3.5 h-3.5 mr-2" /> Copy public URL
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setDialog("edit")}>
+            <Pencil className="w-3.5 h-3.5 mr-2" /> Edit title &amp; slug
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setDialog("move")}>
+            <FolderInput className="w-3.5 h-3.5 mr-2" /> Move to another path
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setDialog("archive")}>
+            <Archive className="w-3.5 h-3.5 mr-2" /> Archive
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => setDialog("delete")}
+            className="text-red-600 dark:text-red-400 focus:text-red-700 dark:focus:text-red-300"
+          >
+            <Trash2 className="w-3.5 h-3.5 mr-2" /> Delete permanently
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {dialog === "edit" && (
+        <EditMetadataDialog
+          item={item}
+          onClose={() => setDialog(null)}
+          onSuccess={() => {
+            setDialog(null);
+            onRefresh();
+          }}
+        />
+      )}
+      {dialog === "move" && (
+        <MovePathDialog
+          item={item}
+          onClose={() => setDialog(null)}
+          onSuccess={() => {
+            setDialog(null);
+            onRefresh();
+          }}
+        />
+      )}
+      {dialog === "archive" && (
+        <ConfirmDialog
+          title="Archive this item?"
+          body="Archived items disappear from the public site and from your IDE's default working set. You can restore by re-publishing."
+          confirmLabel="Archive"
+          onClose={() => setDialog(null)}
+          onConfirm={async () => {
+            try {
+              await archiveItem(item.id);
+              toast.success("Archived.");
+              setDialog(null);
+              onRefresh();
+            } catch {
+              toast.error("Archive failed.");
+            }
+          }}
+        />
+      )}
+      {dialog === "delete" && (
+        <ConfirmDialog
+          title="Delete permanently?"
+          body="This removes the item from your IDE entirely. The underlying content note isn't deleted — only this publication."
+          confirmLabel="Delete"
+          destructive
+          onClose={() => setDialog(null)}
+          onConfirm={async () => {
+            try {
+              await deleteItem(item.id);
+              toast.success("Deleted.");
+              setDialog(null);
+              onRefresh();
+            } catch {
+              toast.error("Delete failed.");
+            }
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function handleCopyUrl(item: PublishItemSummary) {
+  // Canonical URL composition. If the item lives under a path, the path
+  // slug prefixes the item slug. We don't currently have tenant-custom-
+  // host info on the summary, so build the URL relative to whatever host
+  // the user is on (most common case: they're on their own site).
+  const pathPrefix = item.path ? `/${item.path.slug}` : "";
+  const url = `${window.location.origin}${pathPrefix}/${item.slug}`;
+  void navigator.clipboard.writeText(url).then(
+    () => toast.success("URL copied", { description: url }),
+    () => toast.error("Couldn't access clipboard."),
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Edit metadata dialog
+// ─────────────────────────────────────────────────────────────────────────
+
+function EditMetadataDialog({
+  item,
+  onClose,
+  onSuccess,
+}: {
+  item: PublishItemSummary;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const [title, setTitle] = useState(item.publicTitle ?? "");
+  const [slug, setSlug] = useState(item.slug);
+  const [submitting, setSubmitting] = useState(false);
+
+  const trimmedTitle = title.trim();
+  const trimmedSlug = slug.trim().toLowerCase();
+  const hasChanges =
+    trimmedTitle !== (item.publicTitle ?? "") || trimmedSlug !== item.slug;
+  const valid = trimmedSlug.length > 0 && /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/.test(trimmedSlug);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!hasChanges || !valid || submitting) return;
+    setSubmitting(true);
+    try {
+      const body: { publicTitle?: string; slug?: string } = {};
+      if (trimmedTitle !== (item.publicTitle ?? "")) body.publicTitle = trimmedTitle;
+      if (trimmedSlug !== item.slug) body.slug = trimmedSlug;
+      await updatePublicItem(item.id, body);
+      toast.success(
+        body.slug
+          ? `Saved. Old URL redirects to /${trimmedSlug}.`
+          : "Saved.",
+      );
+      onSuccess();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Couldn't save changes.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit publication</DialogTitle>
+          <DialogDescription>
+            Change the public title or URL slug. Slug changes leave a
+            redirect from the old URL automatically.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-xs font-medium mb-1">
+              Public title
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Defaults to the content note's title"
+              className="w-full rounded-md border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium mb-1">URL slug</label>
+            <input
+              type="text"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              required
+              pattern="^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$"
+              className="w-full rounded-md border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 px-3 py-2 text-sm font-mono"
+            />
+            <p className="text-[11px] text-gray-500 mt-1">
+              Lowercase letters, numbers, hyphens. No leading/trailing hyphen.
+            </p>
+          </div>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 rounded-md text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!hasChanges || !valid || submitting}
+              className="px-3 py-1.5 rounded-md text-sm font-medium bg-sky-600 text-white hover:bg-sky-500 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {submitting ? "Saving…" : "Save"}
+            </button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Move-to-path dialog
+// ─────────────────────────────────────────────────────────────────────────
+
+function MovePathDialog({
+  item,
+  onClose,
+  onSuccess,
+}: {
+  item: PublishItemSummary;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const [paths, setPaths] = useState<PublicPathSummary[] | null>(null);
+  const [selectedPathId, setSelectedPathId] = useState<string>(item.pathId);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    fetchPublicPaths()
+      .then((all) => {
+        // Filter to paths owned by the same tenant as this item — backend
+        // would reject moves to other tenants anyway, but pre-filtering
+        // keeps the picker clean.
+        // Note: fetchPublicPaths returns all paths the user owns across
+        // tenants. The PublicPathSummary type doesn't carry tenantId yet,
+        // so we trust the backend's PATCH validation as the gate and show
+        // everything here. Future improvement: include tenantId in the
+        // summary and filter client-side too.
+        setPaths(all);
+      })
+      .catch(() => {
+        toast.error("Couldn't load path list.");
+        onClose();
+      });
+  }, [onClose]);
+
+  const hasChange = selectedPathId !== item.pathId;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!hasChange || submitting) return;
+    setSubmitting(true);
+    try {
+      await updatePublicItem(item.id, { pathId: selectedPathId });
+      toast.success("Moved.");
+      onSuccess();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't move item.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Move to another path</DialogTitle>
+          <DialogDescription>
+            Pick a different path within your site. The item&apos;s URL
+            changes to reflect the new path; a redirect from the old URL is
+            created automatically.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-xs font-medium mb-1">Path</label>
+            {paths === null ? (
+              <div className="text-sm text-gray-500">Loading paths…</div>
+            ) : paths.length === 0 ? (
+              <div className="text-sm text-gray-500">No paths available.</div>
+            ) : (
+              <select
+                value={selectedPathId}
+                onChange={(e) => setSelectedPathId(e.target.value)}
+                className="w-full rounded-md border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 px-3 py-2 text-sm"
+              >
+                {paths.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.title} ({p.slug})
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 rounded-md text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!hasChange || submitting}
+              className="px-3 py-1.5 rounded-md text-sm font-medium bg-sky-600 text-white hover:bg-sky-500 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {submitting ? "Moving…" : "Move"}
+            </button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Confirm dialog (used by Archive + Delete)
+// ─────────────────────────────────────────────────────────────────────────
+
+function ConfirmDialog({
+  title,
+  body,
+  confirmLabel,
+  destructive,
+  onClose,
+  onConfirm,
+}: {
+  title: string;
+  body: string;
+  confirmLabel: string;
+  destructive?: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void> | void;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleConfirm() {
+    setSubmitting(true);
+    try {
+      await onConfirm();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{body}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 rounded-md text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={submitting}
+            className={
+              destructive
+                ? "px-3 py-1.5 rounded-md text-sm font-medium bg-red-600 text-white hover:bg-red-500 disabled:opacity-40"
+                : "px-3 py-1.5 rounded-md text-sm font-medium bg-sky-600 text-white hover:bg-sky-500 disabled:opacity-40"
+            }
+          >
+            {submitting ? "Working…" : confirmLabel}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/extensions/publishing/components/sidebar/PublishItemMenu.tsx
+++ b/extensions/publishing/components/sidebar/PublishItemMenu.tsx
@@ -60,6 +60,14 @@ export function PublishItemMenu({ item, onRefresh }: PublishItemMenuProps) {
 
   return (
     <>
+      {/*
+        Visual style mirrors the file-tree ContextMenu in
+        components/content/context-menu/ContextMenu.tsx so all the IDE's
+        actionable menus feel like one affordance. Item styling, container
+        backdrop, icon opacity, and destructive hover colors are all from
+        that source. See BACKLOG: context-menu unification for the
+        long-term plan to share a single Menu primitive.
+       */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
@@ -69,25 +77,45 @@ export function PublishItemMenu({ item, onRefresh }: PublishItemMenuProps) {
             <MoreHorizontal className="w-3.5 h-3.5" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
-          <DropdownMenuItem onSelect={() => handleCopyUrl(item)}>
-            <LinkIcon className="w-3.5 h-3.5 mr-2" /> Copy public URL
+        <DropdownMenuContent
+          align="end"
+          className="min-w-[200px] rounded-md border border-white/20 bg-white/95 shadow-lg backdrop-blur-sm dark:bg-gray-900/95 p-1"
+        >
+          <DropdownMenuItem
+            onSelect={() => handleCopyUrl(item)}
+            className="flex items-center gap-2 px-2.5 py-1 text-sm rounded-sm text-gray-900 dark:text-gray-100 hover:bg-primary/10 hover:text-primary focus:bg-primary/10 focus:text-primary cursor-pointer"
+          >
+            <LinkIcon className="h-4 w-4 shrink-0 opacity-70" />
+            <span className="truncate">Copy public URL</span>
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setDialog("edit")}>
-            <Pencil className="w-3.5 h-3.5 mr-2" /> Edit title &amp; slug
+          <DropdownMenuItem
+            onSelect={() => setDialog("edit")}
+            className="flex items-center gap-2 px-2.5 py-1 text-sm rounded-sm text-gray-900 dark:text-gray-100 hover:bg-primary/10 hover:text-primary focus:bg-primary/10 focus:text-primary cursor-pointer"
+          >
+            <Pencil className="h-4 w-4 shrink-0 opacity-70" />
+            <span className="truncate">Edit title &amp; slug</span>
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setDialog("move")}>
-            <FolderInput className="w-3.5 h-3.5 mr-2" /> Move to another path
+          <DropdownMenuItem
+            onSelect={() => setDialog("move")}
+            className="flex items-center gap-2 px-2.5 py-1 text-sm rounded-sm text-gray-900 dark:text-gray-100 hover:bg-primary/10 hover:text-primary focus:bg-primary/10 focus:text-primary cursor-pointer"
+          >
+            <FolderInput className="h-4 w-4 shrink-0 opacity-70" />
+            <span className="truncate">Move to another path</span>
           </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => setDialog("archive")}>
-            <Archive className="w-3.5 h-3.5 mr-2" /> Archive
+          <DropdownMenuSeparator className="my-1 mx-1 h-px bg-gray-200 dark:bg-gray-700" />
+          <DropdownMenuItem
+            onSelect={() => setDialog("archive")}
+            className="flex items-center gap-2 px-2.5 py-1 text-sm rounded-sm text-gray-900 dark:text-gray-100 hover:bg-primary/10 hover:text-primary focus:bg-primary/10 focus:text-primary cursor-pointer"
+          >
+            <Archive className="h-4 w-4 shrink-0 opacity-70" />
+            <span className="truncate">Archive</span>
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => setDialog("delete")}
-            className="text-red-600 dark:text-red-400 focus:text-red-700 dark:focus:text-red-300"
+            className="flex items-center gap-2 px-2.5 py-1 text-sm rounded-sm text-gray-900 dark:text-gray-100 hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 focus:bg-red-500/10 focus:text-red-600 dark:focus:text-red-400 cursor-pointer"
           >
-            <Trash2 className="w-3.5 h-3.5 mr-2" /> Delete permanently
+            <Trash2 className="h-4 w-4 shrink-0 opacity-70" />
+            <span className="truncate text-red-600 dark:text-red-400">Delete permanently</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/extensions/publishing/components/sidebar/PublishItemRow.tsx
+++ b/extensions/publishing/components/sidebar/PublishItemRow.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { ExternalLink, MoreHorizontal, Loader2, CalendarClock, X } from "lucide-react";
+import { ExternalLink, Loader2, CalendarClock, X } from "lucide-react";
+import { PublishItemMenu } from "./PublishItemMenu";
 import { toast } from "sonner";
 import { cn } from "@/lib/core/utils";
 import {
@@ -16,6 +17,32 @@ import { usePublishStore, type PublishItemSummary } from "../../state/publish-st
 interface PublishItemRowProps {
   item: PublishItemSummary;
   onRefresh: () => void;
+}
+
+/**
+ * Compact "x ago" formatter. Inlined here because we have one callsite
+ * and don't yet have a relative-time utility in lib/core/. If a second
+ * caller needs this, extract to lib/core/relative-time.ts.
+ */
+function relativeTime(iso: string | null): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffMs = now - then;
+  if (diffMs < 0) return null; // future date — caller's job to handle
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  // For older items show the date — "ago" stops being useful past a week.
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }
 
 export function PublishItemRow({ item, onRefresh }: PublishItemRowProps) {
@@ -115,23 +142,54 @@ export function PublishItemRow({ item, onRefresh }: PublishItemRowProps) {
           {isActing ? (
             <Loader2 className="w-3 h-3 animate-spin text-gray-300 dark:text-gray-500 shrink-0" />
           ) : (
-            <button
-              className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-gray-300 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-300"
-              title="More options"
-              onClick={() => toast.info("Item options — coming soon")}
-            >
-              <MoreHorizontal className="w-3.5 h-3.5" />
-            </button>
+            <PublishItemMenu item={item} onRefresh={onRefresh} />
           )}
         </div>
 
-        {/* State label + validation icons */}
+        {/* Destination breadcrumb: <site> / <path> / <slug> — answers
+            "where does this publication live" at a glance. */}
+        {(item.tenant || item.path) && (
+          <div
+            className="text-[10px] text-gray-400 dark:text-gray-500 truncate mt-0.5 font-mono"
+            title={
+              item.tenant && item.path
+                ? `${item.tenant.slug}/${item.path.slug}/${item.slug}`
+                : undefined
+            }
+          >
+            {item.tenant && (
+              <span className="text-gray-500 dark:text-gray-400">
+                {item.tenant.slug}
+              </span>
+            )}
+            {item.tenant && item.path && (
+              <span className="text-gray-300 dark:text-gray-600">{" / "}</span>
+            )}
+            {item.path && <span>{item.path.slug}</span>}
+            {item.path && (
+              <span className="text-gray-300 dark:text-gray-600">{" / "}</span>
+            )}
+            <span className="text-gray-500 dark:text-gray-400">
+              {item.slug}
+            </span>
+          </div>
+        )}
+
+        {/* State label + validation icons + relative time */}
         <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
           <span className={cn("text-[10px]", stateIcon.color)}>
             {pendingChanges && item.state === "published"
               ? "Changes pending"
               : stateIcon.label}
           </span>
+          {item.state === "published" && item.lastPublishedAt && (
+            <span
+              className="text-[10px] text-gray-400 dark:text-gray-500"
+              title={new Date(item.lastPublishedAt).toLocaleString()}
+            >
+              · {relativeTime(item.lastPublishedAt)}
+            </span>
+          )}
           {item.scheduledFor && (
             <span className="text-[10px] text-sky-500">
               · {new Date(item.scheduledFor).toLocaleDateString()}

--- a/extensions/publishing/components/sidebar/PublishTab.tsx
+++ b/extensions/publishing/components/sidebar/PublishTab.tsx
@@ -129,7 +129,7 @@ export function PublishTab({ contentId, contentTitle }: PublishTabProps) {
             className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-600 transition-colors"
           >
             <ExternalLink className="w-3 h-3" />
-            Open publishing view
+            Open publishing workspace
           </button>
         </div>
       )}

--- a/extensions/publishing/components/sidebar/PublishTab.tsx
+++ b/extensions/publishing/components/sidebar/PublishTab.tsx
@@ -71,19 +71,32 @@ export function PublishTab({ contentId, contentTitle }: PublishTabProps) {
         />
       )}
 
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-gray-100 shrink-0">
-        <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-          {linkedItems.length > 0 ? "Published as" : "Publish"}
-        </span>
-        <button
-          onClick={() => setShowCreateDialog(true)}
-          className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600 transition-colors"
-          title="Add to publishing"
-        >
-          <Plus className="w-3.5 h-3.5" />
-          Add
-        </button>
+      {/* Header — structure mirrors the People companion panel
+          (components/content/people/PeoplePanel.tsx) so the right-sidebar
+          surfaces feel like siblings. Heading + subtitle on the left,
+          action buttons on the right. */}
+      <div className="border-b border-gray-200/60 dark:border-white/10 px-3 py-3 shrink-0">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-700 dark:text-gray-200">
+              {linkedItems.length > 0 ? "Published as" : "Publish"}
+            </h3>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {linkedItems.length > 0
+                ? "Where this content lives publicly"
+                : "Publish this content to a site"}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <button
+              onClick={() => setShowCreateDialog(true)}
+              className="rounded p-1.5 text-gray-500 dark:text-gray-400 transition-colors hover:bg-gray-100 dark:hover:bg-white/10 hover:text-gray-900 dark:hover:text-white"
+              title="Add to publishing"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
       </div>
 
       {/* Body */}

--- a/extensions/publishing/components/view-mode/PublishingPathContextMenu.tsx
+++ b/extensions/publishing/components/view-mode/PublishingPathContextMenu.tsx
@@ -101,74 +101,83 @@ export function PublishingPathContextMenu({
   const menu = (
     <div
       ref={menuRef}
-      className="fixed z-[200] w-52 rounded-lg border border-white/10 bg-zinc-900 shadow-2xl py-1 text-sm"
+      data-context-menu
+      className="fixed z-[200] min-w-[200px] rounded-md border border-white/20 bg-white/95 shadow-lg backdrop-blur-sm dark:bg-gray-900/95 overflow-hidden"
       style={{ left: adjustedPos.x, top: adjustedPos.y }}
     >
-      {/* Path label */}
-      <div className="px-3 py-1.5 text-[11px] text-white/30 truncate border-b border-white/5 mb-1">
+      {/* Path label (subtle title on top, matches file-tree section-label vibe) */}
+      <div className="px-2.5 pt-1.5 pb-1 text-[10px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 truncate border-b border-gray-200/60 dark:border-gray-700/60">
         {node.title}
       </div>
 
-      <MenuItem icon={<FolderPlus className="w-3.5 h-3.5" />} onClick={() => setDialog("create-child")}>
-        New child path
-      </MenuItem>
-
-      <MenuItem icon={<Pencil className="w-3.5 h-3.5" />} onClick={() => setDialog("edit")}>
-        Rename / edit
-      </MenuItem>
-
-      <MenuItem icon={<Copy className="w-3.5 h-3.5" />} onClick={copyUrl}>
-        Copy path URL
-      </MenuItem>
-
-      <MenuItem
-        icon={<ExternalLink className="w-3.5 h-3.5" />}
-        onClick={() => {
-          window.open(`/${node.slug}`, "_blank");
-          onClose();
-        }}
-      >
-        Open in browser
-      </MenuItem>
-
-      <div className="my-1 border-t border-white/5" />
-
-      {dialog === "confirm-delete" ? (
-        <div className="px-3 py-2 space-y-2">
-          <p className="text-[11px] text-white/60 leading-snug">
-            Delete <span className="text-white/90 font-medium">{node.title}</span>? This cannot be undone.
-          </p>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setDialog(null)}
-              className="flex-1 py-1 rounded text-[11px] text-white/50 hover:text-white/80 border border-white/10 transition-colors"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleDelete}
-              disabled={isDeleting}
-              className="flex-1 py-1 rounded text-[11px] font-medium bg-rose-500/20 text-rose-400 hover:bg-rose-500/30 border border-rose-500/20 transition-colors disabled:opacity-50"
-            >
-              {isDeleting ? "Deleting…" : "Delete"}
-            </button>
-          </div>
-        </div>
-      ) : (
-        <MenuItem
-          icon={<Trash2 className="w-3.5 h-3.5" />}
-          onClick={() => setDialog("confirm-delete")}
-          destructive
-        >
-          Delete path
+      <div className="px-1.5 py-1">
+        <MenuItem icon={<FolderPlus className="h-4 w-4" />} onClick={() => setDialog("create-child")}>
+          New child path
         </MenuItem>
-      )}
+
+        <MenuItem icon={<Pencil className="h-4 w-4" />} onClick={() => setDialog("edit")}>
+          Rename / edit
+        </MenuItem>
+
+        <MenuItem icon={<Copy className="h-4 w-4" />} onClick={copyUrl}>
+          Copy path URL
+        </MenuItem>
+
+        <MenuItem
+          icon={<ExternalLink className="h-4 w-4" />}
+          onClick={() => {
+            window.open(`/${node.slug}`, "_blank");
+            onClose();
+          }}
+        >
+          Open in browser
+        </MenuItem>
+
+        <div className="my-1 mx-1 border-t border-gray-200 dark:border-gray-700" />
+
+        {dialog === "confirm-delete" ? (
+          <div className="px-2 py-2 space-y-2">
+            <p className="text-xs text-gray-600 dark:text-gray-300 leading-snug">
+              Delete <span className="text-gray-900 dark:text-gray-100 font-medium">{node.title}</span>? This cannot be undone.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setDialog(null)}
+                className="flex-1 py-1 rounded text-xs text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white border border-gray-200 dark:border-gray-700 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="flex-1 py-1 rounded text-xs font-medium bg-red-500/15 text-red-600 dark:text-red-400 hover:bg-red-500/25 border border-red-500/30 transition-colors disabled:opacity-50"
+              >
+                {isDeleting ? "Deleting…" : "Delete"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <MenuItem
+            icon={<Trash2 className="h-4 w-4" />}
+            onClick={() => setDialog("confirm-delete")}
+            destructive
+          >
+            Delete path
+          </MenuItem>
+        )}
+      </div>
     </div>
   );
 
   return createPortal(menu, document.body);
 }
 
+/**
+ * Item styling mirrors the file-tree ContextMenu in
+ * components/content/context-menu/ContextMenu.tsx so the two surfaces
+ * feel like the same affordance. Future: extract into a shared
+ * MenuItem primitive used by both (see BACKLOG: context-menu unification).
+ */
 function MenuItem({
   icon,
   children,
@@ -184,14 +193,16 @@ function MenuItem({
     <button
       type="button"
       onClick={onClick}
-      className={`w-full flex items-center gap-2.5 px-3 py-1.5 text-left text-xs transition-colors ${
+      className={`w-full flex items-center gap-2 px-2.5 py-1 text-left text-sm rounded-sm transition-colors ${
         destructive
-          ? "text-rose-400 hover:bg-rose-500/10"
-          : "text-white/70 hover:bg-white/5 hover:text-white"
+          ? "text-gray-900 hover:bg-red-500/10 hover:text-red-600 dark:text-gray-100 dark:hover:text-red-400"
+          : "text-gray-900 hover:bg-primary/10 hover:text-primary dark:text-gray-100"
       }`}
     >
-      <span className="shrink-0 opacity-70">{icon}</span>
-      {children}
+      <span className="shrink-0 text-current opacity-70">{icon}</span>
+      <span className={`truncate ${destructive ? "text-red-600 dark:text-red-400" : ""}`}>
+        {children}
+      </span>
     </button>
   );
 }

--- a/extensions/publishing/components/view-mode/PublishingTreeNode.tsx
+++ b/extensions/publishing/components/view-mode/PublishingTreeNode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronRight, Folder, Globe } from "lucide-react";
+import { ChevronRight, Globe } from "lucide-react";
 import { cn } from "@/lib/core/utils";
 import { usePublishTreeStore, type PublicPathNode } from "../../state/publish-tree-store";
 import { PublishingTreeNodeBadge } from "./PublishingTreeNodeBadge";
@@ -31,7 +31,10 @@ export function PublishingTreeNode({
 
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
 
-  const Icon = depth === 0 ? Globe : Folder;
+  // Top-level paths get a Globe (this site's root); nested paths render
+  // a slash glyph instead of a folder icon. Paths are URL path segments,
+  // not filesystem folders — "/" reinforces the right mental model.
+  const isRoot = depth === 0;
 
   // React Compiler memoizes this automatically; no need for useCallback
   const handleContextMenu = (e: React.MouseEvent) => {
@@ -69,8 +72,17 @@ export function PublishingTreeNode({
           ) : null}
         </span>
 
-        {/* Folder/globe icon */}
-        <Icon className="w-3.5 h-3.5 shrink-0 opacity-60" />
+        {/* Globe for top-level, "/" glyph for nested paths */}
+        {isRoot ? (
+          <Globe className="w-3.5 h-3.5 shrink-0 opacity-60" />
+        ) : (
+          <span
+            className="w-3.5 h-3.5 shrink-0 flex items-center justify-center font-mono text-sm opacity-40 leading-none"
+            aria-hidden="true"
+          >
+            /
+          </span>
+        )}
 
         {/* Tenant prefix on root nodes when user owns multiple tenants */}
         {depth === 0 && showTenantPrefix && node.tenantSlug && (

--- a/extensions/publishing/lib/client-api.ts
+++ b/extensions/publishing/lib/client-api.ts
@@ -53,6 +53,36 @@ export async function archiveItem(publicItemId: string): Promise<void> {
   if (!res.ok) throw new Error(`Archive failed: ${res.status}`);
 }
 
+export async function deleteItem(publicItemId: string): Promise<void> {
+  const res = await fetch(`/api/publishing/items/${publicItemId}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
+}
+
+/**
+ * Patch publicTitle, slug, and/or pathId on a PublicItem. Backend
+ * validates ownership + slug uniqueness + path ownership. Returns the
+ * updated item summary.
+ */
+export async function updatePublicItem(
+  publicItemId: string,
+  body: { publicTitle?: string; slug?: string; pathId?: string },
+): Promise<PublishItemSummary> {
+  const res = await fetch(`/api/publishing/items/${publicItemId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(
+      (err as { error?: string }).error ?? `Update failed: ${res.status}`,
+    );
+  }
+  return res.json();
+}
+
 export async function validateItem(
   publicItemId: string
 ): Promise<{ status: string; issues: unknown[] }> {

--- a/lib/domain/tenancy/auto-create-tenant.ts
+++ b/lib/domain/tenancy/auto-create-tenant.ts
@@ -14,6 +14,7 @@
 import { prisma } from "@/lib/database/client";
 import { logger } from "@/lib/core/logger";
 import type { Prisma } from "@/lib/database/generated/prisma";
+import { isReservedSlug } from "./reserved-slugs";
 
 /**
  * Derive a URL-safe slug from a username. Lowercase, alphanumeric + hyphens,
@@ -32,8 +33,11 @@ export function slugFromUsername(username: string): string {
   return cleaned.slice(0, 120) || "user";
 }
 
-// Find a slug not yet taken in the Tenant table. Uses the transaction
-// client so the existence check + create happen in one atomic op.
+// Find a slug not yet taken in the Tenant table AND not on the reserved
+// list. Uses the transaction client so the existence check + create
+// happen in one atomic op. Reserved slugs are treated as collisions — a
+// signup with username "admin" gets slug "admin-2" (or higher if also
+// taken), not an error, so signup never fails on a name conflict.
 async function ensureUniqueSlug(
   tx: Prisma.TransactionClient,
   baseSlug: string,
@@ -41,10 +45,11 @@ async function ensureUniqueSlug(
   let candidate = baseSlug;
   let suffix = 2;
   while (
-    await tx.tenant.findUnique({
+    isReservedSlug(candidate) ||
+    (await tx.tenant.findUnique({
       where: { slug: candidate },
       select: { id: true },
-    })
+    }))
   ) {
     candidate = `${baseSlug}-${suffix}`;
     suffix += 1;

--- a/lib/domain/tenancy/host-gate.ts
+++ b/lib/domain/tenancy/host-gate.ts
@@ -1,0 +1,32 @@
+/**
+ * Platform-host gate.
+ *
+ * Phase 13: restrict surfaces that should ONLY work on PLATFORM_DOMAIN
+ * (e.g. notetrellis.com), not on custom-host tenants like davidvalentine.org.
+ *
+ * The classic case: `/u/<slug>` routes resolve the tenant from the URL slug
+ * regardless of the request host. Without this gate, `davidvalentine.org/u/anyone`
+ * would render that user's content on the wrong domain — a clarity and
+ * potentially reputational concern. Platform-domain-only surfaces stay
+ * scoped to where they belong.
+ *
+ * Backward compatible: when PLATFORM_DOMAIN is unset (legacy single-tenant
+ * deployments), the gate becomes a no-op so existing behavior continues.
+ */
+
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import { normalizeHost } from "./resolve-tenant";
+
+/**
+ * 404s if the request isn't coming from the platform domain.
+ * Call at the top of a route handler before any tenant resolution.
+ */
+export async function assertPlatformHost(): Promise<void> {
+  const platformDomain = process.env.PLATFORM_DOMAIN?.trim().toLowerCase();
+  if (!platformDomain) return;
+  const host = normalizeHost((await headers()).get("host"));
+  if (host !== platformDomain) {
+    notFound();
+  }
+}

--- a/lib/domain/tenancy/index.ts
+++ b/lib/domain/tenancy/index.ts
@@ -17,6 +17,7 @@ export {
   CUSTOM_HOST_DENIED_MESSAGE,
 } from "./permissions";
 export type { PermissionUser } from "./permissions";
+export { assertPlatformHost } from "./host-gate";
 export { invalidateTenantCache } from "./cache";
 export {
   createPersonalTenantForUser,

--- a/lib/domain/tenancy/index.ts
+++ b/lib/domain/tenancy/index.ts
@@ -18,6 +18,11 @@ export {
 } from "./permissions";
 export type { PermissionUser } from "./permissions";
 export { assertPlatformHost } from "./host-gate";
+export {
+  isReservedSlug,
+  listReservedSlugs,
+  RESERVED_SLUG_MESSAGE,
+} from "./reserved-slugs";
 export { invalidateTenantCache } from "./cache";
 export {
   createPersonalTenantForUser,

--- a/lib/domain/tenancy/permissions.ts
+++ b/lib/domain/tenancy/permissions.ts
@@ -6,15 +6,17 @@
  * endpoint and squat on unclaimed domains by routing them through Vercel.
  *
  * Two paths to "yes":
- *   1. UserRole.owner is implicitly granted (the platform operator can
- *      always do this — no DB flag needed, baked into the helper).
- *   2. UserRole.admin and below need an explicit `canClaimCustomHosts`
+ *   1. UserRole.owner and UserRole.admin are implicitly granted — both
+ *      are platform-trust roles. A custom-host claim grafts a domain
+ *      onto the platform's Vercel project, which carries operational
+ *      responsibility; admin and owner are the "trusted enough" tiers.
+ *   2. UserRole.member and below need an explicit `canClaimCustomHosts`
  *      flag flipped to true. Owner controls who gets this — for now via
  *      Prisma Studio, eventually via an admin UI.
  *
- * Why NOT auto-grant admin: admin is a broad capability (user management,
- * audit log access). Custom-host claiming is a narrower trust signal —
- * users should be able to be one without being the other.
+ * The narrower flag stays useful: it lets the owner grant individual
+ * members the capability without promoting them to admin (which carries
+ * broader user-management and audit-log responsibilities).
  */
 
 export type PermissionUser = {
@@ -23,7 +25,7 @@ export type PermissionUser = {
 };
 
 export function canClaimCustomHosts(user: PermissionUser): boolean {
-  if (user.role === "owner") return true;
+  if (user.role === "owner" || user.role === "admin") return true;
   return user.canClaimCustomHosts === true;
 }
 

--- a/lib/domain/tenancy/reserved-slugs.ts
+++ b/lib/domain/tenancy/reserved-slugs.ts
@@ -1,0 +1,121 @@
+/**
+ * Reserved tenant slugs.
+ *
+ * Phase 14: subdomain slugs that should not be claimable by users.
+ *
+ * Slug uniqueness is global (Tenant.slug is @unique), and subdomains on
+ * PLATFORM_DOMAIN auto-resolve from slugs. So a user creating a tenant
+ * with slug "admin" would immediately own admin.<PLATFORM_DOMAIN> — bad
+ * for several reasons (impersonation, conflicting with future admin
+ * surfaces, brand confusion).
+ *
+ * This list is intentionally conservative — easier to add words later
+ * than to free up ones already taken. Grouped by category for
+ * grep-ability when extending.
+ *
+ * NOT enforced retroactively. Existing tenants with reserved slugs (if
+ * any survived the initial seed) keep them. The check fires only on
+ * NEW tenant creation and slug-rename attempts.
+ */
+
+const RESERVED_SLUGS_RAW = [
+  // System surfaces & route prefixes
+  "admin",
+  "api",
+  "app",
+  "auth",
+  "login",
+  "logout",
+  "signin",
+  "sign-in",
+  "signup",
+  "sign-up",
+  "settings",
+  "account",
+  "dashboard",
+  "home",
+  "me",
+  "u", // /u/<slug> subpath prefix — can't have tenant slug "u" or links break
+  "user",
+  "users",
+
+  // Web infrastructure subdomains
+  "www",
+  "mail",
+  "email",
+  "ftp",
+  "cdn",
+  "assets",
+  "static",
+  "media",
+
+  // Operational / status
+  "status",
+  "health",
+  "monitor",
+  "metrics",
+
+  // Brand (own these so nobody else can)
+  "notetrellis",
+  "note-trellis",
+  "davidvalentine",
+  "david-valentine",
+
+  // Legal / policy pages
+  "terms",
+  "tos",
+  "privacy",
+  "legal",
+  "policy",
+  "cookies",
+  "gdpr",
+
+  // Content surfaces a platform typically wants
+  "blog",
+  "docs",
+  "documentation",
+  "wiki",
+  "help",
+  "support",
+  "contact",
+  "about",
+  "pricing",
+  "billing",
+
+  // Common reserved words for "this won't be a tenant"
+  "test",
+  "demo",
+  "example",
+  "staging",
+  "dev",
+  "prod",
+  "production",
+];
+
+const RESERVED_SLUGS = new Set(
+  RESERVED_SLUGS_RAW.map((s) => s.toLowerCase()),
+);
+
+/**
+ * Check whether a slug is on the reserved list.
+ * Case-insensitive — slug pattern is already lowercase but defensive lower
+ * doesn't hurt.
+ */
+export function isReservedSlug(slug: string): boolean {
+  return RESERVED_SLUGS.has(slug.trim().toLowerCase());
+}
+
+/**
+ * Snapshot of reserved words (for UI display, e.g. "these slugs aren't
+ * available" hints). Returns a sorted copy so callers don't accidentally
+ * mutate the set.
+ */
+export function listReservedSlugs(): string[] {
+  return [...RESERVED_SLUGS].sort();
+}
+
+/**
+ * Human-readable rejection message returned by the API + shown by the UI.
+ */
+export const RESERVED_SLUG_MESSAGE =
+  "That slug is reserved for system use. Try a different one.";


### PR DESCRIPTION
## Summary

Three small phases of polish/correctness on top of the multi-tenancy foundation from PR #47. All on the same branch since they're tightly related (subdomain governance + UX).

### Phase 13 (commit \`46f34d1\`)
- **/u/[slug] platform-host gate** — closes the subpath leak where \`davidvalentine.org/u/<any-slug>\` rendered arbitrary tenants on the wrong domain. /u/ now 404 unless served from PLATFORM_DOMAIN. New helper \`assertPlatformHost()\`.
- **Sites page visual affordances** — banner + per-tenant inline URLs (refined in Phase 15).
- **Sign-in error contrast** — bumped from bg-red-500/10 invisible to bg-red-500/15 + border + icon + ARIA. Failed sign-ins now visibly fail.

### Phase 14 (commit \`9cef8dc\`)
- **Reserved slug list** — ~50 curated words (admin, api, www, blog, notetrellis, etc.) that users can't claim as tenant slugs. Prevents brand/system squatting.
- Enforced at tenant create (POST), rename (PATCH), and signup auto-create (treats reserved as collision, suffix -2 -3 etc).
- Not retroactive — existing tenants keep their slugs.

### Phase 15 (commit \`6988682\`)
- **Sites UI now treats subdomain as THE site address.** Drops /u/<slug> from the page banner, per-tenant inline display, and HostManagement info card. The /u/ route stays alive for shared-URL backward compat but isn't advertised as a site address. Conceptual cleanup: paths are decided when content is published, not when a site is created.
- **Admin co-grants custom hosts.** \`canClaimCustomHosts()\` now returns true for owner OR admin. Member/guest still need explicit User flag flip. Per-user flag stays useful for non-admin trusted users.

## Test plan

- [ ] \`davidvalentine.org/u/anything\` → 404 (Phase 13a)
- [ ] \`notetrellis.com/u/david\` → still works (Phase 13a backwards compat)
- [ ] Sites page banner shows ONLY the subdomain pattern, no /u/ (Phase 15)
- [ ] Each tenant row shows only \`<slug>.<platform>\` inline (Phase 15)
- [ ] HostManagement info card shows only the subdomain with \"free, no setup\" tag (Phase 15)
- [ ] Sign in with wrong password → visible red error (Phase 13c)
- [ ] Create site with slug \"admin\" → 400 reserved-slug message (Phase 14)
- [ ] Sign up new user with username \"admin\" → succeeds with slug like \"admin-2\" (Phase 14)
- [ ] Admin-role user sees the \"Add hostname\" form (Phase 15 permission widening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)