### PR TITLE
fix(content): stop save-conflict 412 — custom X-Body-Hash header, not If-Match

### DIFF
--- a/app/api/content/content/[id]/route.ts
+++ b/app/api/content/content/[id]/route.ts
@@ -615,14 +615,20 @@ export async function PATCH(
         );
       }
 
-      // ── If-Match precondition (optional) ─────────────────────────────────
-      // Standard HTTP precondition. When clients pass `If-Match: <bodyHash>`,
-      // we verify the current notePayload hash matches what they last saw.
-      // Mismatch → 409 Conflict; client should re-fetch and re-apply.
-      // Missing header → proceed (backwards compatible — existing clients
-      // are unaffected). Hash is computed on the fly from the existing
-      // tiptapJson, so no schema migration is required for this guard.
-      const ifMatch = request.headers.get("if-match");
+      // ── Body-hash precondition (optional) ────────────────────────────────
+      // App-level optimistic concurrency. Clients echo the bodyHash they last
+      // saw via the CUSTOM `X-Body-Hash` header; we verify it matches the
+      // current notePayload hash. Mismatch → 409 Conflict; client re-fetches.
+      // Missing header → proceed (backwards compatible). Hash is computed on
+      // the fly, so no schema migration is required.
+      //
+      // IMPORTANT: this is NOT the standard `If-Match` header. Vercel's edge
+      // evaluates `If-Match` as an HTTP conditional precondition against the
+      // response ETag and returns 412 *before the request reaches this
+      // function* (our responses carry no matching ETag), so the check never
+      // ran on production. A non-conditional custom header passes through.
+      const ifMatch =
+        request.headers.get("x-body-hash") ?? request.headers.get("if-match");
       if (ifMatch && existing.notePayload) {
         const currentHash = hashTiptap(existing.notePayload.tiptapJson);
         if (currentHash !== ifMatch.trim()) {

--- a/components/content/content/MainPanelContent.tsx
+++ b/components/content/content/MainPanelContent.tsx
@@ -920,8 +920,14 @@ export function MainPanelContent({ paneId, initialContent = null }: MainPanelCon
             // updating the version we last loaded. Server returns 409 if the
             // doc changed elsewhere (stale tab / concurrent edit). Templates
             // don't carry a bodyHash, so skip there.
+            //
+            // CUSTOM header on purpose — do NOT use the standard `If-Match`.
+            // Vercel's edge treats `If-Match` as an HTTP conditional precondition
+            // and rejects it with a 412 *before the request reaches the function*
+            // (our responses have no matching ETag), so the app's check never
+            // runs. A non-conditional `X-Body-Hash` header passes through.
             ...(!isPageTemplateTab && bodyHashRef.current
-              ? { "If-Match": bodyHashRef.current }
+              ? { "X-Body-Hash": bodyHashRef.current }
               : {}),
           },
           body: JSON.stringify({


### PR DESCRIPTION
## 🔴 Production hotfix — the *actual* root cause of the save-conflict

**Symptom:** every content save trips **"This note changed elsewhere"** on production.

## Root cause (proven by response headers)
The optimistic-concurrency token was sent in the **standard `If-Match` HTTP header**. `If-Match` is a reserved HTTP **conditional-request** header (RFC 9110): a failed precondition returns **412**, evaluated against the resource **ETag**. **Vercel's edge enforces this and returns `412` before the request reaches the function** — our responses carry no matching ETag, so the precondition always fails.

The app's own If-Match check returns `409`; the failure we see is **`412 Precondition Failed` with `X-Vercel-Error: PRECONDITION_FAILED`** and a `text/plain` Vercel error page — i.e. the edge, not the app. It reproduces **only on Vercel (never locally)** and **only after a refresh** (when the client attaches the header). The app's hash check never ran.

## Fix
Carry the body hash in a **custom, non-conditional header — `X-Body-Hash`** — which the edge passes through untouched. Server reads `X-Body-Hash` (falls back to `if-match` for non-Vercel/local). Concurrency logic otherwise unchanged. No migration.

## Why the earlier hotfix (#56) didn't fix it
#56 (canonical `bodyHash`) addressed a **real latent ordering bug**, but it's downstream of the app's check — and the request never reached the app, because Vercel killed it at the edge on the header name. #56 stays (still correct); this PR is the one that actually stops the prod conflict.

## Preflight
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new warnings)
- [x] `pnpm build` green
- [x] No migration
- [ ] Smoke on prod after deploy: refresh a note → edit → saves with **no** conflict banner; PATCH returns **200** (not 412)
- [ ] Confirm genuine concurrency still works: stale-tab edit → app returns its **409** + resolver

## Security
No concern. The 412 failed **closed** (saves refused, never corrupted). `X-Body-Hash` carries a non-secret hash of the user's own doc, same-origin, compared as a string. Lesson: app-level concurrency tokens must not reuse reserved HTTP conditional headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
