### PR TITLE
ai-chat polish + file-tree fixes (multi-select D+D, rename, AI tools)

### DIFF
--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -310,7 +310,14 @@ export async function POST(request: Request) {
       // per-tool `enabled` in settings. Tools default to enabled; only
       // `enabled === false` entries are dropped. If the result is empty
       // we pass `undefined` so streamText knows there are no tools at all.
-      const toolCtx = { userId: session.user.id, contentId: editableContentId };
+      const toolCtx = {
+        userId: session.user.id,
+        contentId: editableContentId,
+        // When the user is viewing this conversation in full-page mode the
+        // chat IS the open content. Pass that through so createNote can
+        // default the new note's parent folder to the chat's own parent.
+        chatContentId: isChatContent ? contentId : undefined,
+      };
       const allTools = {
         ...createBaseTools(toolCtx),
         ...(editableContentId ? createEditorTools(toolCtx) : {}),
@@ -450,6 +457,15 @@ IMPORTANT EDITING RULES:
 - Only use replace_document for blank/empty documents or when the user explicitly requests a full rewrite.
 
 When you generate an image, the user can insert it into the document at their cursor position.`
+            : isChatContent
+            ? `\n\nThe user is chatting with you on a full-page chat (ID: ${contentId}). DATA-MODEL FACT YOU MUST KNOW: this chat HAS a notes panel ("Add notes" — a TipTap editor below the conversation) keyed to the chat's own contentId. Writing to it is exactly the same as updating any other content's notes — call \`updateNote\` with the chat's contentId as the \`contentId\` argument. Do NOT create a separate file.
+
+NOTE-TOOL RULES IN CHAT CONTEXT:
+- "add a note to this chat", "create a note on this chat", "put X in the chat notes", "update the note in this chat" all mean: update the notes panel attached to THIS chat. Use \`updateNote({ contentId: "${contentId}", content: "<markdown>" })\`. NEVER set \`title\` — that would rename the chat.
+- For "create a NEW note in a folder" (separate file), use \`createNote\`. It defaults to the chat's parent folder.
+- For "update my Sourdough note" etc. (named other note), use \`searchNotes\` to find the id, then \`updateNote\`.
+- Tooling distinguishes by contentId — same tool, different target.
+- Title-arg rule: never set \`title\` unless the user EXPLICITLY says "rename this to X". Topic-derived titles are a bug. (The tool will hard-ignore \`title\` when the target is this chat, but still follow the rule.)`
             : ""
         }${mentionedContext}`,
         onStepFinish: (step) => {

--- a/app/api/content/content/[id]/route.ts
+++ b/app/api/content/content/[id]/route.ts
@@ -68,6 +68,7 @@ import type {
 } from "@/lib/domain/content/api-types";
 import type { StoredChatMessage } from "@/lib/domain/ai/types";
 import { softDeleteConversation } from "@/lib/features/conversations";
+import { publishConversationEvent } from "@/lib/features/conversations/events";
 
 type Params = Promise<{ id: string }>;
 
@@ -1227,6 +1228,51 @@ export async function PATCH(
               }
             },
           );
+        }
+      }
+
+      // Chat-content title cascade. A chat lives in TWO tables: ContentNode
+      // (what the file tree / tab read) and Conversation (what ChatViewer
+      // reads via useConversationBinding). Renaming from the file tree only
+      // touched ContentNode.title, leaving the conversation header showing
+      // the stale name. Mirror the title to the backing Conversation when
+      // it really changed, then publish `conversation.updated` so any open
+      // ChatViewer instance refreshes via SSE. Best-effort: a sync failure
+      // does not undo the successful content update.
+      if (
+        title !== undefined &&
+        title !== existing.title &&
+        existing.contentType === "chat"
+      ) {
+        try {
+          const backing = await prisma.conversation.findFirst({
+            where: {
+              archivedToContentNodeId: id,
+              ownerId: userId,
+              deletedAt: null,
+            },
+            select: { id: true },
+          });
+          if (backing) {
+            await prisma.conversation.update({
+              where: { id: backing.id },
+              data: { title: updated.title },
+            });
+            publishConversationEvent(userId, {
+              type: "conversation.updated",
+              conversationId: backing.id,
+              title: updated.title,
+              at: new Date().toISOString(),
+            });
+          }
+        } catch (error) {
+          logger.warn({
+            layer: "route",
+            event: "content.rename.conversation_sync_failed",
+            summary: `failed to mirror title to backing Conversation for ${id}`,
+            attrs: { content_id: id },
+            error,
+          });
         }
       }
 

--- a/app/api/content/content/create-document/route.ts
+++ b/app/api/content/content/create-document/route.ts
@@ -18,6 +18,15 @@ import { logger, spanPayload, withRouteTrace, withSpan } from "@/lib/core/logger
 
 const ROUTE_PATH = "/api/content/content/create-document";
 
+/**
+ * Permissive UUID regex (v1-v5). Used to short-circuit obviously-bad
+ * parentId values before they reach Prisma — specifically the
+ * `temp-{ts}-{rand}` placeholder ids the file-tree's optimistic-insert
+ * flow uses for not-yet-persisted parents.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export async function POST(request: NextRequest) {
   return withRouteTrace(request, { route: ROUTE_PATH }, async () => {
     try {
@@ -135,6 +144,25 @@ export async function POST(request: NextRequest) {
       }
 
       if (parentId) {
+        // Guard against the optimistic-create race in the file tree: when
+        // a child is requested while the parent's row hasn't been created
+        // yet, the client still has a "temp-{timestamp}-{rand}" placeholder
+        // id for the parent. Without this guard, Prisma would dispatch the
+        // string to PostgreSQL and the user sees a raw "invalid input
+        // syntax for type uuid" dialog. Return a tractable 400 instead.
+        if (!UUID_RE.test(parentId)) {
+          return NextResponse.json(
+            {
+              success: false,
+              error: {
+                code: "PARENT_NOT_READY",
+                message:
+                  "Parent folder is still being created — try again in a moment.",
+              },
+            },
+            { status: 400 },
+          );
+        }
         const parent = await prisma.contentNode.findUnique({
           where: { id: parentId },
           select: {

--- a/app/api/content/content/route.ts
+++ b/app/api/content/content/route.ts
@@ -35,6 +35,10 @@ import { logger, withRouteTrace, withSpan } from "@/lib/core/logger";
 
 const ROUTE_PATH = "/api/content/content";
 
+/** Permissive UUID v1-v5 — see create-document/route.ts for the rationale. */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 function getExternalDomainParts(url: string) {
   try {
     const parsed = new URL(url);
@@ -554,6 +558,24 @@ export async function POST(request: NextRequest) {
 
     // Validate parent exists
     if (parentId) {
+      // See create-document route for the rationale: optimistic file-tree
+      // inserts pass a `temp-{ts}-{rand}` placeholder for parents that
+      // haven't reached the DB yet. Short-circuit those to a clean 400
+      // instead of letting Prisma surface a raw "invalid input syntax for
+      // type uuid" dialog.
+      if (!UUID_RE.test(parentId)) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: {
+              code: "PARENT_NOT_READY",
+              message:
+                "Parent folder is still being created — try again in a moment.",
+            },
+          },
+          { status: 400 },
+        );
+      }
       const parent = await prisma.contentNode.findUnique({
         where: { id: parentId },
       });

--- a/app/api/conversations/[id]/fork/route.ts
+++ b/app/api/conversations/[id]/fork/route.ts
@@ -64,14 +64,34 @@ export async function POST(request: NextRequest, context: RouteContext) {
           { status: 404 },
         );
       }
+      // Capture the error class + message so prod investigations don't
+      // have to grep the stack trace. Prisma errors carry .code (e.g.
+      // P2002 unique violation, P2025 record not found) — surface it.
+      const errName = error instanceof Error ? error.name : "Unknown";
+      const errMsg = error instanceof Error ? error.message : String(error);
+      const errCode =
+        error && typeof error === "object" && "code" in error
+          ? String((error as { code: unknown }).code)
+          : null;
       logger.error({
         layer: "ai",
         event: "conversation_fork:caught",
-        summary: `POST ${ROUTE_PATH} caught — 500`,
+        summary: `POST ${ROUTE_PATH} caught — 500 (${errName}${errCode ? `:${errCode}` : ""})`,
+        attrs: {
+          err_name: errName,
+          err_code: errCode ?? "none",
+        },
         error,
       });
+      // Surface a short error tag in the body so the client toast can
+      // show something more actionable than "Fork failed". Avoid leaking
+      // raw error.message verbatim — keep it scoped to known classes.
+      const safeError =
+        errCode && errCode.startsWith("P")
+          ? `Fork failed (${errCode})`
+          : `Fork failed (${errName})`;
       return NextResponse.json(
-        { success: false, error: "Fork failed" },
+        { success: false, error: safeError },
         { status: 500 },
       );
     }

--- a/app/api/conversations/[id]/open-in-page/route.ts
+++ b/app/api/conversations/[id]/open-in-page/route.ts
@@ -56,14 +56,27 @@ export async function POST(request: NextRequest, context: RouteContext) {
           { status: 404 },
         );
       }
+      const errName = error instanceof Error ? error.name : "Unknown";
+      const errCode =
+        error && typeof error === "object" && "code" in error
+          ? String((error as { code: unknown }).code)
+          : null;
       logger.error({
         layer: "ai",
         event: "conversation_open_in_page:caught",
-        summary: `POST ${ROUTE_PATH} caught — 500`,
+        summary: `POST ${ROUTE_PATH} caught — 500 (${errName}${errCode ? `:${errCode}` : ""})`,
+        attrs: {
+          err_name: errName,
+          err_code: errCode ?? "none",
+        },
         error,
       });
+      const safeError =
+        errCode && errCode.startsWith("P")
+          ? `Open-in-page failed (${errCode})`
+          : `Open-in-page failed (${errName})`;
       return NextResponse.json(
-        { success: false, error: "Open-in-page failed" },
+        { success: false, error: safeError },
         { status: 500 },
       );
     }

--- a/components/common/FileNameInput.tsx
+++ b/components/common/FileNameInput.tsx
@@ -34,10 +34,16 @@ export function FileNameInput({
 }: FileNameInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isFocused, setIsFocused] = useState(false);
+  // Guard so the initial-position effect runs at most once per mount. Without
+  // this, parent re-renders that flip `focusBehavior` (or re-mount the input
+  // entirely) re-run the effect and snap the cursor back to the end on every
+  // keystroke / click / arrow press — making the input feel "stuck at -1".
+  const hasPositionedRef = useRef(false);
 
   // Auto-focus once on mount. Resumed edit sessions keep the caret at the end
   // instead of re-selecting the entire filename and clobbering the next keypress.
   useEffect(() => {
+    if (hasPositionedRef.current) return;
     if (autoFocus && inputRef.current) {
       inputRef.current.focus();
       if (focusBehavior === "select") {
@@ -46,6 +52,7 @@ export function FileNameInput({
         const { value } = inputRef.current;
         inputRef.current.setSelectionRange(value.length, value.length);
       }
+      hasPositionedRef.current = true;
     }
   }, [autoFocus, focusBehavior]);
 

--- a/components/content/FileNode.tsx
+++ b/components/content/FileNode.tsx
@@ -372,14 +372,19 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     e.preventDefault();
     e.stopPropagation();
 
-    // If right-clicking on a non-selected node, select it first
-    if (!node.isSelected) {
-      node.select();
-    }
-
-    // Get currently selected node IDs from the tree
+    // Previously this called `node.select()` when right-clicking a
+    // non-selected node — which routed through the tree's `onSelect`,
+    // which calls `setSelectedContentId`, which (for folders) navigates
+    // the main panel and triggers `FolderView` to fetch the folder's
+    // children. Right-clicking a folder shouldn't navigate to it; the
+    // user expects ONLY the context menu. We now scope the menu via
+    // `clickedId` instead — multi-select menus still work because we
+    // honor the EXISTING selection when the click is inside it.
     const tree = node.tree;
-    const selectedIds = tree.selectedNodes?.map((n: NodeApi<TreeNode>) => n.id) || [data.id];
+    const isInExistingSelection = node.isSelected;
+    const selectedIds = isInExistingSelection
+      ? tree.selectedNodes?.map((n: NodeApi<TreeNode>) => n.id) || [data.id]
+      : [data.id];
 
     openMenu(
       "file-tree",

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -12,6 +12,7 @@
 "use client";
 
 import { memo, useState, useCallback, useEffect, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { common, createLowlight } from "lowlight";
@@ -19,6 +20,7 @@ import { Bot, User, Wrench, Loader2, Copy, Check, ImagePlus, GripVertical, Brain
 import { cn } from "@/lib/core/utils";
 import { useContentStore } from "@/state/content-store";
 import { useSettingsStore } from "@/state/settings-store";
+import { useNotesPanelStore } from "@/state/notes-panel-store";
 import { useTypewriter } from "@/lib/domain/ai/use-typewriter";
 import type { UIMessage } from "ai";
 import type { Components } from "react-markdown";
@@ -72,6 +74,16 @@ function detectToolPart(part: unknown): DetectedToolPart | null {
     input: p.input,
     output: p.output,
   };
+}
+
+/** Shape of the note payload returned by createNote / updateNote tools. */
+interface NotePayload {
+  __notePayload: true;
+  kind: "created" | "updated";
+  contentId: string;
+  title: string;
+  parentId?: string | null;
+  wordCount?: number;
 }
 
 /** Shape of the image payload returned by generate_image tool */
@@ -220,13 +232,15 @@ export const ChatMessage = memo(function ChatMessage({
     onEdit?.(message.id, next);
   }, [draft, messageText, onEdit, message.id]);
 
-  // Pre-scan: extract image payloads from ALL tool parts at message level.
-  // This is more reliable than detecting inside the parts loop because it
+  // Pre-scan: extract image + note payloads from ALL tool parts at message
+  // level. More reliable than detecting inside the parts loop because it
   // handles streaming state transitions and part type variations.
-  const { imagePayloads, hasRunningTools } = useMemo(() => {
-    const payloads: ImagePayload[] = [];
+  const { imagePayloads, notePayloads, hasRunningTools } = useMemo(() => {
+    const images: ImagePayload[] = [];
+    const notes: NotePayload[] = [];
     let running = false;
-    const seenIds = new Set<string>();
+    const seenImageIds = new Set<string>();
+    const seenNoteIds = new Set<string>();
 
     for (const part of message.parts) {
       const tp = detectToolPart(part);
@@ -237,16 +251,32 @@ export const ChatMessage = memo(function ChatMessage({
       }
 
       if (tp.state === "output-available" && tp.output !== undefined) {
-        const payload = parseImagePayload(tp.output);
-        if (payload && !seenIds.has(payload.contentId)) {
-          seenIds.add(payload.contentId);
-          payloads.push(payload);
+        const image = parseImagePayload(tp.output);
+        if (image && !seenImageIds.has(image.contentId)) {
+          seenImageIds.add(image.contentId);
+          images.push(image);
+          continue;
+        }
+        const note = parseNotePayload(tp.output);
+        if (note && !seenNoteIds.has(note.contentId)) {
+          seenNoteIds.add(note.contentId);
+          notes.push(note);
         }
       }
     }
 
-    return { imagePayloads: payloads, hasRunningTools: running };
+    return {
+      imagePayloads: images,
+      notePayloads: notes,
+      hasRunningTools: running,
+    };
   }, [message.parts]);
+
+  // NOTE: tree-refresh + content-updated dispatch for AI note writes
+  // lives in `use-conversation-engine.ts` `onFinish` — fires exactly
+  // once per AI completion. Putting that logic here (in the render
+  // path) re-fired every time a historical assistant message mounted,
+  // which caused a refetch loop on page open. Do NOT move it back.
 
   return (
     <div
@@ -273,15 +303,24 @@ export const ChatMessage = memo(function ChatMessage({
           <User className="h-4 w-4" />
         </div>
       ) : (
-        <AssistantAvatar providerId={providerId} modelId={modelId} />
+        <AssistantAvatar
+          providerId={providerId}
+          modelId={modelId}
+          metadata={
+            (message as { metadata?: Record<string, unknown> }).metadata
+          }
+        />
       )}
 
-      {/* Message content */}
+      {/* Message content. User bubbles are positioned right via flex-row-reverse
+          (line ~267) and the action row uses its own justify-end, so we do NOT
+          add text-right here — keeping text-left makes line-wrapped bullet
+          lists / multi-line prompts read left-to-right while the bubble still
+          sits on the right side of the column. */}
       <div
         className={cn(
           "min-w-0 space-y-2",
           theme.bubble.columnClassName,
-          isUser && "text-right",
         )}
       >
         {/* Inline editor for user messages (Session 5a) */}
@@ -451,12 +490,12 @@ export const ChatMessage = memo(function ChatMessage({
 
           // Tool parts: detect via detectToolPart helper (handles both static and dynamic)
           // Image generation tool results render as GeneratedImageCard at message level below.
+          // Note creation/update tool results render as NotePayloadCard at message level below.
           const toolPart = detectToolPart(part);
           if (toolPart) {
-            // Skip image tool results — they render at message level
             if (toolPart.state === "output-available") {
-              const isImageResult = parseImagePayload(toolPart.output) !== null;
-              if (isImageResult) return null;
+              if (parseImagePayload(toolPart.output) !== null) return null;
+              if (parseNotePayload(toolPart.output) !== null) return null;
             }
 
             return (
@@ -476,6 +515,11 @@ export const ChatMessage = memo(function ChatMessage({
         {/* Image cards — rendered at message level for reliability */}
         {imagePayloads.map((payload) => (
           <GeneratedImageCard key={payload.contentId} payload={payload} />
+        ))}
+
+        {/* Note cards — clickable link affordance for createNote / updateNote */}
+        {notePayloads.map((payload) => (
+          <NotePayloadCard key={payload.contentId} payload={payload} />
         ))}
 
         {/* Thinking indicator — shows during tool execution */}
@@ -954,37 +998,89 @@ function renderHastNode(node: HastNode, key: number): React.ReactNode {
 // ─── Existing Sub-Components ─────────────────────────────────
 
 /**
- * Assistant avatar with provider/model tooltip.
+ * Assistant avatar with provider/model/usage tooltip.
  *
- * Tooltip shows after a 1-second deliberate hover — short hovers from
- * cursor passes don't trigger it. Background tints to the producing
- * provider's brand color so the avatar itself is an at-a-glance
- * provider indicator.
+ * Tooltip:
+ *   - shows after a 1-second deliberate hover (cursor-pass-through guard)
+ *   - rendered in a body-level portal anchored to the avatar's
+ *     getBoundingClientRect, so message-bubble overflow:hidden / rounded
+ *     corners can't clip or reflow it
+ *   - displays provider name + model name + this turn's input/output
+ *     tokens when present in message.metadata.usage
+ *
+ * Background tints to the producing provider's brand color so the
+ * avatar itself is an at-a-glance provider indicator.
  */
+type UsageShape = {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+} | undefined;
+
+function extractUsage(metadata: Record<string, unknown> | undefined): UsageShape {
+  if (!metadata || typeof metadata !== "object") return undefined;
+  const usage = (metadata as { usage?: unknown }).usage;
+  if (!usage || typeof usage !== "object") return undefined;
+  const u = usage as Record<string, unknown>;
+  const num = (v: unknown): number | undefined =>
+    typeof v === "number" && Number.isFinite(v) ? v : undefined;
+  return {
+    inputTokens: num(u.inputTokens),
+    outputTokens: num(u.outputTokens),
+    totalTokens: num(u.totalTokens),
+  };
+}
+
 function AssistantAvatar({
   providerId,
   modelId,
+  metadata,
 }: {
   providerId?: string | null;
   modelId?: string | null;
+  metadata?: Record<string, unknown>;
 }) {
-  const [showTooltip, setShowTooltip] = useState(false);
+  const [tooltipAnchor, setTooltipAnchor] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [portalReady, setPortalReady] = useState(false);
 
   const theme = getProviderTheme(providerId);
   const provider = PROVIDER_CATALOG.find((p) => p.id === providerId);
   const model = provider?.models.find((m) => m.id === modelId);
   const providerName = provider?.name ?? "AI assistant";
   const modelName = model?.name ?? modelId ?? null;
+  const usage = useMemo(() => extractUsage(metadata), [metadata]);
+
+  useEffect(() => {
+    // One-shot SSR/hydration boundary marker so we only render the
+    // portal once `document.body` is present. The React Compiler flags
+    // "setState in effect" defensively here; this is the same one-shot
+    // pattern used by the right-sidebar hydration hook, not a render-
+    // synchronization bug.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot post-mount marker
+    setPortalReady(typeof document !== "undefined");
+  }, []);
 
   const handleEnter = useCallback(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setShowTooltip(true), 1000);
+    timerRef.current = setTimeout(() => {
+      const rect = anchorRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      // Anchor to the right edge of the avatar, vertically centered.
+      setTooltipAnchor({
+        top: rect.top + rect.height / 2,
+        left: rect.right + 8, // 8px gap (matches the prior `ml-2`)
+      });
+    }, 1000);
   }, []);
 
   const handleLeave = useCallback(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
-    setShowTooltip(false);
+    setTooltipAnchor(null);
   }, []);
 
   useEffect(() => {
@@ -995,7 +1091,8 @@ function AssistantAvatar({
 
   return (
     <div
-      className="relative shrink-0"
+      ref={anchorRef}
+      className="shrink-0"
       onMouseEnter={handleEnter}
       onMouseLeave={handleLeave}
     >
@@ -1009,25 +1106,56 @@ function AssistantAvatar({
       >
         <Bot className="h-4 w-4" />
       </div>
-      {showTooltip && (
-        <div
-          role="tooltip"
-          className="absolute left-full top-1/2 ml-2 z-50 -translate-y-1/2 whitespace-nowrap rounded-md border border-white/10 bg-[#1a1a1a] px-2.5 py-1.5 text-[10px] text-gray-200 shadow-xl"
-        >
-          <div className="flex items-center gap-1.5">
-            <span
-              className="h-2 w-2 shrink-0 rounded-full"
-              style={{ background: theme.brandColor }}
-            />
-            <span className="font-medium">{providerName}</span>
-          </div>
-          {modelName && (
-            <div className="mt-0.5 text-gray-500 dark:text-gray-400">
-              {modelName}
+      {portalReady && tooltipAnchor &&
+        createPortal(
+          <div
+            role="tooltip"
+            // Fixed positioning relative to the viewport — no ancestor
+            // overflow / transform can clip or reflow this.
+            style={{
+              position: "fixed",
+              top: tooltipAnchor.top,
+              left: tooltipAnchor.left,
+              transform: "translateY(-50%)",
+              zIndex: 9999,
+            }}
+            className="pointer-events-none whitespace-nowrap rounded-md border border-white/10 bg-[#1a1a1a] px-2.5 py-1.5 text-[10px] text-gray-200 shadow-xl"
+          >
+            <div className="flex items-center gap-1.5">
+              <span
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ background: theme.brandColor }}
+              />
+              <span className="font-medium">{providerName}</span>
             </div>
-          )}
-        </div>
-      )}
+            {modelName && (
+              <div className="mt-0.5 text-gray-500 dark:text-gray-400">
+                {modelName}
+              </div>
+            )}
+            {usage && (usage.inputTokens != null || usage.outputTokens != null) && (
+              <div className="mt-1 flex items-center gap-2 border-t border-white/10 pt-1 text-gray-400 dark:text-gray-500">
+                {usage.inputTokens != null && (
+                  <span>
+                    <span className="text-gray-500">in</span>{" "}
+                    <span className="tabular-nums text-gray-300">
+                      {usage.inputTokens.toLocaleString()}
+                    </span>
+                  </span>
+                )}
+                {usage.outputTokens != null && (
+                  <span>
+                    <span className="text-gray-500">out</span>{" "}
+                    <span className="tabular-nums text-gray-300">
+                      {usage.outputTokens.toLocaleString()}
+                    </span>
+                  </span>
+                )}
+              </div>
+            )}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }
@@ -1057,6 +1185,20 @@ function parseImagePayload(result: unknown): ImagePayload | null {
     if (parsed.__imagePayload) return parsed as ImagePayload;
   } catch {
     // not valid JSON
+  }
+  return null;
+}
+
+/** Parse a note payload (createNote / updateNote) from a tool result. */
+function parseNotePayload(result: unknown): NotePayload | null {
+  if (result === undefined) return null;
+  const str = typeof result === "string" ? result : JSON.stringify(result);
+  if (!str.includes('"__notePayload"')) return null;
+  try {
+    const parsed = JSON.parse(str);
+    if (parsed.__notePayload) return parsed as NotePayload;
+  } catch {
+    /* not valid JSON */
   }
   return null;
 }
@@ -1263,6 +1405,69 @@ function toolActionLabel(toolName: string, isRunning: boolean): string {
  * - Draggable via HTML5 drag with image URL in dataTransfer,
  *   compatible with TipTap's image drop handler.
  */
+/**
+ * Inline card rendered when createNote / updateNote tool returns. Replaces
+ * the raw "Created note (id: …)" string with a clickable affordance that
+ * opens the note in the main panel. Compact so it doesn't dominate the
+ * assistant turn — Bug C target.
+ */
+function NotePayloadCard({ payload }: { payload: NotePayload }) {
+  // Self-edit detection: the AI updated this very chat's own sidecar
+  // notes (same contentId as the open content). In that case clicking
+  // "open" doesn't make sense — you're already here — so instead we
+  // expand + scroll to the Notes editor panel below the chat. For
+  // non-self payloads (a different note got created or updated), the
+  // click navigates to that content as before.
+  const selectedContentId = useContentStore((s) => s.selectedContentId);
+  const isSelfEdit = selectedContentId === payload.contentId;
+
+  const handleClick = useCallback(() => {
+    if (isSelfEdit) {
+      useNotesPanelStore.getState().setExpanded(true);
+      // Defer scroll until React has had a chance to render the
+      // newly-expanded panel.
+      setTimeout(() => {
+        document
+          .getElementById("notes-panel-anchor")
+          ?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }, 0);
+      return;
+    }
+    useContentStore.getState().setSelectedContentId(payload.contentId);
+  }, [isSelfEdit, payload.contentId]);
+
+  const verb = payload.kind === "updated" ? "Updated" : "Created";
+  const wordCount =
+    typeof payload.wordCount === "number" && payload.wordCount > 0
+      ? ` · ${payload.wordCount.toLocaleString()} word${payload.wordCount === 1 ? "" : "s"}`
+      : "";
+  const subline = isSelfEdit
+    ? `${verb} this chat's notes${wordCount} · click to view`
+    : `${verb} note${wordCount} · click to open`;
+  const tooltipText = isSelfEdit
+    ? "View the updated notes for this chat"
+    : `Open "${payload.title}"`;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="group inline-flex max-w-full items-center gap-2 rounded-lg border border-black/10 bg-black/[0.03] px-3 py-2 text-left text-sm transition-colors hover:border-blue-400/40 hover:bg-blue-500/5 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
+      title={tooltipText}
+    >
+      <FileText className="h-4 w-4 shrink-0 text-blue-500 dark:text-blue-400" />
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate font-medium text-gray-900 group-hover:text-blue-700 dark:text-gray-100 dark:group-hover:text-blue-300">
+          {payload.title}
+        </span>
+        <span className="text-[11px] text-gray-500 dark:text-gray-400">
+          {subline}
+        </span>
+      </span>
+    </button>
+  );
+}
+
 function GeneratedImageCard({ payload }: { payload: ImagePayload }) {
   const [inserted, setInserted] = useState(false);
   const selectedContentType = useContentStore((s) => s.selectedContentType);

--- a/components/content/content/LeftSidebarContent.tsx
+++ b/components/content/content/LeftSidebarContent.tsx
@@ -662,58 +662,58 @@ export function LeftSidebarContent({
   }) => {
     const { dragIds, parentId, index } = args;
 
-    // Store original tree state for rollback if move fails
+    // Store original tree state for rollback if any move fails
     const originalTree = treeData;
 
-    if (!originalTree) return;
+    if (!originalTree || dragIds.length === 0) return;
 
-    // Find the dragged node's current position
-    let currentParentId: string | null = null;
-    let currentIndex = -1;
-
-    const findNode = (nodes: TreeNode[], parent: string | null = null): boolean => {
+    // Find each dragged node's current position. Computed up-front so
+    // we don't re-traverse the tree N times in the loop, and so the
+    // displayOrder math below can correctly adjust for each item's
+    // own pre-move location (different items may live in different
+    // parents under a multi-select drag).
+    const positions = new Map<
+      string,
+      { currentParentId: string | null; currentIndex: number }
+    >();
+    const findPositions = (nodes: TreeNode[], parent: string | null = null) => {
       for (let i = 0; i < nodes.length; i++) {
-        if (nodes[i].id === dragIds[0]) {
-          currentParentId = parent;
-          currentIndex = i;
-          return true;
+        if (dragIds.includes(nodes[i].id)) {
+          positions.set(nodes[i].id, { currentParentId: parent, currentIndex: i });
         }
         if (nodes[i].children && nodes[i].children.length > 0) {
-          if (findNode(nodes[i].children, nodes[i].id)) {
-            return true;
-          }
+          findPositions(nodes[i].children, nodes[i].id);
         }
       }
-      return false;
     };
+    findPositions(originalTree);
 
-    findNode(originalTree);
-
-    // Check if this is actually a position change
-    const isSameParent = currentParentId === parentId;
-    const isSamePosition = isSameParent && (currentIndex === index || currentIndex === index - 1);
-    const draggedNode = findTreeNode(originalTree, dragIds[0]);
-
-    if (isSamePosition) {
-      return; // Skip the move - item is being dropped in same position
-    }
-
-    if (!draggedNode) {
+    // Resolve every dragged node. If any can't be found we bail before
+    // touching the optimistic tree.
+    const dragged = dragIds
+      .map((id) => ({ id, node: findTreeNode(originalTree, id) }))
+      .filter((x): x is { id: string; node: TreeNode } => x.node !== null);
+    if (dragged.length !== dragIds.length) {
       toast.error("Failed to move item", {
-        description: "The dragged item could not be found in the current tree.",
+        description: "One or more dragged items could not be found in the current tree.",
       });
       return;
     }
 
-    if (isPeopleTreeNode(draggedNode) && dragIds.length > 1) {
+    // People-mount drags are routed through a different endpoint and
+    // cannot be batched. Reject any multi-drag that includes one.
+    const peopleDragged = dragged.filter((d) => isPeopleTreeNode(d.node));
+    if (peopleDragged.length > 0 && dragged.length > 1) {
       toast.error("Failed to move item", {
         description: "People mounts can only be moved one at a time.",
       });
       return;
     }
 
+    // For the people single-drag path: reject placement into virtual
+    // people parents (only real folders or root are allowed).
     if (
-      isPeopleTreeNode(draggedNode) &&
+      peopleDragged.length === 1 &&
       (parentId?.startsWith("peopleGroup:") || parentId?.startsWith("person:"))
     ) {
       toast.error("Failed to move item", {
@@ -723,67 +723,110 @@ export function LeftSidebarContent({
       return;
     }
 
+    // Skip no-op drops: every dragged item is already at its target
+    // position (same parent, adjacent index). React-arborist sometimes
+    // fires `onMove` even when the user just released without changing
+    // anything.
+    const everyDragIsNoop = dragged.every(({ id }) => {
+      const pos = positions.get(id);
+      if (!pos) return false;
+      const isSameParent = pos.currentParentId === parentId;
+      return (
+        isSameParent &&
+        (pos.currentIndex === index || pos.currentIndex === index - 1)
+      );
+    });
+    if (everyDragIsNoop) return;
+
     try {
-      // OPTIMISTIC UPDATE: Apply the move immediately to the UI
-      const optimisticTree = applyMoveToTree(originalTree, dragIds[0], parentId, index);
+      // OPTIMISTIC UPDATE: walk every dragged id and apply each move to
+      // the working tree, offsetting the index by i so items keep their
+      // drag-order in the destination.
+      let optimisticTree = originalTree;
+      for (let i = 0; i < dragged.length; i++) {
+        optimisticTree = applyMoveToTree(
+          optimisticTree,
+          dragged[i].id,
+          parentId,
+          index + i,
+        );
+      }
       setTreeData(optimisticTree);
 
-      // Calculate the API index: react-arborist gives us insertion point, but server expects final visual position
-      // If moving down within same parent, we need to subtract 1 because server removes item first
-      let apiIndex = index;
-      if (isSameParent && currentIndex < index) {
-        apiIndex = index - 1; // Adjust for removal shifting items left
+      // Fire the moves sequentially. Parallel POSTs against the move
+      // endpoint would race each other on displayOrder slot assignment
+      // (the server computes the final slot from current children).
+      // Sequential keeps the contract simple and yields stable order.
+      const failures: Array<{ id: string; message: string }> = [];
+      for (let i = 0; i < dragged.length; i++) {
+        const { id, node } = dragged[i];
+        const pos = positions.get(id);
+        const isSameParent = pos?.currentParentId === parentId;
+        const insertionIndex = index + i;
+        // react-arborist gives the insertion point; the server expects
+        // the final visual position. When moving DOWN within the same
+        // parent, subtract 1 to account for the item's own removal
+        // shifting everything left.
+        const apiIndex =
+          isSameParent && pos && pos.currentIndex < insertionIndex
+            ? insertionIndex - 1
+            : insertionIndex;
+
+        const response = isPeopleTreeNode(node)
+          ? await fetch("/api/people/mounts", {
+              method: "POST",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                target: toPeopleMountTarget(node),
+                contentParentId: parentId,
+                displayOrder: apiIndex,
+                allowRemount: true,
+              }),
+            })
+          : await fetch("/api/content/content/move", {
+              method: "POST",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                contentId: id,
+                targetParentId: parentId,
+                newDisplayOrder: apiIndex,
+              }),
+            });
+
+        const result = await response.json().catch(() => ({}) as { error?: { message?: string; code?: string }; success?: boolean });
+        if (!response.ok || !result.success) {
+          failures.push({
+            id,
+            message: result.error?.message ?? `HTTP ${response.status}`,
+          });
+        }
       }
 
-      const response = isPeopleTreeNode(draggedNode)
-        ? await fetch("/api/people/mounts", {
-            method: "POST",
-            credentials: "include",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              target: toPeopleMountTarget(draggedNode),
-              contentParentId: parentId,
-              displayOrder: apiIndex,
-              allowRemount: true,
-            }),
-          })
-        : await fetch("/api/content/content/move", {
-            method: "POST",
-            credentials: "include",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              contentId: dragIds[0], // Only support single drag for now
-              targetParentId: parentId,
-              newDisplayOrder: apiIndex,
-            }),
-          });
-
-      const result = await response.json();
-
-      if (!response.ok || !result.success) {
+      if (failures.length > 0) {
         clientLogger.error({
           layer: "ui",
           event: "tree_move:failed",
-          summary: "tree move api rejected",
+          summary: `tree move api rejected ${failures.length}/${dragged.length} item(s)`,
           attrs: {
-            content_id: dragIds[0],
             target_parent_id: parentId ?? "root",
-            error_code: result.error?.code ?? "unknown",
+            failure_count: failures.length,
+            total_count: dragged.length,
+            first_failure: failures[0]?.message ?? "unknown",
           },
         });
-        // Rollback to original tree state
+        // Rollback to original tree state so the UI matches truth.
         setTreeData(originalTree);
-        toast.error("Failed to move item", {
-          description: result.error?.message || "Could not move the item to the new location. Please try again.",
-        });
-        throw new Error(result.error?.message || "Failed to move content");
+        const desc =
+          failures.length === dragged.length
+            ? failures[0].message
+            : `${failures.length} of ${dragged.length} items could not be moved (${failures[0].message}).`;
+        toast.error("Failed to move item", { description: desc });
+        throw new Error(desc);
       }
 
-      if (isPeopleTreeNode(draggedNode)) {
+      if (peopleDragged.length > 0) {
         window.dispatchEvent(new CustomEvent("dg:tree-refresh"));
         window.dispatchEvent(new CustomEvent("dg:people-refresh"));
       }
@@ -792,7 +835,10 @@ export function LeftSidebarContent({
         layer: "ui",
         event: "tree_move:caught",
         summary: "tree move handler caught",
-        attrs: { content_id: dragIds[0] ?? "unknown" },
+        attrs: {
+          content_id: dragIds[0] ?? "unknown",
+          drag_count: dragIds.length,
+        },
         error: err,
       });
       // Rollback to original tree state on any error
@@ -996,6 +1042,23 @@ export function LeftSidebarContent({
       requestParentId: parentId,
       ...parsePeopleVirtualParentId(parentId),
     };
+
+    // Race guard: if the resolved server-side parent is still a `temp-…`
+    // placeholder, the parent's optimistic insert hasn't been confirmed
+    // by the server yet. Sending this would surface the raw Prisma
+    // "invalid input syntax for type uuid" error (server now translates
+    // it to PARENT_NOT_READY, but skipping the round-trip is friendlier).
+    // The user can retry in a moment once the parent's real UUID lands.
+    const reqParent = createTarget.requestParentId;
+    if (typeof reqParent === "string" && reqParent.startsWith("temp-")) {
+      setErrorDialog({
+        title: "Parent still being created",
+        message:
+          "The parent folder hasn't finished saving yet. Wait a moment and try again.",
+      });
+      handleCreateCancel();
+      return;
+    }
     const optimisticContentType: ContentType =
       type === "docx" || type === "xlsx" || type === "json"
         ? "file"

--- a/components/content/content/MainPanelContent.tsx
+++ b/components/content/content/MainPanelContent.tsx
@@ -705,6 +705,52 @@ export function MainPanelContent({ paneId, initialContent = null }: MainPanelCon
     };
   }, [selectedContentId, updateContentTab]);
 
+  // Targeted notes-only refresh — fired by `use-conversation-engine`'s
+  // onFinish when the AI's updateNote tool writes new note content.
+  // Why a separate path from `content-updated`: that listener triggers
+  // `refreshTrigger++`, which re-runs `fetchNote`, which resets loading
+  // state, re-extracts the outline, syncs the tab title, and reloads
+  // ALL content. The user only sees the note panel change, but every
+  // surface flickers. This handler does the minimum work — a small GET
+  // on the content endpoint, then a single `setNoteContent` — so only
+  // the editor's content updates. Pane scoping is automatic because the
+  // listener gates on `selectedContentId === detail.contentId`; in a
+  // multi-pane layout, every pane that has this content open reacts
+  // (including non-focused panes — the user expects them to stay in
+  // sync even when they're not the active one).
+  useEffect(() => {
+    const handler = async (event: Event) => {
+      const detail = (event as CustomEvent<{ contentId: string }>).detail;
+      if (!detail?.contentId) return;
+      if (detail.contentId !== selectedContentId) return;
+      try {
+        const res = await fetch(
+          `/api/content/content/${encodeURIComponent(detail.contentId)}`,
+          { credentials: "include" },
+        );
+        if (!res.ok) return;
+        // ContentDetailResponse exposes the NotePayload as `data.note`
+        // (not `data.notePayload`). Read site has to match the route's
+        // formatter at app/api/content/content/[id]/route.ts:397.
+        const body = (await res.json()) as {
+          data?: {
+            note?: { tiptapJson?: JSONContent };
+          };
+        };
+        const json = body?.data?.note?.tiptapJson;
+        if (json) {
+          setNoteContent(json);
+        }
+      } catch {
+        /* silent — user can always trigger a full refresh manually */
+      }
+    };
+    window.addEventListener("dg:notes-refresh", handler);
+    return () => {
+      window.removeEventListener("dg:notes-refresh", handler);
+    };
+  }, [selectedContentId]);
+
   // Stats change handler
   const handleStatsChange = useCallback(
     (stats: EditorStats) => {

--- a/components/content/context-menu/file-tree-actions.tsx
+++ b/components/content/context-menu/file-tree-actions.tsx
@@ -337,7 +337,12 @@ export const fileTreeActionProvider: ContextMenuActionProvider = (ctx) => {
         },
         {
           id: "toggle-referenced",
-          label: clickedNode?.includeReferencedContent ? "Hide Referenced Content" : "Show Referenced Content",
+          // Scoped to THIS folder. Distinct from the tree-wide toggle in
+          // Section 8 ("Show all referenced content"). The labels used to
+          // collide as "Show Referenced Content" in both places.
+          label: clickedNode?.includeReferencedContent
+            ? "Hide referenced content in this folder"
+            : "Show referenced content in this folder",
           icon: clickedNode?.includeReferencedContent ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />,
           onClick: async () => {
             if (onToggleReferencedContent) {
@@ -569,9 +574,11 @@ export const fileTreeActionProvider: ContextMenuActionProvider = (ctx) => {
       actions: [
         {
           id: "toggle-referenced-content",
+          // Tree-wide filter. Section 2 has a per-folder variant labeled
+          // "Show referenced content in this folder" — distinct scope.
           label: showReferencedContent
-            ? "Hide referenced content"
-            : "Show referenced content",
+            ? "Hide all referenced content"
+            : "Show all referenced content",
           icon: showReferencedContent ? (
             <EyeOff className="h-4 w-4" />
           ) : (

--- a/components/content/editor/ExpandableEditor.tsx
+++ b/components/content/editor/ExpandableEditor.tsx
@@ -117,7 +117,9 @@ export function ExpandableEditor({
   );
 
   return (
-    <div className="border-t border-white/10">
+    // `id` here is the scroll target for the AI's "click to view" link
+    // on self-edit `NotePayloadCard`s — see ChatMessage.tsx.
+    <div id="notes-panel-anchor" className="border-t border-white/10">
       {/* Collapsible Header */}
       <div
         className={cn(

--- a/components/content/viewer/ChatViewer.tsx
+++ b/components/content/viewer/ChatViewer.tsx
@@ -268,6 +268,20 @@ function ChatViewerInner({
   const handleBranch = useCallback(
     async (messageId: string) => {
       if (!conversationId) return;
+      // Helper: pull the most useful error string out of a non-OK response.
+      // The server now returns shape `{ success: false, error: string }`
+      // with a code-bearing tag (e.g. "Fork failed (P2002)"). Falling back
+      // to status text + status code if the body isn't parseable keeps the
+      // toast informative even when the server crashed pre-body.
+      const readErr = async (res: Response, fallback: string) => {
+        try {
+          const body = (await res.json()) as { error?: string };
+          if (body?.error) return body.error;
+        } catch {
+          /* unparseable */
+        }
+        return `${fallback} (${res.status})`;
+      };
       try {
         const forkRes = await fetch(
           `/api/conversations/${encodeURIComponent(conversationId)}/fork`,
@@ -278,22 +292,25 @@ function ChatViewerInner({
             body: JSON.stringify({ uptoMessageId: messageId }),
           },
         );
-        if (!forkRes.ok) throw new Error("Branch failed");
+        if (!forkRes.ok) throw new Error(await readErr(forkRes, "Fork failed"));
         const newId = (await forkRes.json())?.data?.conversationId as
           | string
           | undefined;
-        if (!newId) return;
+        if (!newId) throw new Error("Fork returned no conversation id");
+
         const openRes = await fetch(
           `/api/conversations/${encodeURIComponent(newId)}/open-in-page`,
           { method: "POST", credentials: "include" },
         );
+        if (!openRes.ok)
+          throw new Error(await readErr(openRes, "Open-in-page failed"));
         const nodeId = (await openRes.json())?.data?.contentNodeId as
           | string
           | undefined;
-        if (nodeId) {
-          toast.success("Branched into a new chat");
-          useContentStore.getState().setSelectedContentId(nodeId);
-        }
+        if (!nodeId) throw new Error("Open-in-page returned no content node id");
+
+        toast.success("Branched into a new chat");
+        useContentStore.getState().setSelectedContentId(nodeId);
       } catch (e) {
         toast.error(e instanceof Error ? e.message : "Branch failed");
       }

--- a/components/settings/AIFeatureRoutingPage.tsx
+++ b/components/settings/AIFeatureRoutingPage.tsx
@@ -37,16 +37,32 @@ export default function AIFeatureRoutingPage({ embedded }: AIFeatureRoutingPageP
   const [connections, setConnections] = useState<ConnectionView[]>([]);
   const [routes, setRoutes] = useState<Record<string, RouteEntry[]>>({});
   const [loading, setLoading] = useState(true);
+  // Free-form steering for the follow-up generator. Persisted as
+  // `settings.ai.followUpsPrompt`; appended to the generator's default
+  // prompt server-side. Kept here (not inside FeatureRow) because the
+  // value lives in user settings, not in feature-route entries.
+  const [followUpsPrompt, setFollowUpsPrompt] = useState("");
+  const [savedFollowUpsPrompt, setSavedFollowUpsPrompt] = useState("");
+  const [savingFollowUpsPrompt, setSavingFollowUpsPrompt] = useState(false);
+  const followUpsPromptDirty = followUpsPrompt !== savedFollowUpsPrompt;
 
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
-      const [connsRes, routesRes] = await Promise.all([
+      const [connsRes, routesRes, settingsRes] = await Promise.all([
         fetch("/api/ai/connections", { credentials: "include" }),
         fetch("/api/ai/feature-routes", { credentials: "include" }),
+        fetch("/api/user/settings", { credentials: "include" }),
       ]);
       const connsBody = await connsRes.json();
       const routesBody = await routesRes.json();
+      const settingsBody = await settingsRes.json().catch(() => null);
+      const raw =
+        (settingsBody?.data?.settings?.ai as
+          | { followUpsPrompt?: string }
+          | undefined)?.followUpsPrompt ?? "";
+      setFollowUpsPrompt(raw);
+      setSavedFollowUpsPrompt(raw);
       setConnections(connsBody?.data?.items ?? []);
       const byFeature = routesBody?.data?.byFeature ?? {};
       const normalized: Record<string, RouteEntry[]> = {};
@@ -87,6 +103,27 @@ export default function AIFeatureRoutingPage({ embedded }: AIFeatureRoutingPageP
     [],
   );
 
+  const saveFollowUpsPrompt = useCallback(async () => {
+    setSavingFollowUpsPrompt(true);
+    try {
+      const next = followUpsPrompt.trim().slice(0, 600);
+      const res = await fetch("/api/user/settings", {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ai: { followUpsPrompt: next } }),
+      });
+      if (!res.ok) throw new Error("Failed to save follow-up prompt");
+      setSavedFollowUpsPrompt(next);
+      setFollowUpsPrompt(next);
+      toast.success("Follow-up steering saved");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSavingFollowUpsPrompt(false);
+    }
+  }, [followUpsPrompt]);
+
   return (
     <div className={embedded ? "space-y-6" : "max-w-4xl mx-auto p-6 space-y-6"}>
       <header>
@@ -116,25 +153,73 @@ export default function AIFeatureRoutingPage({ embedded }: AIFeatureRoutingPageP
           </Link>
         </div>
       ) : (
-        <ul className="space-y-3">
-          {FEATURE_REGISTRY.map((feature) => {
-            const entries = routes[feature.id] ?? [];
-            // Remount on entries-change rather than useEffect-syncing
-            // local state — avoids the React Compiler's setState-in-
-            // effect cascade rule.
-            const remountKey = `${feature.id}::${JSON.stringify(entries)}`;
-            return (
-              <FeatureRow
-                key={remountKey}
-                feature={feature}
-                connections={connections}
-                entries={entries}
-                onSave={(next) => void handleSetRoutes(feature.id, next)}
-                glass0={glass0}
-              />
-            );
-          })}
-        </ul>
+        <>
+          <ul className="space-y-3">
+            {FEATURE_REGISTRY.map((feature) => {
+              const entries = routes[feature.id] ?? [];
+              // Remount on entries-change rather than useEffect-syncing
+              // local state — avoids the React Compiler's setState-in-
+              // effect cascade rule.
+              const remountKey = `${feature.id}::${JSON.stringify(entries)}`;
+              return (
+                <FeatureRow
+                  key={remountKey}
+                  feature={feature}
+                  connections={connections}
+                  entries={entries}
+                  onSave={(next) => void handleSetRoutes(feature.id, next)}
+                  glass0={glass0}
+                />
+              );
+            })}
+          </ul>
+
+          {/* Follow-ups steering — free-form prompt appended to the
+              generator's system instructions. Sits alongside the
+              follow-ups feature row above because the model lives there
+              but the prompt's value belongs in user settings. */}
+          <section
+            className="rounded-xl border border-white/10 p-4 space-y-3"
+            style={{ background: glass0.background }}
+          >
+            <div>
+              <h3 className="text-sm font-medium text-white">
+                Follow-up steering
+              </h3>
+              <p className="mt-1 text-xs text-gray-500">
+                Optional free-form guidance appended to the follow-up
+                generator&apos;s prompt. Example: &ldquo;Focus on next
+                experiments and pitfalls to watch for. Skip rephrasings of
+                the last assistant turn.&rdquo;
+              </p>
+            </div>
+            <textarea
+              value={followUpsPrompt}
+              onChange={(e) =>
+                setFollowUpsPrompt(e.target.value.slice(0, 600))
+              }
+              rows={3}
+              maxLength={600}
+              placeholder="What should the follow-up suggestions focus on?"
+              className="w-full resize-y rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm text-white placeholder:text-gray-500 focus:border-blue-400/40 focus:outline-none"
+            />
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-[11px] text-gray-500">
+                {followUpsPrompt.length}/600 characters
+              </span>
+              {followUpsPromptDirty && (
+                <Button
+                  size="sm"
+                  onClick={() => void saveFollowUpsPrompt()}
+                  disabled={savingFollowUpsPrompt}
+                >
+                  <Check className="h-3.5 w-3.5 mr-1" />
+                  {savingFollowUpsPrompt ? "Saving…" : "Save"}
+                </Button>
+              )}
+            </div>
+          </section>
+        </>
       )}
     </div>
   );

--- a/lib/domain/ai/follow-ups.ts
+++ b/lib/domain/ai/follow-ups.ts
@@ -20,6 +20,7 @@ import {
   getConnectionWithKey,
   listConnections,
 } from "@/lib/features/ai-connections";
+import { getUserSettings } from "@/lib/features/settings";
 import { logger } from "@/lib/core/logger";
 
 /** Zod schema for the generator's structured output. */
@@ -96,23 +97,50 @@ export async function generateFollowUps(
       }
     }
 
+    // Optional user-supplied steering — appended to the default
+    // instructions so the model can still produce well-formed structured
+    // output. Read defensively: bad/missing settings must not break
+    // generation (we just fall back to the default prompt).
+    let userGuidance = "";
+    try {
+      const settings = await getUserSettings(userId);
+      const raw = (settings.ai as { followUpsPrompt?: unknown } | undefined)
+        ?.followUpsPrompt;
+      if (typeof raw === "string" && raw.trim().length > 0) {
+        userGuidance = raw.trim().slice(0, 600);
+      }
+    } catch {
+      /* settings unavailable — generate with defaults */
+    }
+
+    const promptLines = [
+      "You are helping a user continue an AI chat.",
+      "Given the exchange below, return 2-3 short follow-up prompts the",
+      "user could reasonably send next. Phrase them as questions or",
+      "instructions in the user's voice (first-person, imperative or",
+      "interrogative). Each must stand alone and be under ~120 chars.",
+      "Do not number them. Do not preface with 'You could ask:' etc.",
+    ];
+    if (userGuidance) {
+      promptLines.push(
+        "",
+        "Additional guidance from the user (steers the suggestions):",
+        userGuidance,
+      );
+    }
+    promptLines.push(
+      "",
+      `User: ${truncate(lastUserText, 800)}`,
+      `Assistant: ${truncate(lastAssistantText, 1600)}`,
+    );
+
     const result = await generateObject({
       // resolveChat* returns the right language-model shape but the
       // shared type is wider; cast at the call boundary keeps the helper
       // tolerant to both direct and connection-routed models.
       model,
       schema: FollowUpsSchema,
-      prompt: [
-        "You are helping a user continue an AI chat.",
-        "Given the exchange below, return 2-3 short follow-up prompts the",
-        "user could reasonably send next. Phrase them as questions or",
-        "instructions in the user's voice (first-person, imperative or",
-        "interrogative). Each must stand alone and be under ~120 chars.",
-        "Do not number them. Do not preface with 'You could ask:' etc.",
-        "",
-        `User: ${truncate(lastUserText, 800)}`,
-        `Assistant: ${truncate(lastAssistantText, 1600)}`,
-      ].join("\n"),
+      prompt: promptLines.join("\n"),
     });
 
     return result.object.suggestions;

--- a/lib/domain/ai/tools/metadata.ts
+++ b/lib/domain/ai/tools/metadata.ts
@@ -17,6 +17,7 @@ export const BASE_TOOL_IDS = [
   "searchNotes",
   "getCurrentNote",
   "createNote",
+  "updateNote",
   "generate_image",
 ] as const;
 
@@ -51,6 +52,10 @@ export const BASE_TOOL_METADATA: Record<BaseToolId, BaseToolMeta> = {
   createNote: {
     name: "Create Note",
     description: "Create a new note with a title and optional content",
+  },
+  updateNote: {
+    name: "Update Note",
+    description: "Update an existing note's content (and optionally its title)",
   },
   generate_image: {
     name: "Generate Image",

--- a/lib/domain/ai/tools/registry.ts
+++ b/lib/domain/ai/tools/registry.ts
@@ -12,6 +12,7 @@
 import { tool } from "ai";
 import { z } from "zod/v4";
 import { prisma } from "@/lib/database/client";
+import type { Prisma } from "@/lib/database/generated/prisma";
 import {
   generateUniqueSlug,
   extractSearchTextFromTipTap,
@@ -68,6 +69,39 @@ async function resolveImageGenRoute(
     // settings couldn't be read.
     return aiArgs;
   }
+}
+
+/**
+ * Detect markdownToTiptap's silent fallback. The fallback wraps the
+ * entire markdown string as a SINGLE plain-text paragraph — so the user
+ * sees raw `### Heading` / `- **Bold**` text in the rendered note
+ * instead of structured TipTap nodes (Bug G). When this happens we
+ * upgrade to a paragraph-per-blank-line split so at least newline
+ * structure survives.
+ */
+function isMarkdownFallback(
+  json: { content?: Array<{ type?: string; content?: Array<{ type?: string; text?: string }> }> },
+  source: string,
+): boolean {
+  const doc = json.content;
+  if (!doc || doc.length !== 1) return false;
+  const p = doc[0];
+  if (!p || p.type !== "paragraph") return false;
+  const text = p.content?.[0]?.text;
+  return typeof text === "string" && text.trim() === source.trim();
+}
+
+function paragraphSplitFallback(source: string) {
+  const blocks = source.split(/\n\s*\n/).map((s) => s.trim()).filter(Boolean);
+  return {
+    type: "doc" as const,
+    content: blocks.length
+      ? blocks.map((block) => ({
+          type: "paragraph" as const,
+          content: [{ type: "text" as const, text: block }],
+        }))
+      : [{ type: "paragraph" as const }],
+  };
 }
 
 /**
@@ -163,7 +197,10 @@ export function createBaseTools(ctx: ToolExecuteContext) {
 
     createNote: tool({
       description:
-        "Create a new note in the user's Digital Garden. Returns the new note's ID and title.",
+        "Create a NEW note in the user's Digital Garden. Use this only when the user EXPLICITLY asks for a new file. " +
+        "Ambiguous phrasings to watch for: 'update the note in this chat', 'add to this conversation's notes', 'put X in the note' — these do NOT mean 'create a new note'. They typically refer to an existing note. When the phrasing is ambiguous, ASK the user whether to create a new note or update an existing one before calling this tool. " +
+        "If they confirm a new note, this is the right tool. If they name an existing note, use `searchNotes` to find its id then use `updateNote`. " +
+        "By default the new note is placed in the same folder as the active chat (when the user is chatting from a chat content page). Pass `parentId` to override.",
       inputSchema: z.object({
         title: z
           .string()
@@ -173,13 +210,57 @@ export function createBaseTools(ctx: ToolExecuteContext) {
         content: z
           .string()
           .optional()
-          .describe("Markdown content for the note (optional)"),
+          .describe(
+            "Markdown content for the note (optional). Use standard markdown: # headings, **bold**, *italic*, `code`, bulleted/numbered lists, tables, blockquotes, links, images. The system converts it to rich text.",
+          ),
+        parentId: z
+          .string()
+          .uuid()
+          .optional()
+          .describe(
+            "Optional UUID of a folder to create the note in. Defaults to the active chat's parent folder. Omit unless the user names a specific folder.",
+          ),
       }),
-      execute: async ({ title, content = "" }) => {
+      execute: async ({ title, content = "", parentId }) => {
+        // Resolve the parent folder. Priority:
+        //   1. AI-supplied parentId (validated to exist + belong to user)
+        //   2. Chat's own parent folder (when in a chat context)
+        //   3. null (vault root)
+        let resolvedParentId: string | null = null;
+        if (parentId) {
+          const candidate = await prisma.contentNode.findFirst({
+            where: {
+              id: parentId,
+              ownerId: ctx.userId,
+              deletedAt: null,
+              contentType: "folder",
+            },
+            select: { id: true },
+          });
+          if (candidate) resolvedParentId = candidate.id;
+        }
+        if (!resolvedParentId && ctx.chatContentId) {
+          const chatNode = await prisma.contentNode.findFirst({
+            where: { id: ctx.chatContentId, ownerId: ctx.userId },
+            select: { parentId: true },
+          });
+          resolvedParentId = chatNode?.parentId ?? null;
+        }
+
         const slug = await generateUniqueSlug(title, ctx.userId);
-        const tiptapJson = content
+        // markdownToTiptap → marked → generateJSON pipeline. If it throws,
+        // the internal fallback wraps raw markdown as plain text — which
+        // produces the "raw ### headings showing in the note" bug. Detect
+        // that fallback (single paragraph whose text equals the input) and
+        // upgrade to a paragraph-per-blank-line split so at least line
+        // breaks survive. The full markdown features depend on the
+        // pipeline succeeding upstream.
+        let tiptapJson = content
           ? markdownToTiptap(content)
           : { type: "doc", content: [{ type: "paragraph" }] };
+        if (content && isMarkdownFallback(tiptapJson, content)) {
+          tiptapJson = paragraphSplitFallback(content);
+        }
         const searchText = extractSearchTextFromTipTap(tiptapJson);
         const wordCount = searchText.split(/\s+/).filter(Boolean).length;
 
@@ -189,6 +270,7 @@ export function createBaseTools(ctx: ToolExecuteContext) {
             title,
             slug,
             contentType: "note",
+            parentId: resolvedParentId,
             notePayload: {
               create: {
                 tiptapJson,
@@ -203,7 +285,121 @@ export function createBaseTools(ctx: ToolExecuteContext) {
           },
         });
 
-        return `Created note "${title}" (id: ${node.id}). ${content ? `Contains ${wordCount} words.` : "Empty note created."}`;
+        // Structured payload so ChatMessage renders a clickable link to the
+        // new note + a signal the client uses to refresh the file tree
+        // without a full page reload. Mirrors the __imagePayload pattern.
+        return JSON.stringify({
+          __notePayload: true,
+          kind: "created",
+          contentId: node.id,
+          title,
+          parentId: resolvedParentId,
+          wordCount,
+        });
+      },
+    }),
+
+    updateNote: tool({
+      description:
+        "Update the markdown/TipTap notes attached to a content item. " +
+        "WORKS ON ANY CONTENT TYPE: notes (full-page editor), chats (the 'Add notes' panel below the chat), folders, files, externals, etc. — every content type has an optional sidecar NotePayload keyed by its contentId. " +
+        "Common phrasings: 'update this conversation's notes', 'add to my Sourdough note', 'put X in the notes for this chat'. " +
+        "If the user is chatting in a full-page chat and asks to update 'the note in this chat' or 'this chat's notes', pass the CHAT's contentId here — that updates the notes panel attached to the chat itself, not a separate file. " +
+        "Do NOT use this to create new top-level notes — use `createNote` for that. " +
+        "RENAME RULE: do NOT set the `title` argument unless the user EXPLICITLY asks to rename (e.g. 'rename this to X'). Mentioning a topic or theme is NOT a rename request. NEVER set `title` when the target is the user's open chat — renaming a chat while updating its notes is wrong.",
+      inputSchema: z.object({
+        contentId: z
+          .string()
+          .uuid()
+          .describe(
+            "UUID of the content whose notes to update. For 'this chat's notes' this is the CHAT's contentId, not a separate note.",
+          ),
+        content: z
+          .string()
+          .min(1)
+          .describe(
+            "Full new markdown content for the notes. This replaces the current notes; if the user wants to append, include the existing content in this string.",
+          ),
+        title: z
+          .string()
+          .min(1)
+          .max(255)
+          .optional()
+          .describe(
+            "New title for the content. ONLY set this if the user explicitly asked to rename. NEVER set when updating a chat's notes.",
+          ),
+      }),
+      execute: async ({ contentId, content, title }) => {
+        // Allow updateNote against ANY content type the user owns —
+        // notes, chats (their 'Add notes' sidecar), folders, files, etc.
+        // The legacy filter of `contentType: "note"` was the cause of the
+        // "you can't update this chat's notes" behavior the user reported.
+        const existing = await prisma.contentNode.findFirst({
+          where: {
+            id: contentId,
+            ownerId: ctx.userId,
+            deletedAt: null,
+          },
+          select: { id: true, title: true, contentType: true },
+        });
+        if (!existing) {
+          return `Content "${contentId}" not found or deleted. Use searchNotes to find the right id.`;
+        }
+
+        // Hard rename-guard: never rename when the target IS the active
+        // chat. This protects against the AI inferring a title from the
+        // user's update prompt and silently rewriting the chat's name.
+        const isUpdatingActiveChat =
+          ctx.chatContentId !== undefined && contentId === ctx.chatContentId;
+        const titleToApply = isUpdatingActiveChat ? undefined : title;
+
+        let tiptapJson = markdownToTiptap(content);
+        if (isMarkdownFallback(tiptapJson, content)) {
+          tiptapJson = paragraphSplitFallback(content);
+        }
+        const searchText = extractSearchTextFromTipTap(tiptapJson);
+        const wordCount = searchText.split(/\s+/).filter(Boolean).length;
+
+        // Upsert (not nested update) because non-note content types may
+        // not have a NotePayload row yet. Mirrors the PATCH route's
+        // unified write path.
+        await prisma.notePayload.upsert({
+          where: { contentId },
+          update: {
+            tiptapJson: tiptapJson as unknown as Prisma.InputJsonValue,
+            searchText,
+            metadata: {
+              wordCount,
+              characterCount: searchText.length,
+              readingTime: Math.ceil(wordCount / 200),
+            },
+          },
+          create: {
+            contentId,
+            tiptapJson: tiptapJson as unknown as Prisma.InputJsonValue,
+            searchText,
+            metadata: {
+              wordCount,
+              characterCount: searchText.length,
+              readingTime: Math.ceil(wordCount / 200),
+            },
+          },
+        });
+        if (titleToApply) {
+          await prisma.contentNode.update({
+            where: { id: contentId },
+            data: { title: titleToApply },
+          });
+        }
+
+        return JSON.stringify({
+          __notePayload: true,
+          kind: "updated",
+          contentId: existing.id,
+          title: titleToApply ?? existing.title,
+          wordCount,
+          targetKind: existing.contentType,
+        });
       },
     }),
 

--- a/lib/domain/ai/tools/types.ts
+++ b/lib/domain/ai/tools/types.ts
@@ -11,4 +11,14 @@ export interface ToolExecuteContext {
   userId: string;
   /** The content node being edited — required for editor tools */
   contentId?: string;
+  /**
+   * The chat content node id when this chat is being viewed as a full-page
+   * ChatViewer (i.e. the chat IS the open content, not the editor). Set
+   * even though `contentId` is intentionally undefined for editor tools.
+   *
+   * Used by createNote to default the parent folder to the chat's own
+   * parent — so "create a note about X" in a chat under /Recipes drops the
+   * note next to the chat instead of at the vault root.
+   */
+  chatContentId?: string;
 }

--- a/lib/domain/ai/use-conversation-binding.ts
+++ b/lib/domain/ai/use-conversation-binding.ts
@@ -396,5 +396,48 @@ export function useConversationBinding({
     };
   }, [conversationId, truncateRef]);
 
+  // Live title sync: subscribe to /api/conversations/events for
+  // `conversation.updated` matching THIS conversationId. Without this,
+  // renaming the underlying ContentNode (which now mirrors title to the
+  // Conversation server-side) wouldn't reach an already-open ChatViewer —
+  // it only refetches `/api/conversations/[id]` on mount. The cache store
+  // also subscribes to the same endpoint; the duplicate EventSource is
+  // acceptable here because (a) the work this effect does is tiny, (b) we
+  // need a focused subscription tied to ChatViewer's lifecycle, and (c)
+  // HTTP/2 multiplexes the two streams over one connection in dev/prod.
+  //
+  // NB: the server uses NAMED SSE events (`event: conversation\ndata: …`)
+  // not generic messages, so we must `addEventListener(EVENT_NAME)` —
+  // `es.onmessage` would silently drop every event (and produced the
+  // initial "title doesn't update in the header" report).
+  useEffect(() => {
+    if (!conversationId) return;
+    if (typeof EventSource === "undefined") return;
+    const es = new EventSource("/api/conversations/events", {
+      withCredentials: true,
+    });
+    const handler = (e: MessageEvent) => {
+      try {
+        const event = JSON.parse(e.data) as
+          | { type: string; conversationId?: string; title?: string | null }
+          | null;
+        if (!event) return;
+        if (
+          event.type === "conversation.updated" &&
+          event.conversationId === conversationId
+        ) {
+          setConversationTitle(event.title ?? null);
+        }
+      } catch {
+        /* malformed event — ignore */
+      }
+    };
+    es.addEventListener("conversation", handler as EventListener);
+    return () => {
+      es.removeEventListener("conversation", handler as EventListener);
+      es.close();
+    };
+  }, [conversationId]);
+
   return { loadingInitial, conversationTitle };
 }

--- a/lib/domain/ai/use-conversation-engine.ts
+++ b/lib/domain/ai/use-conversation-engine.ts
@@ -466,6 +466,51 @@ export function useConversationEngine({
         });
       }
 
+      // Surface AI note writes to any open MainPanelContent so the
+      // chat's notes panel (or any other editor pointed at the same
+      // contentId) reloads without a manual refresh. This MUST live
+      // here (one-shot per real completion) instead of in ChatMessage
+      // — putting it in the render path re-fires the dispatch every
+      // time historical messages mount, which previously caused a
+      // refetch loop on page open.
+      try {
+        const fresh = e.message;
+        if (fresh && typeof window !== "undefined") {
+          for (const part of fresh.parts ?? []) {
+            const output = (part as { output?: unknown }).output;
+            if (output === undefined) continue;
+            const str =
+              typeof output === "string" ? output : JSON.stringify(output);
+            if (!str.includes('"__notePayload"')) continue;
+            try {
+              const parsed = JSON.parse(str) as {
+                __notePayload?: boolean;
+                contentId?: string;
+              };
+              if (parsed.__notePayload && typeof parsed.contentId === "string") {
+                window.dispatchEvent(new CustomEvent("dg:tree-refresh"));
+                // Surgical notes-only refresh — narrower than the
+                // existing `content-updated` event which triggers
+                // MainPanelContent's full `fetchNote` (which resets
+                // loading + outline + tab title + content + clears
+                // error state). Only the pane whose `selectedContentId`
+                // matches this contentId reacts, and only `noteContent`
+                // gets updated. Outline / title / tab unchanged.
+                window.dispatchEvent(
+                  new CustomEvent("dg:notes-refresh", {
+                    detail: { contentId: parsed.contentId },
+                  }),
+                );
+              }
+            } catch {
+              /* unparseable tool output — skip */
+            }
+          }
+        }
+      } catch {
+        /* never let dispatch errors break the chat */
+      }
+
       // Fire suggested follow-ups (Session 7). Decorative, soft-fails
       // to an empty list — never blocks the chat UX.
       try {

--- a/lib/features/conversations/service.ts
+++ b/lib/features/conversations/service.ts
@@ -668,30 +668,60 @@ export async function forkConversation(
   const forkTitle =
     baseTitle.length > 240 ? baseTitle.slice(0, 240) : baseTitle;
 
-  const created = await prisma.conversation.create({
-    data: {
-      ownerId: userId,
-      title: `${forkTitle} (branch)`.slice(0, 255),
-      messages: {
-        create: sourceMessages.map((m) => ({
-          role: m.role,
-          providerId: m.providerId,
-          modelId: m.modelId,
-          parts: m.parts as unknown as Prisma.InputJsonValue,
-          textCache: m.textCache,
-        })),
+  // Estimated byte size of the parts JSON we're about to write — a useful
+  // signal in error logs when an Insert blows past timeouts (typically
+  // very long conversations with image attachments). Cheap upper bound:
+  // a JSON.stringify cost is paid by Prisma anyway.
+  const partsBytes = sourceMessages.reduce(
+    (sum, m) => sum + JSON.stringify(m.parts ?? "").length,
+    0,
+  );
+
+  let created: { id: string };
+  try {
+    created = await prisma.conversation.create({
+      data: {
+        ownerId: userId,
+        title: `${forkTitle} (branch)`.slice(0, 255),
+        messages: {
+          create: sourceMessages.map((m) => ({
+            role: m.role,
+            providerId: m.providerId,
+            modelId: m.modelId,
+            parts: m.parts as unknown as Prisma.InputJsonValue,
+            textCache: m.textCache,
+          })),
+        },
+        associations: source.associations.length
+          ? {
+              create: source.associations.map((a) => ({
+                contentNodeId: a.contentNodeId,
+                source: "snapshot" as const,
+              })),
+            }
+          : undefined,
       },
-      associations: source.associations.length
-        ? {
-            create: source.associations.map((a) => ({
-              contentNodeId: a.contentNodeId,
-              source: "snapshot" as const,
-            })),
-          }
-        : undefined,
-    },
-    select: { id: true },
-  });
+      select: { id: true },
+    });
+  } catch (error) {
+    // Re-throw after attaching diagnostic attrs so the route handler's
+    // catch sees them in the error log. Without this, prod failures
+    // surface as "Fork failed" with no context about size or shape.
+    logger.warn({
+      layer: "ai",
+      event: "conv.fork.create_failed",
+      summary: `Prisma create threw during fork of ${sourceConversationId}`,
+      attrs: {
+        source_id: sourceConversationId,
+        message_count: sourceMessages.length,
+        parts_bytes_estimate: partsBytes,
+        association_count: source.associations.length,
+        upto: uptoMessageId ?? "none",
+      },
+      error,
+    });
+    throw error;
+  }
 
   logger.info({
     layer: "ai",
@@ -701,7 +731,8 @@ export async function forkConversation(
       source_id: sourceConversationId,
       new_id: created.id,
       message_count: sourceMessages.length,
-      upto: uptoMessageId ?? null,
+      parts_bytes_estimate: partsBytes,
+      upto: uptoMessageId ?? "none",
     },
   });
 

--- a/lib/features/settings/validation.ts
+++ b/lib/features/settings/validation.ts
@@ -139,6 +139,11 @@ const aiSettingsSchema = z
     // call after each assistant reply and render 2-3 next-prompt chips.
     // The chosen model lives in Feature Routing under "follow-ups".
     showFollowUps: z.boolean().optional(),
+    // Optional free-form guidance appended to the follow-up generator's
+    // system prompt. Lets users steer suggestions toward their domain
+    // (e.g. "Focus on next experiments / pitfalls to watch for / cite
+    // sources"). Capped at 600 chars to keep the prompt manageable.
+    followUpsPrompt: z.string().max(600).optional(),
   })
   .optional();
 


### PR DESCRIPTION
## Summary

Round of polish on top of the AI Chat Revamp (PR #48 / #49). Eight themed commits covering AI-tools correctness, file-tree fixes, live state propagation, and settings. All bundles smoke-tested by the user before commit.

### AI chat
- **ChatMessage polish** (`8ce0a7c`) — user-msg text alignment, avatar tooltip portaled (no more clipping), input/output tokens in the tooltip, self-edit \`NotePayloadCard\` (expand+scroll notes panel instead of navigating)
- **createNote / updateNote rewrite** (`d361260`) — chat-aware (defaults parent to chat's folder, hard rename-guard on chat target), sidecar-aware (every content type has an optional \`NotePayload\` row), markdown→TipTap fallback hardened, structured payload so the chat renders a clickable result card. New chat-context system prompt with accurate data-model facts
- **Live notes refresh** (`9ed7a05`) — \`dg:notes-refresh\` event fires from engine \`onFinish\` (once per real completion, NOT from render path which caused a refetch loop). Surgical \`setNoteContent\` only; outline/title/tabs untouched. Multi-pane: every pane with the file open reacts via \`selectedContentId\` filter
- **Conversation title sync** (`47ddebb`) — content rename mirrors to backing Conversation + publishes \`conversation.updated\` SSE. \`useConversationBinding\` subscribes via \`addEventListener("conversation")\` (the server emits NAMED events; \`onmessage\` silently drops them)
- **Fork from main panel** (`2b9254c`) — error surface improvement. Server returns \`Fork failed (P2002)\` shape instead of generic 500; service logs parts_bytes_estimate so the next prod failure self-describes
- **Settings: follow-up steering** (`9bfdb3b`) — free-form prompt appended to follow-up generator's system instructions, lives under \`/settings/ai/feature-routing\` next to the follow-ups model choice

### File tree
- **Rename cursor + right-click + menu labels** (`9b0512a`) — cursor no longer snaps to end on click/arrow (single-fire guard on \`FileNameInput\`'s position effect); right-click on folder no longer navigates (was triggering the "Failed to load folder contents" toast); two duplicate "Show Referenced Content" menu items disambiguated as "in this folder" vs. "all"
- **Multi-select D+D + temp-id race** (`5276d8d`) — \`handleMove\` rewritten from \`dragIds[0]\` only to a sequential N-move loop with partial-failure rollback. UUID regex guard on parent lookup in both create routes (\`PARENT_NOT_READY\` instead of raw Prisma crash); client pre-flight short-circuits when parent is still in temp-state

## Test plan

- [x] Open a chat with prior AI messages — no refetch loop, no spurious events
- [x] Ask AI to update this chat's notes — notes panel updates within ~200ms, no full-page reflow, chat title unchanged
- [x] Rename a chat from the file tree — header inside the panel updates without refresh
- [x] Multi-select files (cmd-click) → drag into a folder — all selected items move, preserve drag-order
- [x] Right-click a freshly-created folder → New file — friendly "parent still being created" message instead of UUID-crash dialog
- [x] Rename a file, click in the middle of the text, type — cursor stays at click position
- [x] Right-click any folder — context menu opens without navigating to or loading that folder
- [x] Fork a chat from the main panel — succeeds, or surfaces a useful error tag (\`Fork failed (PXXXX)\`)
- [x] Visit \`/settings/ai/feature-routing\` — new "Follow-up steering" textarea with 600-char limit; save persists

## Gates

- \`pnpm typecheck\` — no new errors (pre-existing \`@ai-sdk/gateway\` types unchanged)
- \`pnpm lint\` — 158/175 warnings, 0 errors (under ratchet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)