### PR TITLE
chore(collab): clearer degraded-mode copy + reconcile STATUS.md

### DIFF
--- a/docs/notes-feature/STATUS.md
+++ b/docs/notes-feature/STATUS.md
@@ -1,8 +1,8 @@
 ---
-last_updated: 2026-05-31
-current_epoch: 13
+last_updated: 2026-06-11
+current_epoch: 18
 current_sprint: 58
-sprint_status: planned
+sprint_status: in-progress
 ---
 
 # Digital Garden Content IDE - Status
@@ -35,23 +35,35 @@ before planning and executing. There may be additions or modifications.
 
 ## Current Work
 
-### Active Epoch: Epoch 13 - People + Collaboration
-**Duration**: 6 sprints (58-63)
-**Theme**: People/domain tree mirroring, person mentions, safe sharing, and Hocuspocus-backed collaboration
+> **Reconciled 2026-06-11.** This project runs **multiple parallel feature epochs/worktrees**, not a single linear sprint ladder. The frontmatter `current_epoch`/`current_sprint` reflect the primary in-flight focus; the lists below reflect reality across worktrees.
 
-**Sprint Plan**:
-- Sprint 58: Foundations (planned)
-- Sprint 59: People View + Mount UX (planned)
-- Sprint 60: Tree Policy Hardening (planned)
-- Sprint 61: Person Mentions (planned)
-- Sprint 62: Hocuspocus Collaboration (planned)
-- Sprint 63: Share + Media Prototype (planned)
+### Active Epoch: Epoch 18 — Multi-Tenancy Foundation
+**Status**: In progress (Phase 1) — worktree `feature+multi-tenancy`, dev DB isolated (Neon `dev-david`, `pg_trgm` enabled). Phase 0 ✅; additive schema + tenancy helpers + backfill underway.
+**Theme**: Additive multi-tenant schema, tenancy helper module, backfill
+**Detailed Plan**: `docs/notes-feature/work-tracking/epochs/epoch-18-multi-tenancy.md` (+ `MULTI-TENANCY-PLAN.md`)
 
-**Worktree**: `/Users/davidvalentine/Documents/Digital-Garden/.worktrees/epoch-13-people-collab`
-**Branch**: `codex/epoch-13-people-collab`
+**Other in-flight worktrees** (parallel): Epoch 19 — Flashcards FSRS (`flashcards-fsrs`); `ai-chat-polish`; `ai-flashcards-tools`; `mobile-webview-spike`; `speed-reader`.
+
+### Next (booked, not started): Epoch 13 — People + Collaboration
+**Duration**: 6 sprints (58–63) — Foundations · People View + Mount UX · Tree Policy Hardening · Person Mentions · Hocuspocus Collaboration · Share + Media Prototype
 **Detailed Plan**: `docs/notes-feature/work-tracking/epochs/epoch-13-people-and-collaboration.md`
 
