### PR TITLE
chore: observability instrumentation — collaboration routes + logging standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Archived apps** in `/archive` (not in build): `web-amino` (amino acid learning), `open-notes` (documentation).
 
+**[AGENTS.md](AGENTS.md):** Codex-authored briefs for side projects (typically starter scaffolds handed to Claude for final polish, especially UI/UX). When the user references a Codex hand-off, check AGENTS.md for context. CLAUDE.md is authoritative for everything else.
+
 ## Development Commands
 
 ```bash
@@ -19,16 +21,22 @@ pnpm lint             # ESLint with --max-warnings 175 ratchet (fails if count g
 pnpm build:tokens     # Regenerate CSS variables from design tokens
 pnpm db:seed          # Seed database with test ContentNode data
 pnpm collab:schema:check  # CI gate: validate collaboration schema covers all editor extensions
+pnpm collab:env:check     # Verify Hocuspocus env vars are present (scripts/check-hocuspocus-env.ts)
 pnpm publishing:schema:check  # CI gate: validate every publishing block has Server* variant + correct registerBlock type
 pnpm publishing:audit:defaults  # Static drift detector: Zod defaults vs renderHTML fallbacks across publishing blocks
 pnpm publishing:audit:themes  # Static theme-coverage audit: flags `.public-prose .block-*` rules with extreme colors (white-ish / dark-ish) that lack a `.dark` companion. Triage required — theme-stable surfaces (pricing, testimonial, etc.) are intentional false positives.
 pnpm test:e2e         # Playwright visual regression (assumes pnpm dev is running)
 pnpm test:e2e:update  # Regenerate baseline screenshots
 pnpm test:e2e:report  # Open last HTML run report
+pnpm extension:dev    # Build browser extension in watch mode (Phase 5 iframe shell)
+pnpm extension:build  # Build browser extension (production)
+pnpm extension:tokens # Sync design tokens into the extension's manifest/styles
 npx prisma generate   # Regenerate Prisma client (lib/database/generated/prisma)
 npx prisma db push    # Push schema changes in dev (no migration file)
 npx prisma studio     # Database GUI (http://localhost:5555)
 ```
+
+**Browser extension source** lives at [extensions/browser-bookmarks/browser-extension/](extensions/browser-bookmarks/browser-extension/). Build scripts are in [scripts/build-extension.mjs](scripts/build-extension.mjs) and [scripts/sync-extension-tokens.mjs](scripts/sync-extension-tokens.mjs).
 
 **Primary verification is still manual** — `pnpm build` must pass, then smoke-test in browser. The Playwright harness adds visual regression coverage but only for signed-out routes today (auth fixture pending).
 
@@ -218,7 +226,7 @@ First-party feature modules with clear ownership boundaries. Each extension live
 - `server/` — Services, types, route handlers
 - `state/` — Extension-local Zustand stores
 
-**Active extensions:** `daily-notes`, `flashcards`, `people`, `workplaces`, `calendar`
+**Active extensions:** `daily-notes`, `flashcards`, `people`, `workplaces`, `calendar`, `browser-bookmarks`, `publishing`
 
 **Key rules:**
 - Disabled extensions disappear through registry filters — never add direct conditionals in shared UI
