### PR TITLE
fix(content): canonical save-conflict bodyHash + collab degraded-copy + STATUS reconcile

### DIFF
--- a/app/api/content/content/[id]/route.ts
+++ b/app/api/content/content/[id]/route.ts
@@ -49,16 +49,43 @@ import {
 import crypto from "node:crypto";
 
 /**
+ * Stable JSON serialization with deep-sorted object keys.
+ *
+ * `JSON.stringify` emits keys in insertion order, which is NOT stable across the
+ * round-trip a note body takes: `sanitizeTipTapJsonWithExtensions` rebuilds the
+ * node tree (reordering `type`/`attrs`/`content`), and Postgres JSONB doesn't
+ * preserve key order on store/read. So two byte-different serializations of the
+ * SAME content would hash differently — tripping a false `If-Match` conflict on
+ * every save. Sorting keys makes the hash purely content-based; array order
+ * (which is semantically meaningful in TipTap) is preserved.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const body = Object.keys(obj)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(obj[key])}`)
+    .join(",");
+  return `{${body}}`;
+}
+
+/**
  * Deterministic short hash of the tiptap JSON body. Used for `If-Match`
  * preconditions on PATCH so clients can prove they're updating the version
  * of the document they last saw. Slicing to 64 hex chars (SHA-256 truncated)
  * keeps the header value compact while preserving negligible collision risk
  * for per-document version checks.
+ *
+ * Hashes a canonical (key-sorted) serialization so the hash compares CONTENT,
+ * not serialization order — see `stableStringify`.
  */
 function hashTiptap(json: unknown): string {
   return crypto
     .createHash("sha256")
-    .update(JSON.stringify(json))
+    .update(stableStringify(json))
     .digest("hex")
     .slice(0, 64);
 }

--- a/docs/notes-feature/STATUS.md
+++ b/docs/notes-feature/STATUS.md
@@ -1,8 +1,8 @@
 ---
-last_updated: 2026-05-31
-current_epoch: 13
+last_updated: 2026-06-11
+current_epoch: 18
 current_sprint: 58
-sprint_status: planned
+sprint_status: in-progress
 ---
 
 # Digital Garden Content IDE - Status
@@ -35,23 +35,35 @@ before planning and executing. There may be additions or modifications.
 
 ## Current Work
 
-### Active Epoch: Epoch 13 - People + Collaboration
-**Duration**: 6 sprints (58-63)
-**Theme**: People/domain tree mirroring, person mentions, safe sharing, and Hocuspocus-backed collaboration
+> **Reconciled 2026-06-11.** This project runs **multiple parallel feature epochs/worktrees**, not a single linear sprint ladder. The frontmatter `current_epoch`/`current_sprint` reflect the primary in-flight focus; the lists below reflect reality across worktrees.
 
-**Sprint Plan**:
-- Sprint 58: Foundations (planned)
-- Sprint 59: People View + Mount UX (planned)
-- Sprint 60: Tree Policy Hardening (planned)
-- Sprint 61: Person Mentions (planned)
-- Sprint 62: Hocuspocus Collaboration (planned)
-- Sprint 63: Share + Media Prototype (planned)
+### Active Epoch: Epoch 18 — Multi-Tenancy Foundation
+**Status**: In progress (Phase 1) — worktree `feature+multi-tenancy`, dev DB isolated (Neon `dev-david`, `pg_trgm` enabled). Phase 0 ✅; additive schema + tenancy helpers + backfill underway.
+**Theme**: Additive multi-tenant schema, tenancy helper module, backfill
+**Detailed Plan**: `docs/notes-feature/work-tracking/epochs/epoch-18-multi-tenancy.md` (+ `MULTI-TENANCY-PLAN.md`)
 
-**Worktree**: `/Users/davidvalentine/Documents/Digital-Garden/.worktrees/epoch-13-people-collab`
-**Branch**: `codex/epoch-13-people-collab`
+**Other in-flight worktrees** (parallel): Epoch 19 — Flashcards FSRS (`flashcards-fsrs`); `ai-chat-polish`; `ai-flashcards-tools`; `mobile-webview-spike`; `speed-reader`.
+
+### Next (booked, not started): Epoch 13 — People + Collaboration
+**Duration**: 6 sprints (58–63) — Foundations · People View + Mount UX · Tree Policy Hardening · Person Mentions · Hocuspocus Collaboration · Share + Media Prototype
 **Detailed Plan**: `docs/notes-feature/work-tracking/epochs/epoch-13-people-and-collaboration.md`
 
+### Planned: Offline Work epoch (number TBD)
+Durable offline editing for the **plain/REST save path** (continuous localStorage draft + reconnect replay), tab-content preload, and clearer collaboration-degraded UX. Continuation of the May-17 anti-overwrite ("Phase I") guards and the 2026-06-11 canonical-`bodyHash` hotfix (#56). Today the conflict resolver only protects the **online plain path**; the collab path relies on Y.js IndexedDB + CRDT, and plain-path offline edits are **not** durably persisted (in-memory; reload can lose them).
+
 ## Recent Completions (Last 30 Days)
+
+**June 11, 2026**: Canonical `bodyHash` save-conflict hotfix — PR #56 (open)
+
+- Fixes a production false-positive: **every** content save tripped the "This note changed elsewhere" conflict banner. Root cause — the `If-Match` optimistic-concurrency hash used `JSON.stringify` (key-order sensitive), but a note body's key order isn't stable across a save round-trip (`sanitizeTipTapJsonWithExtensions` rebuilds the node tree; Postgres JSONB doesn't preserve key order), so the client's echoed hash never matched the server's recompute for identical content.
+- Fix: hash a **canonical (deep key-sorted) serialization** so the check compares content, not byte order. Array order preserved. Client echoes the server's hash, so one server function fixes GET baseline + PATCH response + If-Match check together. No migration. Gates green (typecheck/lint/build).
+
+**June 11, 2026**: Audio Subsystem epoch merged via PR #55
+
+- Speech generation (OpenAI / ElevenLabs / Google) + flashcard audio + **TTS read-aloud**: content-type-aware Listen (note text vs file extracted text), BubbleMenu Read-selection, persistent mini-player, draggable **PDF text reader** (extracted text in own DOM → select → right-click → Speak), and a **bearer-auth `/tts` proxy** for the browser extension (provider key never leaves the server) with Web Speech fallback. Session LRU audio cache; speed via `playbackRate`.
+- Workplaces chores in the same PR: progressive-disclosure borrow dialog + lazy borrowed-tab expiry badge.
+
+**May 31, 2026**: AI Chat Revamp follow-up polish merged via PR #49 (commit `abaad12`)
 
 **May 31, 2026**: AI Chat Revamp follow-up polish merged via PR #49 (commit `abaad12`)
 

--- a/lib/domain/collaboration/runtime.ts
+++ b/lib/domain/collaboration/runtime.ts
@@ -464,7 +464,7 @@ function deriveEditPolicy(
       reason: "degraded-plain-fallback",
       warning:
         state.warning ||
-        "Collaborative state could not be created for this note, so editing is using the saved note content directly until collaboration becomes available again.",
+        "Collaborative editing isn't working for this note. You can keep editing — we'll warn you if it's changed somewhere else.",
     };
   }
 
@@ -500,7 +500,7 @@ function deriveEditPolicy(
       reason: "degraded-local-fallback",
       warning:
         state.warning ||
-        "Editing is using durable local collaborative state, but collaboration exclusivity and remote sync are not guaranteed until collaboration reconnects.",
+        "We're experiencing some signal degradation with the collaboration server. Editing should sync, but cannot be guaranteed until the collaboration server reconnects. Edit with caution.",
     };
   }
 


### PR DESCRIPTION
## 🔴 Production hotfix (+ two small related changes from the same review)

### 1. Canonical `bodyHash` — stop false "changed elsewhere" on every save

**Symptom:** Saving *any* content falsely triggered the **"This note changed elsewhere"** conflict banner on every save. Edits were intact; the banner was spurious.

**Root cause:** the `If-Match` optimistic-concurrency check hashed the note body with `JSON.stringify` (key-order sensitive). A body's key order isn't stable across a save round-trip — `sanitizeTipTapJsonWithExtensions` rebuilds the node tree and Postgres JSONB doesn't preserve key order — so the `bodyHash` the client echoed back never matched the server's recompute for **identical content** → `409` → banner.

**Fix:** hash a **canonical (deep key-sorted) serialization** (`stableStringify`) so the check compares content, not byte order. Array order preserved. The client only echoes the server's hash, so the one server function fixes the GET baseline, PATCH response, and If-Match check together. No client change, no migration.

> Deploy note: tabs opened **before** deploy hold an old-format hash → one spurious conflict until reloaded.

### 2. Clearer collaboration degraded-mode copy
Two user-facing warnings ([runtime.ts](lib/domain/collaboration/runtime.ts)) rewritten into plainer language that leans on conflict detection:
- **plainFallback** → "Collaborative editing isn't working for this note. You can keep editing — we'll warn you if it's changed somewhere else."
- **degraded-local-fallback** → "We're experiencing some signal degradation with the collaboration server. Editing should sync, but cannot be guaranteed until the collaboration server reconnects. Edit with caution."

### 3. Reconcile STATUS.md
Was ~11 days stale and self-contradictory. Marked Epoch 18 (Multi-Tenancy) active, Epoch 13 (People+Collab) next/booked, listed parallel worktrees, logged the planned **Offline Work epoch**, and added Recent Completions for Audio Subsystem (#55) and this hotfix.

## Preflight
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new warnings)
- [x] `pnpm build` green
- [x] No migration (canonical hash is compute-only; copy + docs are non-code/text)
- [ ] Smoke: repeated autosave → **no** conflict banner
- [ ] Smoke: genuine two-tab concurrent edit → banner **still** appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