+### Planned: Offline Work epoch (number TBD)
+Durable offline editing for the **plain/REST save path** (continuous localStorage draft + reconnect replay), tab-content preload, and clearer collaboration-degraded UX. Continuation of the May-17 anti-overwrite ("Phase I") guards and the 2026-06-11 canonical-`bodyHash` hotfix (#56). Today the conflict resolver only protects the **online plain path**; the collab path relies on Y.js IndexedDB + CRDT, and plain-path offline edits are **not** durably persisted (in-memory; reload can lose them).
+
 ## Recent Completions (Last 30 Days)
+
+**June 11, 2026**: Canonical `bodyHash` save-conflict hotfix — PR #56 (open)
+
+- Fixes a production false-positive: **every** content save tripped the "This note changed elsewhere" conflict banner. Root cause — the `If-Match` optimistic-concurrency hash used `JSON.stringify` (key-order sensitive), but a note body's key order isn't stable across a save round-trip (`sanitizeTipTapJsonWithExtensions` rebuilds the node tree; Postgres JSONB doesn't preserve key order), so the client's echoed hash never matched the server's recompute for identical content.
+- Fix: hash a **canonical (deep key-sorted) serialization** so the check compares content, not byte order. Array order preserved. Client echoes the server's hash, so one server function fixes GET baseline + PATCH response + If-Match check together. No migration. Gates green (typecheck/lint/build).
+
+**June 11, 2026**: Audio Subsystem epoch merged via PR #55
+
+- Speech generation (OpenAI / ElevenLabs / Google) + flashcard audio + **TTS read-aloud**: content-type-aware Listen (note text vs file extracted text), BubbleMenu Read-selection, persistent mini-player, draggable **PDF text reader** (extracted text in own DOM → select → right-click → Speak), and a **bearer-auth `/tts` proxy** for the browser extension (provider key never leaves the server) with Web Speech fallback. Session LRU audio cache; speed via `playbackRate`.
+- Workplaces chores in the same PR: progressive-disclosure borrow dialog + lazy borrowed-tab expiry badge.
+
+**May 31, 2026**: AI Chat Revamp follow-up polish merged via PR #49 (commit `abaad12`)
 
 **May 31, 2026**: AI Chat Revamp follow-up polish merged via PR #49 (commit `abaad12`)
 

--- a/lib/domain/collaboration/runtime.ts
+++ b/lib/domain/collaboration/runtime.ts
@@ -464,7 +464,7 @@ function deriveEditPolicy(
       reason: "degraded-plain-fallback",
       warning:
         state.warning ||
-        "Collaborative state could not be created for this note, so editing is using the saved note content directly until collaboration becomes available again.",
+        "Collaborative editing isn't working for this note. You can keep editing — we'll warn you if it's changed somewhere else.",
     };
   }
 
@@ -500,7 +500,7 @@ function deriveEditPolicy(
       reason: "degraded-local-fallback",
       warning:
         state.warning ||
-        "Editing is using durable local collaborative state, but collaboration exclusivity and remote sync are not guaranteed until collaboration reconnects.",
+        "We're experiencing some signal degradation with the collaboration server. Editing should sync, but cannot be guaranteed until the collaboration server reconnects. Edit with caution.",
     };
   }
 


### PR DESCRIPTION
## Summary

Two small, related housekeeping changes from the post-incident collaboration review.

### 1. Clearer collaboration degraded-mode copy
Rewrites two user-facing warnings ([runtime.ts](lib/domain/collaboration/runtime.ts)) into plainer language that leans on conflict detection instead of jargon:

- **plainFallback** — _"Collaborative state could not be created…"_ → **"Collaborative editing isn't working for this note. You can keep editing — we'll warn you if it's changed somewhere else."**
- **degraded-local-fallback** — _"Editing is using durable local collaborative state, but collaboration exclusivity…"_ → **"We're experiencing some signal degradation with the collaboration server. Editing should sync, but cannot be guaranteed until the collaboration server reconnects. Edit with caution."**

### 2. Reconcile STATUS.md
The status doc was ~11 days stale and internally contradictory (frontmatter said Epoch 13; CURRENT-SPRINT.md said Epoch 12). Reconciled to reality:
- Epoch 18 (Multi-Tenancy) marked **active** (per its own prior recommendation); Epoch 13 (People+Collab) noted as **next/booked**.
- Parallel in-flight worktrees listed; the codebase runs multiple epochs in parallel, not a linear ladder.
- **Planned Offline Work epoch** logged (durable plain-path offline editing — the deferred follow-up).
- Recent Completions added for Audio Subsystem (#55) and the bodyHash hotfix (#56).

## Preflight
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (runtime.ts: no new warnings)
- [x] No schema/migration changes (copy + docs only)
- [ ] Visual: confirm the new warning text renders in a degraded-collab note

## Notes
- Independent of the bodyHash hotfix (#56); can merge in any order.
- The `bootstrap-failed` read-only → editable-with-conflict-detection change discussed in review is **not** included here — deferred as a separate, safety-sensitive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