@@ -293,7 +301,7 @@ All stores in `state/`. Pattern: `create<T>()(persist((set, get) => ({...}), { n
 
 ### Collaboration Architecture
 
-**Transport:** Hocuspocus server hosted on Google Cloud Run (not local). Do not check port 1234 or suggest `pnpm dev:collab` for production testing.
+**Transport:** Hocuspocus server hosted on Google Cloud Run (not local). The `pnpm dev:collab` / `pnpm start:collab` scripts (entry: [server/hocuspocus/bootstrap.ts](server/hocuspocus/bootstrap.ts)) exist to build/run the Cloud Run image — they are NOT used for local app development. Do not check port 1234 or recommend running them when debugging client-side collab issues.
 
 **Y.js document storage:** `CollaborationDocument` Prisma table stores binary `ydocState`. On load, the server bootstraps from TipTap JSON if no Y.js state exists. Presence (awareness) state is persisted to Postgres to handle Vercel serverless split.
 
@@ -398,7 +406,14 @@ extensions/                     # First-party feature extensions
 ├── flashcards/
 ├── people/
 ├── workplaces/
-└── calendar/
+├── calendar/
+├── publishing/                 # Public path / publish workflow (Epoch 15)
+└── browser-bookmarks/          # Phase 5 browser extension iframe embed
+
+server/
+└── hocuspocus/                 # Cloud Run Hocuspocus collab server (bootstrap.ts entry)
+
+proxy.ts                        # Next.js 16 proxy — runs before every matched request
 
 components/content/
 ├── ai/                         # AI chat panel components

--- a/app/api/collaboration/presence/heartbeat/route.ts
+++ b/app/api/collaboration/presence/heartbeat/route.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/domain/collaboration/presence-access-cache";
 import { upsertCollaborationPresence } from "@/lib/domain/collaboration/presence-server";
 import { getSession } from "@/lib/infrastructure/auth/session";
-import { logger } from "@/lib/core/logger";
+import { logger, withSpan } from "@/lib/core/logger";
 import { withRouteTrace } from "@/lib/core/logger/route-trace";
 
 export const runtime = "nodejs";
@@ -80,7 +80,11 @@ function sanitizeDisplayName(value: unknown) {
 export async function POST(request: NextRequest) {
   return withRouteTrace(request, { route: "/api/collaboration/presence/heartbeat" }, async () => {
   try {
-    const session = await getSession();
+    const session = await withSpan(
+      { layer: "auth", name: "session" },
+      { summary: "session lookup" },
+      async () => getSession(),
+    );
     const body = (await request.json()) as PresenceHeartbeatInput & {
       sessions?: PresenceHeartbeatInput[];
     };

--- a/app/api/collaboration/presence/route.ts
+++ b/app/api/collaboration/presence/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/database/client";
 import { filterCachedPresenceContentIds } from "@/lib/domain/collaboration/presence-access-cache";
 import { listCollaborationPresence } from "@/lib/domain/collaboration/presence-server";
 import { getSession } from "@/lib/infrastructure/auth/session";
-import { logger } from "@/lib/core/logger";
+import { logger, withSpan } from "@/lib/core/logger";
 import { withRouteTrace } from "@/lib/core/logger/route-trace";
 
 export const runtime = "nodejs";
@@ -34,7 +34,11 @@ function isUuid(value: string) {
 export async function GET(request: NextRequest) {
   return withRouteTrace(request, { route: "/api/collaboration/presence" }, async () => {
   try {
-    const session = await getSession();
+    const session = await withSpan(
+      { layer: "auth", name: "session" },
+      { summary: "session lookup" },
+      async () => getSession(),
+    );
     const contentIds = parseContentIds(request);
     const excludeSessionId = request.nextUrl.searchParams.get("excludeSessionId")?.trim();
 

--- a/app/api/collaboration/state/route.ts
+++ b/app/api/collaboration/state/route.ts
@@ -1,4 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { TiptapTransformer } from "@hocuspocus/transformer";
+import type { JSONContent } from "@tiptap/core";
+import * as Y from "yjs";
 
 import { prisma } from "@/lib/database/client";
 import type { ContentType } from "@/lib/database/generated/prisma";
@@ -6,79 +9,159 @@ import { resolveContentAccess } from "@/lib/domain/collaboration/access";
 import { loadCollaborationYDocState } from "@/lib/domain/collaboration/documents";
 import { getCollaborationDocumentName } from "@/lib/domain/collaboration/tokens";
 import { requireAuth } from "@/lib/infrastructure/auth/middleware";
+import { logger, spanPayload, withRouteTrace, withSpan } from "@/lib/core/logger";
 
 export const runtime = "nodejs";
 
+const ROUTE_PATH = "/api/collaboration/state";
+
 export async function POST(request: NextRequest) {
-  try {
-    const session = await requireAuth();
-    const body = (await request.json()) as { contentId?: string };
-    const contentId = body.contentId?.trim();
-
-    if (!contentId) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: { code: "VALIDATION_ERROR", message: "contentId is required" },
-        },
-        { status: 400 }
+  return withRouteTrace(request, { route: ROUTE_PATH }, async () => {
+    try {
+      const session = await withSpan(
+        { layer: "auth", name: "session" },
+        { summary: "session lookup" },
+        async () => requireAuth(),
       );
-    }
+      const body = (await request.json()) as { contentId?: string };
+      const contentId = body.contentId?.trim();
 
-    const access = await resolveContentAccess(prisma, {
-      contentId,
-      userId: session.user.id,
-      require: "view",
-    });
+      if (!contentId) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: { code: "VALIDATION_ERROR", message: "contentId is required" },
+          },
+          { status: 400 }
+        );
+      }
 
-    const COLLABORATIVE_CONTENT_TYPES: ContentType[] = ["note", "visualization"];
+      const access = await withSpan(
+        { layer: "collab", name: "resolve_access" },
+        { attrs: { content_id: contentId } },
+        async (span) => {
+          const result = await resolveContentAccess(prisma, {
+            contentId,
+            userId: session.user.id,
+            require: "view",
+          });
+          span.attr("read_only", result.readOnly);
+          return result;
+        },
+      );
 
-    const content = await prisma.contentNode.findFirst({
-      where: {
-        id: contentId,
-        contentType: { in: COLLABORATIVE_CONTENT_TYPES },
-        deletedAt: null,
-      },
-      select: { id: true },
-    });
+      const COLLABORATIVE_CONTENT_TYPES: ContentType[] = ["note", "visualization"];
 
-    if (!content) {
+      const content = await withSpan(
+        { layer: "collab", name: "content_lookup" },
+        { attrs: { content_id: contentId } },
+        async (span) => {
+          const result = await prisma.contentNode.findFirst({
+            where: {
+              id: contentId,
+              contentType: { in: COLLABORATIVE_CONTENT_TYPES },
+              deletedAt: null,
+            },
+            select: { id: true },
+          });
+          span.attr("found", Boolean(result));
+          return result;
+        },
+      );
+
+      if (!content) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: {
+              code: "UNSUPPORTED_CONTENT",
+              message: "This content type does not support real-time collaboration",
+            },
+          },
+          { status: 400 }
+        );
+      }
+
+      const documentName = getCollaborationDocumentName(contentId);
+
+      const state = await withSpan(
+        { layer: "collab", name: "load_ydoc_state" },
+        { attrs: { content_id: contentId, document_name: documentName } },
+        async (span) => {
+          const loaded = await loadCollaborationYDocState(prisma, documentName);
+          span.attr("has_update", Boolean(loaded));
+          span.attr("update_bytes", loaded?.byteLength ?? 0);
+          return loaded;
+        },
+      );
+
+      // Forensic payload: decoded Y.Doc snapshot for cross-checking against
+      // REST NotePayload. Bootstrap inconsistencies (e.g., canonical contains
+      // a stale template overlaying real saved content) are diagnosed by
+      // comparing this snapshot to the GET /api/content/content/[id]
+      // `content_response` payload from the same trace.
+      if (state) {
+        await withSpan(
+          { layer: "collab", name: "decode_canonical_snapshot" },
+          { attrs: { content_id: contentId, update_bytes: state.byteLength } },
+          async (span) => {
+            try {
+              const ydoc = new Y.Doc();
+              Y.applyUpdate(ydoc, state);
+              const snapshot = TiptapTransformer.fromYdoc(ydoc, "default") as JSONContent;
+              const xmlLength = ydoc.getXmlFragment("default").length;
+              span.attr("xml_fragment_length", xmlLength);
+              await spanPayload(span, "canonical_tiptap_snapshot", snapshot);
+              await spanPayload(span, "canonical_ydoc_update_b64", {
+                bytes: state.byteLength,
+                base64: Buffer.from(state).toString("base64"),
+              });
+            } catch (err) {
+              span.attr("decode_failed", true);
+              logger.warn({
+                layer: "collab",
+                event: "canonical_snapshot:decode_failed",
+                summary: "failed to decode canonical Y.Doc for forensic payload",
+                attrs: { content_id: contentId },
+                error: err,
+              });
+            }
+          },
+        );
+      }
+
+      return NextResponse.json({
+        success: true,
+        data: {
+          documentName,
+          readOnly: access.readOnly,
+          update: state ? Buffer.from(state).toString("base64") : null,
+        },
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to load collaboration state";
+      const status =
+        message.includes("Access") || message.includes("required") ? 403 : 500;
+
+      logger.error({
+        layer: "collab",
+        event: "collab:state:failed",
+        summary: "collaboration state route error",
+        attrs: { status },
+        error,
+      });
+
       return NextResponse.json(
         {
           success: false,
           error: {
-            code: "UNSUPPORTED_CONTENT",
-            message: "This content type does not support real-time collaboration",
+            code: status === 403 ? "FORBIDDEN" : "SERVER_ERROR",
+            message,
           },
         },
-        { status: 400 }
+        { status }
       );
     }
-
-    const documentName = getCollaborationDocumentName(contentId);
-    const state = await loadCollaborationYDocState(prisma, documentName);
-
-    return NextResponse.json({
-      success: true,
-      data: {
-        documentName,
-        readOnly: access.readOnly,
-        update: state ? Buffer.from(state).toString("base64") : null,
-      },
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to load collaboration state";
-    const status = message.includes("Access") || message.includes("required") ? 403 : 500;
-
-    return NextResponse.json(
-      {
-        success: false,
-        error: {
-          code: status === 403 ? "FORBIDDEN" : "SERVER_ERROR",
-          message,
-        },
-      },
-      { status }
-    );
-  }
+  });
 }

--- a/lib/core/logger/encoders/pretty.ts
+++ b/lib/core/logger/encoders/pretty.ts
@@ -143,13 +143,18 @@ function renderSummaryBlock(trace_id: string): string {
     (a, b) => b[1].duration_ms - a[1].duration_ms,
   );
   const rows = sortedLayers.map(([layer, stats]) => {
+    // stats.duration_ms is a sum of per-event durations. When a route fans
+    // out concurrent work (e.g., Promise.all of N queries) the sum
+    // exceeds the wall-clock total. Showing a >100% number reads like a
+    // math bug, so we label parallel cases explicitly instead.
     const pct = total_ms > 0 ? Math.round((stats.duration_ms / total_ms) * 100) : 0;
+    const pctLabel = pct > 100 ? "(parallel)" : `(${pct}%)`;
     const eventsLabel =
       stats.count === 1 ? "1 event " : `${stats.count} events`;
     return `  ${padRight(layer, 14)} ${padLeft(eventsLabel, 8)}  ${padLeft(
       `${stats.duration_ms}ms`,
       7,
-    )}  (${pct}%)`;
+    )}  ${pctLabel}`;
   });
 
   const block = [headerLine, ...rows, footerLine].join("\n");

--- a/lib/database/client.ts
+++ b/lib/database/client.ts
@@ -1,13 +1,24 @@
 // Prisma Client singleton + structured-log bridge.
 //
 // We use `emit: "event"` for all log levels so Prisma's output goes through
-// our logger instead of stdout. Each query becomes a `content:db:query`
-// debug-level event that inherits the active trace context via ALS.
+// our logger instead of stdout. Each query becomes a `<layer>:db:completed`
+// debug-level event that inherits the active trace context via ALS, where
+// <layer> is the ServerLayer the queried model belongs to (see
+// `tableToLayer` below). The event name uses the closed-set Marker
+// `completed` per the Phase 17 logger contract.
+//
+// Known gap: Prisma's `$on("query")` callbacks can flush *after* the
+// originating request's AsyncLocalStorage context tears down, producing
+// `[trace:no-trace]` lines in the dev stream. Fixing this requires a
+// Prisma `$extends` wrapper that captures the trace_id at query-start and
+// re-applies it inside the callback — a non-trivial rework deferred to a
+// future epoch. See log audit dated 2026-05-18.
 
 import { PrismaClient, Prisma } from "@/lib/database/generated/prisma";
 import { Pool } from "pg";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { logger } from "@/lib/core/logger";
+import type { ServerLayer } from "@/lib/core/logger/types";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
@@ -93,6 +104,36 @@ function buildQuerySummary({ op, table, param_count }: QuerySummary): string {
 }
 
 // ----------------------------------------------------------------------
+// Table → ServerLayer routing
+// ----------------------------------------------------------------------
+// Models cluster into the ServerLayer they belong to so trace summaries
+// attribute DB time to the right domain rather than dumping everything
+// into `content`. Unknown models fall back to `content` (the historical
+// catch-all). Add entries here when you introduce a new model family.
+
+const TABLE_LAYER_MAP: Record<string, ServerLayer> = {
+  // auth
+  User: "auth",
+  Account: "auth",
+  Session: "auth",
+  VerificationToken: "auth",
+  // collab
+  CollaborationDocument: "collab",
+  CollaborationPresence: "collab",
+  CollaborationGrant: "collab",
+  // storage
+  StorageProvider: "storage",
+  FileObject: "storage",
+  // admin
+  AuditLog: "admin",
+  // editor / content payloads live under `content` (default)
+};
+
+function tableToLayer(table: string): ServerLayer {
+  return TABLE_LAYER_MAP[table] ?? "content";
+}
+
+// ----------------------------------------------------------------------
 // Client factory + bridge wiring
 // ----------------------------------------------------------------------
 
@@ -103,8 +144,8 @@ function attachLogBridge(client: PrismaClient): PrismaClient {
   client.$on("query" as never, (e: Prisma.QueryEvent) => {
     const summary = parseQuerySummary(e.query);
     logger.debug({
-      layer: "content",
-      event: "db:query",
+      layer: tableToLayer(summary.table),
+      event: "db:completed",
       summary: buildQuerySummary(summary),
       duration_ms: Math.round(e.duration),
       attrs: {
@@ -115,10 +156,15 @@ function attachLogBridge(client: PrismaClient): PrismaClient {
     });
   });
 
+  // info/warn/error events come from Prisma's own logger, not a specific
+  // query — they describe the client/engine, not a model — so they stay
+  // on the `content` catch-all layer. Event names use Marker states
+  // (`info` → `:completed` since there's no started/completed pair;
+  // `warn`/`error` → `:failed` to match the closed-set Marker).
   client.$on("info" as never, (e: Prisma.LogEvent) => {
     logger.info({
       layer: "content",
-      event: "db:info",
+      event: "db:completed",
       summary: e.message,
     });
   });
@@ -126,7 +172,7 @@ function attachLogBridge(client: PrismaClient): PrismaClient {
   client.$on("warn" as never, (e: Prisma.LogEvent) => {
     logger.warn({
       layer: "content",
-      event: "db:warn",
+      event: "db:failed",
       summary: e.message,
     });
   });
@@ -134,7 +180,7 @@ function attachLogBridge(client: PrismaClient): PrismaClient {
   client.$on("error" as never, (e: Prisma.LogEvent) => {
     logger.error({
       layer: "content",
-      event: "db:error",
+      event: "db:failed",
       summary: e.message,
     });
   });


### PR DESCRIPTION
## Summary
Observability improvements across the collaboration system and logging infrastructure:

1. **Instrumentation** — /api/collaboration/state route with structured spans (session lookup, access resolution, content loading, Y.Doc decoding)
2. **Bootstrap diagnostics** — Detailed client-side logging for initial content bootstrap with forensic payloads (canonical snapshots, Y.Doc updates)
3. **Logging standards** — Prisma layer routing (model→layer mapping), marker-compliant event names, presence span nesting
4. **Documentation** — Port of browser extension and Hocuspocus environment verification docs to CLAUDE.md

## Implementation Details
- Wraps `/api/collaboration/state` with `withRouteTrace` + named spans for diagnosing the daily-notes template-overlay bug
- Client logger events at all 5 bootstrap decision branches (preserved, pending, applied, fresh, refused)
- Fixed Prisma bridge routing so Session/User→auth, CollaborationPresence→collab, FileObject→storage
- Renamed db events for Marker compliance: db:query→completed, db:warn/error→failed

## Gates
- ✅ typecheck clean
- ✅ lint: 156 warnings (ratchet: 159)
- ✅ build: 132 pages

## Test Plan
- [ ] Verify /api/collaboration/state responds with correct response structure
- [ ] Check browser dev tools: presence heartbeat logs include session span
- [ ] Daily-notes edit test: confirm bootstrap logs appear when opening a note
- [ ] Verify no observable perf regression in collaboration connect times

🤖 Generated with Claude Code