### PR TITLE
feat: AI rate limiting, modular system prompt, editor undo + UI polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,595 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+**Next.js 16 application** — Digital Garden Content IDE, an Obsidian-inspired knowledge management system with panel-based layout, rich text editing, and multi-cloud storage.
+
+**Archived apps** in `/archive` (not in build): `web-amino` (amino acid learning), `open-notes` (documentation).
+
+## Development Commands
+
+```bash
+pnpm dev              # Start dev server (http://localhost:3015)
+pnpm build            # prisma generate → build:tokens → tsc → collab:schema:check → lint → next build
+pnpm typecheck        # tsc --noEmit only (fast type check)
+pnpm start            # Production server
+pnpm lint             # ESLint with --max-warnings 175 ratchet (fails if count grows)
+pnpm build:tokens     # Regenerate CSS variables from design tokens
+pnpm db:seed          # Seed database with test ContentNode data
+pnpm collab:schema:check  # CI gate: validate collaboration schema covers all editor extensions
+pnpm publishing:schema:check  # CI gate: validate every publishing block has Server* variant + correct registerBlock type
+pnpm publishing:audit:defaults  # Static drift detector: Zod defaults vs renderHTML fallbacks across publishing blocks
+pnpm publishing:audit:themes  # Static theme-coverage audit: flags `.public-prose .block-*` rules with extreme colors (white-ish / dark-ish) that lack a `.dark` companion. Triage required — theme-stable surfaces (pricing, testimonial, etc.) are intentional false positives.
+pnpm test:e2e         # Playwright visual regression (assumes pnpm dev is running)
+pnpm test:e2e:update  # Regenerate baseline screenshots
+pnpm test:e2e:report  # Open last HTML run report
+npx prisma generate   # Regenerate Prisma client (lib/database/generated/prisma)
+npx prisma db push    # Push schema changes in dev (no migration file)
+npx prisma studio     # Database GUI (http://localhost:5555)
+```
+
+**Primary verification is still manual** — `pnpm build` must pass, then smoke-test in browser. The Playwright harness adds visual regression coverage but only for signed-out routes today (auth fixture pending).
+
+**Build pipeline:** `prisma generate` → `pnpm build:tokens` (style-dictionary) → `tsc --noEmit` → `pnpm collab:schema:check` → `pnpm lint` → `next build --turbopack`.
+
+**Vercel build** skips the `tsc --noEmit` and `lint` steps (`vercel-build` script). Those gates are enforced locally and in CI; Vercel stays minimal for fast deploys. Migrations are run manually via `npx prisma migrate deploy`.
+
+**Bundler is Turbopack** for both `build` and `vercel-build` (and dev). Switched off `next build --webpack` after the webpack production build began timing out on Vercel's 2-core/8 GB builder — the growing module graph sent V8's GC into a thrash spiral under the 5120 MB heap cap (45-min timeout, no error). Turbopack builds the same tree in ~40s at the same cap. Keep local `build` and `vercel-build` on the **same** bundler so local green faithfully predicts the deploy.
+
+**Heap size for local `pnpm build`** — Node's default V8 heap (~4 GB) is no longer enough on this codebase; full builds can abort with `Abort trap: 6` during the type-emit or compilation phase. Local builds need `NODE_OPTIONS='--max-old-space-size=8192'`:
+
+```bash
+NODE_OPTIONS='--max-old-space-size=8192' pnpm build
+```
+
+CI runners (GitHub Actions, Vercel) have larger heaps by default and don't need this. Add it to your shell rc or build-script alias if you're on a machine with <16 GB RAM.
+
+**CI gates** (`.github/workflows/`):
+- **quality.yml** — runs `pnpm lint` (with the `--max-warnings 175` ratchet) and `pnpm typecheck` on every PR. Lint failures or warning count growth block merge.
+- **collaboration-hardening.yml** — runs `pnpm collab:schema:check` on collab-touching PRs. Scans all TipTap extension source files for `Node.create`/`Mark.create` and asserts every discovered node/mark is covered in `getCollaborationServerExtensions()`. Every new TipTap Node/Mark **must** export a `Server*` variant and be registered in `lib/domain/collaboration/extensions.ts`.
+- **publishing-visual.yml** — runs on PRs touching the publishing surface (`extensions/publishing/`, `components/public/`, `app/(public)/`, `app/(test)/test/publishing-fixtures/`, `app/globals.css`, the publishing fixtures/spec/schema scripts). Two jobs: `schema` (typecheck + `publishing:schema:check` + `publishing:audit:defaults`) and `visual` (Playwright per-block snapshot suite against the synthetic fixture route). Visual job uploads diff PNGs as an artifact on failure. Hard-gate; failures block merge. Can be temporarily skipped via repo var `PUBLISHING_VISUAL_GATE=skip`.
+
+## Visual Regression Testing (Playwright)
+
+**Two layers in one harness** — operational dark-mode screenshot coverage running today, plus non-operational stubs scaffolding future regression categories. See [tests/e2e/README.md](tests/e2e/README.md) for the full conventions.
+
+### One-time setup (per machine)
+
+```bash
+pnpm install                              # Playwright is in devDependencies
+pnpm exec playwright install chromium     # Browser binary, ~92MB
+```
+
+### Daily workflow
+
+```bash
+pnpm dev                # in one terminal — Playwright assumes it's already running
+pnpm test:e2e           # in another — runs all e2e tests against http://localhost:3015
+```
+
+A typical run reports `n passed, m skipped`. Skipped tests are intentional stubs (see Stub Convention below) and their reasons surface in the reporter — keep an eye on the skipped count as a "remaining work" signal.
+
+### When you intentionally change visual output
+
+```bash
+pnpm test:e2e:update    # regenerates ALL snapshots
+```
+
+Review the regenerated PNGs in `tests/e2e/__snapshots__/` before committing — those PNGs ARE the visual contract going forward. Diffs against them in CI mean either a real regression or an undocumented intentional change.
+
+### Project structure
+
+```
+tests/e2e/
+├── _fixtures/theme.ts         # themedGoto: seeds notes:settings localStorage before nav
+├── dark-mode/                 # OPERATIONAL — runs every CI invocation
+│   ├── home.spec.ts
+│   ├── sign-in.spec.ts
+│   ├── sign-up.spec.ts
+│   ├── embed-blank.spec.ts
+│   └── authenticated-routes.spec.ts  # currently test.skip — needs auth fixture
+├── auth/ editor/ file-tree/ content/ search/ extensions/
+│   └── *.spec.ts              # STUBS — test.skip() with docstring describing scope
+└── __snapshots__/             # committed baseline screenshots, per-spec per-project
+```
+
+Two Playwright projects run every spec: `light` and `dark`. Snapshots auto-suffix with the project name (e.g., `home-light.png`, `home-dark.png`).
+
+### Theme propagation in tests
+
+Tests **MUST** import from `_fixtures/theme.ts` (not `@playwright/test` directly) so theme preference is set before navigation:
+
+```ts
+import { test, expect } from "../_fixtures/theme";
+
+test("my surface renders correctly in both themes", async ({ page, themedGoto }) => {
+  await themedGoto("/my/route");
+  await expect(page).toHaveScreenshot("my-surface.png");
+});
+```
+
+`themedGoto` writes `notes:settings.state.ui.theme` to localStorage before navigation, so the pre-hydration FOUC script in [lib/features/theme/script.ts](lib/features/theme/script.ts) applies the correct `.dark` class on first paint.
+
+### Stub convention (non-operational specs)
+
+Stubs document *what should be tested* without yet implementing it. Each stub file:
+
+1. Has a top-level JSDoc with **Scope** (what to cover) and **Blocked on** (what's needed to enable).
+2. Uses `test.skip("description", async ({ page }) => { void page; })` per scenario — empty body with `void page;` to satisfy the linter.
+3. Does NOT depend on unmerged infrastructure.
+
+To activate a stub:
+
+1. Remove `.skip` from `test.skip(...)`.
+2. Implement the test body.
+3. Update the file's top-level docstring with new scope.
+4. Run the test; commit any new snapshot PNG.
+
+### Adding a new operational test
+
+1. Decide if the surface needs auth. **Without auth** → put it in `tests/e2e/dark-mode/`. **With auth** → it stays stubbed in `dark-mode/authenticated-routes.spec.ts` until the auth fixture lands.
+2. Use the `themedGoto` fixture (not raw `page.goto`).
+3. Wait for a stable element before snapshotting (avoids flake from font/hydration timing): `await expect(page.getByRole("...")).toBeVisible();`
+4. Run `pnpm test:e2e:update` to capture baselines, then `pnpm test:e2e` to verify.
+5. Commit both the spec and the generated PNG(s).
+
+### Known gaps (followups in BACKLOG.md)
+
+- **Auth fixture** for `tests/e2e/_fixtures/auth.ts` — should sign in a seeded test user and persist `storageState`. Unblocks 5 stubbed authenticated dark-mode tests.
+- **Hocuspocus fixture** for collaboration tests (`tests/e2e/editor/collaboration.spec.ts`) — needs a local Hocuspocus server or mock provider.
+- **Seeded fixture content** for tests that depend on specific note state.
+
+### CI integration
+
+`playwright.config.ts` is **soft-gate by default**: failures surface in the PR but don't block merge automatically. Set `forbidOnly` and adjust `retries` in config if you want strict gating. For CI environments where the dev server isn't already running, set `PLAYWRIGHT_AUTOSTART=1` and the `webServer` block activates.
+
+### When NOT to add a Playwright test
+
+- Pure type/logic changes — `pnpm typecheck` is the right gate.
+- API contract changes — write a unit test against the route handler, not a screenshot test.
+- Animation timing — Playwright disables animations by default; capture the end state, not the motion.
+
+## Environment Setup
+
+```bash
+# Create .env.local with required vars
+npx prisma generate           # Generate Prisma client
+npx prisma migrate reset --force  # Dev only! Creates tables + seeds
+pnpm dev
+```
+
+**Required:** `DATABASE_URL` (PostgreSQL), `STORAGE_ENCRYPTION_KEY` (32-byte hex)
+**Optional:** `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, storage provider credentials (R2/S3/Vercel Blob)
+
+## Architecture
+
+### Core Data Model: ContentNode v2.0
+
+Single `ContentNode` table as universal container. Each leaf node has exactly one typed payload relation; folders have no payload.
+
+**Payloads:** `NotePayload` (TipTap JSON), `FilePayload` (binary + storage metadata), `HtmlPayload`, `CodePayload`, `ExternalPayload` (URL + Open Graph metadata)
+
+**Key columns:** `parentId` (hierarchy), `displayOrder` (ordering), `deletedAt`/`deletedBy` (soft delete), `customIcon`/`iconColor`, `searchText` (full-text search)
+
+**Schema:** `prisma/schema.prisma`
+
+### UI Architecture: Server/Client Split
+
+**Critical pattern:** Server components for instant visual feedback, client components for interactivity.
+
+- **Server components:** Panel headers, borders, layout structure, skeleton states. Use inline SVG for icons (NOT `lucide-react`).
+- **Client components:** File tree (`react-arborist`), resizable panels (`allotment`), state (`zustand`), drag-and-drop.
+
+```tsx
+// Server Component pattern
+<div>
+  <Header />  {/* Server: instant render */}
+  <Suspense fallback={<Skeleton />}>
+    <Content />  {/* Client: progressive hydration */}
+  </Suspense>
+</div>
+```
+
+### Panel Layout
+
+Three-panel layout managed by `ResizablePanels.tsx` using Allotment:
+- **Left sidebar:** File tree, search, tags (`LeftSidebar.tsx`)
+- **Main panel:** Content editor/viewer with toolbar (`MainPanel.tsx` → `MainPanelContent.tsx`)
+- **Right sidebar:** Backlinks, outline, tags tabs (`RightSidebar.tsx`)
+
+Both sidebars follow the same pattern:
+```
+Sidebar Wrapper (Client) — manages shared state
+  ├─ SidebarHeader (Client) ← receives props
+  └─ SidebarContent (Client) ← receives props
+```
+
+### Extension System
+
+First-party feature modules with clear ownership boundaries. Each extension lives in `extensions/<name>/` and is registered once in `lib/extensions/installed.ts`.
+
+**Expected structure per extension:**
+- `manifest.ts` — ID, label, nav items, `enabledByDefault`, `canDisable`, surfaces
+- `client.tsx` — Client runtime: shell controls, dialogs, slash commands, editor blocks, content viewer matcher
+- `server-runtime.ts` — Server-safe editor/runtime contributions
+- `components/` — UI owned by the extension
+- `server/` — Services, types, route handlers
+- `state/` — Extension-local Zustand stores
+
+**Active extensions:** `daily-notes`, `flashcards`, `people`, `workplaces`, `calendar`, `publishing`, `speed-reader`, `browser-bookmarks`
+
+**Key rules:**
+- Disabled extensions disappear through registry filters — never add direct conditionals in shared UI
+- Shell controls, dialogs, and settings don't mount when extension is disabled
+- New logic belongs inside `extensions/<name>/`, not in shared components
+
+**Client registry:** `lib/extensions/client-registry.tsx` — `useIsExtensionEnabled(id)`, `getExtensionClientEditorExtensions()`
+**Server registry:** `lib/extensions/server-registry.ts` — `getExtensionServerEditorExtensions()`
+
+### Tool Surfaces System
+
+Declarative registry mapping tools to UI surfaces with content-type filtering.
+
+**Location:** `lib/domain/tools/`
+
+- `types.ts` — `ContentType`, `ToolSurface` ("toolbar" | "toolbelt" | "sidebar-tab"), `ToolDefinition`, `ToolInstance`
+- `registry.ts` — Static `TOOL_REGISTRY` array + `queryTools({ surface, contentType })` filter
+- `context.tsx` — `ToolSurfaceProvider` wraps MainPanelContent; `useRegisterToolHandler()` for child components
+
+**Surfaces:**
+- **toolbar** — ContentToolbar buttons (export, copy link). Rendered in `components/content/toolbar/ContentToolbar.tsx`.
+- **toolbelt** — BubbleMenu formatting buttons. BubbleMenu reads from registry at module level (no hooks — prevents TipTap plugin lifecycle interference).
+- **sidebar-tab** — Right sidebar tabs (backlinks, outline, tags, chat). Filtered by content type via Zustand store.
+
+**Key constraint:** `useContext` only sees PARENT providers. The component rendering `ToolSurfaceProvider` passes handlers via a `handlers` prop, not `useRegisterToolHandler`.
+
+**BubbleMenu fix:** All buttons must have `onMouseDown={e => e.preventDefault()}` to prevent browser focus theft from the ProseMirror editor.
+
+### State Management (Zustand)
+
+All stores in `state/`. Pattern: `create<T>()(persist((set, get) => ({...}), { name, version }))`.
+
+**Key stores:**
+- `panel-store.ts` — Panel widths, visibility, localStorage persistence (v3)
+- `content-store.ts` — Selected content ID/type, multi-selection, URL + localStorage sync
+- `tree-state-store.ts` — Expanded/collapsed nodes
+- `context-menu-store.ts` — Right-click menu positioning + actions
+- `editor-stats-store.ts` — Word/char count, reading time
+- `outline-store.ts` — Heading hierarchy from TipTap JSON
+- `search-store.ts` — Query, filters, results cache
+- `settings-store.ts` — User preferences (includes periodic notes config)
+- `navigation-history-store.ts` — Back/forward navigation
+- `left-panel-view-store.ts` / `left-panel-collapse-store.ts` — Left sidebar view/collapse
+- `right-panel-collapse-store.ts` — Right sidebar collapse state
+- `ai-chat-store.ts` — AI chat panel state
+
+### TipTap Editor
+
+**Location:** `lib/domain/editor/`
+
+**Four extension sets:**
+- `getEditorExtensions()` — Client-side, includes React components (SlashCommands, WikiLink suggestion, Tag suggestion, PersonMention)
+- `getServerExtensions()` — Server-safe for API routes and markdown conversion
+- `getViewerExtensions()` — Read-only display (delegates to `getEditorExtensions()`)
+- `getCollaborationServerExtensions()` — Used by Hocuspocus server and `collab:schema:check` CI; lives in `lib/domain/collaboration/extensions.ts`
+
+**Custom extensions** (in `lib/domain/editor/extensions/`):
+- `wiki-link.ts` — `[[Note Title]]` or `[[slug|Display]]`, autocomplete, click navigation
+- `callout.ts` — Obsidian `> [!type] Title` syntax, 6 types (note, tip, warning, danger, info, success)
+- `tag.ts` — Inline atomic node with `tagId`, `tagName`, `slug`, `color`. Renders as colored pill.
+- `inline-timestamp.ts` — Clickable inline date/time with popover picker; `ServerInlineTimestamp` for server use
+- `blocks/` — Custom block nodes (SectionHeader, CardPanel, Accordion, Tabs, Columns, DailySummary, WeeklySummary, ExcalidrawBlock, MermaidBlock, etc.)
+- `commands/slash-commands.tsx` — `/` menu for quick insertion
+
+**Server variants:** Every custom Node/Mark must have a `Server*` variant in the same file (e.g. `ServerExcalidrawBlock`). All three extension sets (`getServerExtensions`, `getCollaborationServerExtensions`, and client) must stay in sync — the CI check enforces this.
+
+**Unsupported content safety net:** `lib/domain/editor/unsupported-content.ts` exports `sanitizeTipTapJsonWithExtensions()`. Any unknown node types are rewritten to `unsupportedBlock`/`unsupportedInline` placeholders instead of being silently dropped, preserving round-trip fidelity.
+
+**Schema versioning:** `lib/domain/editor/schema-version.ts` — MUST update `TIPTAP_SCHEMA_VERSION` (semver) whenever the schema changes. MAJOR bump requires a migration in `lib/domain/export/migrations.ts`.
+
+**Auto-save:** 2-second debounce with visual indicator (yellow → green).
+
+### Collaboration Architecture
+
+**Transport:** Hocuspocus server hosted on Google Cloud Run (not local). Do not check port 1234 or suggest `pnpm dev:collab` for production testing.
+
+**Y.js document storage:** `CollaborationDocument` Prisma table stores binary `ydocState`. On load, the server bootstraps from TipTap JSON if no Y.js state exists. Presence (awareness) state is persisted to Postgres to handle Vercel serverless split.
+
+**Client topology states** (from `lib/domain/collaboration/runtime.ts`):
+- `CollaborationAvailabilityState`: `"canonical"` | `"localFallback"` | `"plainFallback"`
+- `ConnectionState`: `"localOnly"` | `"promoting"` | `"connecting"` | `"connected"` | `"synced"` | `"disconnectedButDirty"` | `"coolingDown"`
+
+**editorMode dep array:** TipTap `useEditor` recreates the editor when the `deps` array changes. The `editorMode` string must encode provider presence (`"collaboration"` vs `"collaboration-local"`) so the editor recreates when Hocuspocus transitions from null → non-null.
+
+**Collaborative fields:** `CollaborativeFieldKind` = `"tiptapXml"` | `"text"` | `"map"` | `"array"` | `"viewOnly"`. Embedded diagrams (Excalidraw, Mermaid) use sub-maps keyed by `blockExcalidraw:{blockId}` / `blockMermaid:{blockId}`.
+
+### Periodic Notes / Daily Notes
+
+**Extension:** `extensions/daily-notes/` — user-toggleable, `enabledByDefault: true`
+
+**API routes:** `app/api/periodic-notes/resolve/` (find or create today's note), `app/api/periodic-notes/summary/` (activity signal for the daily summary block)
+
+**Domain logic:** `lib/domain/periodic-notes/` — `period.ts` (date math), `settings.ts` (user prefs), `types.ts`
+
+**Editor blocks:** `DailySummary` and `WeeklySummary` in `lib/domain/editor/extensions/blocks/periodic-summary.ts` — render activity summaries inline in notes. `ServerDailySummary` / `ServerWeeklySummary` are the server-safe variants.
+
+**Activity signal:** `getEffectiveContentUpdatedAt()` in the summary route resolves payload-specific `updatedAt` (note, file, visualization, etc.) for accurate "last edited" tracking.
+
+### Export System
+
+**Location:** `lib/domain/export/`
+
+**Converters:** Markdown (with wiki-links, callouts, semantic HTML comments for tags), HTML (standalone with embedded CSS), JSON (lossless TipTap JSON), PlainText. PDF/DOCX are stubs.
+
+**Metadata sidecars:** `.meta.json` files preserve tags (ID, color), wiki-link targets, callout structure. Generated on export but **no import consumer exists** — round-trip import loses semantic data.
+
+**Markdown tag format:** `<!-- tag:tagId:colorValue -->#tagname<!-- /tag -->` — renders as raw HTML comments when reimported.
+
+### Storage Architecture
+
+Factory pattern in `lib/infrastructure/storage/`. Providers: Cloudflare R2 (primary), AWS S3, Vercel Blob. Two-phase upload: initiate (get presigned URL) → finalize (confirm completion).
+
+### Authentication
+
+Custom OAuth with Google Sign-In. `lib/infrastructure/auth/` (barrel export via `index.ts`). Role hierarchy: owner > admin > member > guest. Admin endpoints require `requireRole("owner")`.
+
+### AI Integration
+
+**Location:** `lib/domain/ai/`
+
+AI SDK v6 integration with BYOK (Bring Your Own Key) support.
+
+**AI domain structure:**
+- `types.ts` — Chat types, model configuration
+- `providers/` — Model provider factories (Anthropic, OpenAI) using `createAnthropic()` / `createOpenAI()`
+- `middleware/` — `defaultSettingsMiddleware` for model defaults
+- `tools/` — AI tool definitions: `metadata.ts` (client-safe, no Prisma), `registry.ts` (server-only, has Prisma)
+- `features/` — Multi-model routing: `FEATURE_REGISTRY`, `resolveFeatureRoute()`, `executeWithFallback()` for model fallback chains
+- `speech/` — TTS (text-to-speech) generation and storage: `generate.ts`, `generate-and-store.ts`, `catalog.ts`
+- `transcribe/` — STT (speech-to-text): `transcribe.ts`
+- `image/` — AI image generation: `generate.ts`, `generate-via-gateway.ts`, `generate-and-store.ts`
+- `use-conversation-engine.ts` — Shared hook for all AI chat surfaces
+- `conversation-persistence.ts` — Persists chat history to Prisma (`Conversation`, `ConversationMessage`, `ConversationAssociation` tables)
+
+**AI SDK v6 conventions:**
+- `useChat()`: Use `transport: new DefaultChatTransport({ api, body })` — no `api`/`body` props directly
+- `useChat()`: No `initialMessages` — use `messages` field. No `input`/`setInput`/`handleSubmit` — use `sendMessage({ text })`
+- `tool()`: Uses `inputSchema` (not `parameters`), import `z` from `zod/v4`
+- `maxTokens` → `maxOutputTokens` in V3 call options
+- `ChatStatus`: `'ready' | 'submitted' | 'streaming' | 'error'`
+
+**AI tools ≠ Tool Surfaces** — separate directories (`lib/domain/ai/tools/` vs `lib/domain/tools/`), separate registries.
+
+## API Routes
+
+All content endpoints under `app/api/content/`:
+
+```
+GET/POST         /content/content              # List/create
+GET/PATCH/DELETE /content/content/[id]         # CRUD
+GET              /content/content/tree         # Hierarchical tree
+POST             /content/content/move         # Drag-and-drop reorder
+POST             /content/content/create-document
+POST             /content/content/duplicate
+POST             /content/content/upload/initiate   # Presigned URL
+POST             /content/content/upload/finalize
+POST             /content/content/upload/simple
+GET              /content/content/[id]/download
+GET/PATCH        /content/folder/[id]/view     # Folder view settings
+GET              /content/search
+GET              /content/backlinks
+GET/POST         /content/tags
+GET              /content/tags/content/[id]
+GET/POST         /content/storage
+POST             /content/export/[id]
+POST             /content/export/vault          # Bulk ZIP export
+POST             /content/external/preview      # Open Graph metadata fetch
+```
+
+Other API areas: `app/api/admin/`, `app/api/auth/`, `app/api/google-drive/`, `app/api/onlyoffice/`, `app/api/visualization/`, `app/api/categories/`, `app/api/user/`, `app/api/periodic-notes/`, `app/api/calendar/`, `app/api/conversations/` (persisted chat history), `app/api/flashcards/`, `app/api/publishing/`, `app/api/speed-reader/`, `app/api/media/`, `app/api/integrations/`, `app/api/trash/`, `app/api/logs/`, `app/api/cron/`
+
+**AI-specific routes:** `app/api/ai/chat/`, `app/api/ai/speech/` (TTS), `app/api/ai/transcribe/` (STT), `app/api/ai/image/`, `app/api/ai/inject-media/`, `app/api/ai/follow-ups/`, `app/api/ai/folder-assist/`
+
+**Type definitions:** `lib/domain/content/api-types.ts`
+
+## Directory Structure
+
+```
+app/
+├── (authenticated)/content/    # Content IDE routes
+├── api/                        # API routes
+└── globals.css                 # Global styles + generated design tokens
+
+extensions/                     # First-party feature extensions
+├── daily-notes/                # Periodic notes (manifest, client, components)
+├── flashcards/
+├── people/
+├── workplaces/
+├── calendar/
+├── publishing/                 # Public site publishing
+├── speed-reader/               # RSVP speed reader (global-dialog surface)
+└── browser-bookmarks/          # Browser extension + embed iframe integration
+
+components/content/
+├── ai/                         # AI chat panel components
+├── editor/                     # TipTap editor + BubbleMenu
+├── toolbar/                    # ContentToolbar, ToolDebugPanel
+├── tool-belt/                  # Tool management providers
+├── folder-views/               # List, Grid, Kanban view components
+├── external/                   # External link viewer + dialog
+├── file-tree/                  # Tree node rendering
+├── headers/                    # Left/Right sidebar headers
+├── context-menu/               # Right-click context menu
+├── viewer/                     # File type viewers (image, PDF, code, etc.)
+├── dialogs/                    # Modal dialogs
+└── skeletons/                  # Loading skeletons
+
+lib/
+├── core/                       # utils.ts (cn()), deep-merge, menu-positioning, glass-utils
+├── database/                   # client.ts (Prisma singleton), generated/prisma/
+├── domain/
+│   ├── admin/                  # Admin panel + audit logging
+│   ├── content/                # ContentNode utilities, OG fetcher, external validation
+│   ├── collaboration/          # Hocuspocus runtime, documents, extensions, content-safety
+│   ├── editor/                 # TipTap extensions (extensions/, commands/), schema-version, unsupported-content
+│   ├── export/                 # Converters, metadata sidecars, bulk export, migrations
+│   ├── periodic-notes/         # Period math, settings, types (daily/weekly notes domain)
+│   ├── search/                 # Search filters
+│   ├── ai/                     # AI SDK v6 integration (providers, middleware, tools)
+│   ├── tools/                  # Tool Surfaces registry + context provider
+│   └── visualization/          # Excalidraw, Mermaid, diagrams.net collaboration
+├── extensions/                 # Extension registry infrastructure (client-registry, server-registry, types)
+├── infrastructure/
+│   ├── auth/                   # OAuth, sessions, middleware (barrel: index.ts)
+│   ├── crypto/                 # Encryption utilities
+│   ├── media/                  # File processing
+│   └── storage/                # Multi-cloud provider abstraction
+├── features/
+│   ├── navigation/             # Branch builder
+│   ├── office/                 # Blank document generator
+│   └── settings/               # User settings CRUD (barrel: index.ts)
+└── design/
+    ├── system/                 # Liquid Glass tokens (surfaces, intents, motion)
+    └── integrations/           # Third-party UI utilities
+
+state/                          # Zustand stores
+prisma/                         # schema.prisma, migrations/, seed.ts
+scripts/                        # validate-collaboration-schema.ts, check-hocuspocus-env.ts
+```
+
+## Design System: Liquid Glass
+
+Tokens in `lib/design/system/`: `surfaces.ts` (Glass-0/1/2 blur levels), `intents.ts` (semantic colors), `motion.ts` (animations).
+
+Generated via `pnpm build:tokens` (style-dictionary → CSS variables in `globals.css`).
+
+```tsx
+import { getSurfaceStyles } from "@/lib/design/system";
+const glass0 = getSurfaceStyles("glass-0");
+<div style={{ background: glass0.background, backdropFilter: glass0.backdropFilter }}>
+```
+
+## Key Patterns & Conventions
+
+### Code Standards
+- TypeScript strict mode, **no `any` types**. Use `unknown` and narrow, `Record<string, unknown>` for loose objects, or a proper type. If genuinely unfixable (untyped third-party lib, etc.) flag with `// eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO(...): <reason>`.
+- Ignore directories with " 2" suffix (e.g., `content 2`, `editor 2`) — filesystem artifacts, not part of the build
+- Inline SVG for server component icons; `lucide-react` OK in client components only
+- Import from barrel exports: `lib/domain/editor`, `lib/infrastructure/auth`, `lib/features/settings`, `lib/domain/tools`
+- Use `lib/design/system/` tokens for styling
+- **Never import Prisma into `"use client"` components** — causes dns/fs/net/tls bundler errors. Client-safe AI tool metadata lives in `lib/domain/ai/tools/metadata.ts`; server-only registry in `lib/domain/ai/tools/registry.ts`
+- For Prisma JSON writes, use `as unknown as Prisma.InputJsonValue` (the cast goes through `unknown` because Prisma's input type is intentionally narrow)
+- For unused parameters/vars that must remain (kept-for-signature, caught errors), prefix with `_` — eslint is configured to ignore `_`-prefixed identifiers via `argsIgnorePattern`/`varsIgnorePattern`/`caughtErrorsIgnorePattern`. **Do NOT** add bare `// eslint-disable` for unused-vars; rename instead.
+- **Next.js 16 middleware is `proxy.ts`, not `middleware.ts`** — this repo renames it per Next.js 16 conventions. The function export is named `proxy`. Do not create `middleware.ts`; the build will fail if both files coexist.
+
+### Quality Gates — before declaring a task done
+
+The workflow is `typecheck → lint → build`. Each gates the next:
+
+1. **`pnpm typecheck`** — fast. Run continuously while editing. Must be clean before lint.
+2. **`pnpm lint`** — uses `--max-warnings 175` ratchet. **Zero new warnings, zero errors.** If you must introduce a warning, fix an equal-or-greater number elsewhere or update the ratchet number with justification.
+3. **`pnpm build`** — full production build (runs both the above plus `collab:schema:check`). Final gate before declaring complete.
+4. **Browser smoke test** — for any UI change, manually exercise the feature in a browser. Type checks verify correctness; they don't verify behavior.
+
+Rules for specific lint signals:
+- **`react-hooks/exhaustive-deps`** — the missing dep is almost always a real bug. Add it. If you genuinely can't (callback should be stable, dep would cause infinite loop), restructure with `useCallback`/`useRef` or add `// eslint-disable-next-line react-hooks/exhaustive-deps -- <why>`. Don't suppress silently.
+- **`react-hooks/rules-of-hooks`** — never suppress. Hoist all hooks above early-return branches.
+- **`react-hooks/immutability` (React Compiler)** — "cannot modify value": you're mutating something derived from a prop or hook argument. Fix patterns: (a) move the mutation into a `useEffect` and use a ref the component owns, (b) extract to a module-scope helper function (parameter rebinding breaks lineage analysis).
+- **"Compilation Skipped" (React Compiler)** — the compiler found incorrect manual memoization (typically a `useCallback`/`useMemo` dep array that disagrees with what it would generate). Fix the dep array; don't suppress.
+- **"Cannot access refs during render" / "Cannot call impure function during render"** — render must be pure. Move ref writes and `Date.now()`/`Math.random()`/etc. into effects. `useId()` is the pure alternative to `Date.now()` for unique IDs.
+
+### Lessons learned (recorded in the lint-cleanup epic, Apr 2026)
+
+Bugs found by the React Compiler and the type cleanup that we'd otherwise have missed:
+- **OnlyOfficeEditor iframe reload churn** — `key: \`${contentId}-${Date.now()}\`` regenerated every render. Replaced with `useId()` for stable-per-mount keys.
+- **ChatInput stale mention callback** — `handleSelect`'s `useCallback` dep array was missing `onMentionInserted`, leaving the parent's tracking callback frozen at its first identity.
+- **DiagramsNetEditor StrictMode hazard** — `xmlRef.current = xml` ran during render, doubling under StrictMode. Moved into `useEffect(() => { ref.current = x }, [x])`.
+
+These were all caught by enforcing the React Compiler rules during lint. Treat compiler errors as bug reports, not stylistic complaints.
+
+### Adding a New TipTap Extension
+
+1. Create `lib/domain/editor/extensions/<name>.ts` with both `MyExtension` (client) and `ServerMyExtension` (server-safe, no React) exports
+2. Add `MyExtension` to `getEditorExtensions()` in `extensions-client.ts`
+3. Add `ServerMyExtension` to `getServerExtensions()` in `extensions-server.ts`
+4. Add `ServerMyExtension` to `getCollaborationServerExtensions()` in `lib/domain/collaboration/extensions.ts`
+5. Bump `TIPTAP_SCHEMA_VERSION` in `lib/domain/editor/schema-version.ts` (MINOR for new nodes, MAJOR for breaking changes)
+6. Run `pnpm collab:schema:check` to confirm CI passes
+
+### Adding a New Extension Module
+
+1. Create `extensions/<name>/manifest.ts`, `client.tsx`, and (if needed) `server-runtime.ts`
+2. Register in `lib/extensions/installed.ts`
+3. Shell UI contributions go through runtime shell slots — do not import extension UI directly into shared components
+4. Content viewer: if the extension owns rendering for a specific content type, declare the matcher in `client.tsx`
+
+### Database Workflows
+
+**Development:** Edit `prisma/schema.prisma` → `npx prisma db push` → `npx prisma generate`
+
+**Production:** `npx prisma migrate dev --name name --create-only` → review SQL → `npx prisma migrate deploy`
+
+**Rules:** Use `db push` for dev (fast, no data loss). Never `migrate reset` in prod. Always `generate` after schema changes. Use `migrate resolve` to fix drift.
+
+**Checklist:** `docs/notes-feature/guides/database/DATABASE-CHANGE-CHECKLIST.md` (mandatory for all schema changes)
+
+### Menu Positioning
+
+Portal rendering + boundary detection in `lib/core/menu-positioning.ts`. Two-phase: render hidden to measure, then position. Auto-flips at viewport edges. Used by context menus, dropdowns, tooltips.
+
+## Publishing Block Development Protocol
+
+Full guide (block inventory, per-step checklist, footguns, template, CI gates reference):
+**[docs/notes-feature/guides/publishing/PUBLISHING-BLOCK-GUIDE.md](docs/notes-feature/guides/publishing/PUBLISHING-BLOCK-GUIDE.md)**
+
+### Five required surfaces — every block must satisfy all of them
+
+| # | What | Where |
+|---|---|---|
+| 1 | Block file: schema + `registerBlock()` + client extension + server extension | `extensions/publishing/blocks/<name>.ts` |
+| 2 | Server-runtime registration | `extensions/publishing/server-runtime.ts` |
+| 3 | CSS (light defaults + `.dark` companions for any extreme colors) | `app/globals.css` |
+| 4 | Playwright fixture JSON + entry in `PUBLISHING_FIXTURE_BLOCKS` + committed PNGs | `tests/e2e/_fixtures/publishing/` |
+| 5 | Post-merge Hocuspocus redeploy via Cloud Build | `cloudbuild.hocuspocus.yaml` |
+
+### Key rules (expanded in the guide)
+
+- **Always use `dataAttr("camelKey")`** in `addAttributes()` — hand-rolling attribute access has silently dropped attrs in production (see `hero-image.ts`).
+- **`renderHTML` reads kebab keys**: `HTMLAttributes["data-cta-text"]`, not `HTMLAttributes["ctaText"]`.
+- **No collab registration step needed**: publishing blocks flow into `getCollaborationServerExtensions()` automatically via `getExtensionServerEditorExtensions()` → `publishingExtensionServerRuntime`. Unlike editor-level TipTap extensions, no manual entry in `lib/domain/collaboration/extensions.ts` is required.
+- **Hocuspocus must be redeployed after merge**: it's a separate Cloud Run service (Docker image snapshot). Vercel does not redeploy it. Without a redeploy, unknown block types are serialized as `unsupportedBlock` placeholders, corrupting collaborative documents.
+- **Dark-mode CSS is hard**: every `.public-prose .block-*` rule using an extreme color needs a `.dark` companion. Eight blocks were invisible on light pages for this reason. Run `pnpm publishing:audit:themes`.
+
+### Quality gate commands
+
+```bash
+pnpm publishing:schema:check   # Server* export in server-runtime (hard gate)
+pnpm publishing:audit:defaults # Zod defaults vs renderHTML fallback drift (info)
+pnpm publishing:audit:themes   # CSS extreme colors without dark companion (info)
+pnpm typecheck && pnpm lint    # TypeScript + ESLint
+pnpm build                     # Full production build
+pnpm test:e2e                  # Per-block Playwright visual regression (hard gate)
+```
+
+## Sprint/Epoch Development Model
+
+2-week sprints within 8-12 week strategic epochs.
+
+**Status tracking:**
+- `docs/notes-feature/STATUS.md` — Single source of truth (MUST update when completing work)
+- `docs/notes-feature/work-tracking/CURRENT-SPRINT.md` — Detailed sprint tracking
+- `docs/notes-feature/work-tracking/BACKLOG.md` — Prioritized backlog
+
+**After completing work:** Update STATUS.md frontmatter `last_updated`, move work items (⚪→🟡→✅), add to "Recent Completions" at top. Update BACKLOG.md when backlogging incomplete sprint items.
+
+## Documentation
+
+**Start here:** `docs/notes-feature/00-START-HERE.md`
+
+**Core architecture:** `docs/notes-feature/core/`
+
+**Guides:** `docs/notes-feature/guides/` — `database/`, `editor/`, `ui/`, `storage/`, `collaboration/`, `export/`
+
+**History:** `docs/notes-feature/work-tracking/history/`

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -99,7 +99,9 @@ import type {
 import {
   applyMiddleware,
   defaultSettingsMiddleware,
+  rateLimitRetryMiddleware,
 } from "@/lib/domain/ai/middleware";
+import { buildSystemPrompt } from "@/lib/domain/ai/system-prompt";
 import { createBaseTools } from "@/lib/domain/ai/tools";
 import { createEditorTools } from "@/lib/domain/ai/tools";
 import { createFlashcardTools } from "@/lib/domain/ai/tools";
@@ -294,6 +296,7 @@ export async function POST(request: Request) {
               });
           return applyMiddleware(model, [
             defaultSettingsMiddleware({ temperature, maxTokens }),
+            rateLimitRetryMiddleware(),
           ]);
         },
       );
@@ -512,80 +515,16 @@ export async function POST(request: Request) {
         //   with headroom for an optional search_decks or get_deck call.
         // Base chat (no flashcards, no document) typically needs 2-3 steps.
         stopWhen: stepCountIs(editableContentId ? 8 : 7),
-        system: `You are a helpful AI assistant in Digital Garden, a knowledge management application. Help the user with their notes, writing, and research. Be concise and helpful.
-
-You have a generate_image tool that creates AI images from text prompts. When asked to generate, create, or draw an image, use this tool. Available providers: DALL·E 3, GPT Image 1, Imagen 3, FLUX (fal.ai/Together/Fireworks), DeepAI, RunwayML, Artbreeder. Default to DALL·E 3 unless specified. Write detailed prompts for best results.
-
-You can manage the user's flashcard decks. Vocabulary first:
-- "skill" and "deck" are interchangeable in the user's vocabulary — both mean a flashcard deck. Treat them the same way.
-- A "sub-skill" or "sub-deck" is a nested deck under a parent (e.g. "spanish/irregular-verbs" is a sub-deck under "spanish").
-- When the user says "make me a skill on X" or "create a deck for X," they want a deck named after the topic X. NEVER name the deck literally "Skill" or "Deck" — those are category words, not deck names. Name the deck after the topic the user mentioned.
-
-Tool design:
-- propose_deck_with_cards is the primary tool for "cards in a deck context." It takes BOTH the deck info (name + optional parentDeckPath) AND the cards. The commit handles deck creation atomically — including parent creation when the parent doesn't yet exist either. ONE tool call covers any depth of hierarchy. The user reviews the card and clicks "Create deck & add" (or "Add selected" if the deck already exists); the server cascades through missing ancestors and adds the cards in one flow.
-- propose_deck (standalone) is RARE. Use it only when the user explicitly asks to create a deck WITHOUT any cards yet (e.g. "set up a Japanese deck, I'll add cards later"). For "make me cards on X" — even when the deck or its parent doesn't exist yet — just call propose_deck_with_cards.
-- propose_image_cards creates IDENTIFICATION cards whose front is an AI-GENERATED IMAGE plus a short instruction caption, for VISUAL recall — identifying plants, insects, animals, anatomy, landmarks, chemical structures, code screenshots, etc. Use it ONLY when the study goal is recognizing something visual (the user asks for "picture cards," "identify-the-X cards," or the topic is inherently visual). For each card provide: imagePrompt (a specific, unambiguous prompt that makes the image clearly depict the answer — e.g. "a single monarch butterfly, wings open, photorealistic, plain white background"), identifyLabel (few-word instruction shown under the image, e.g. "Identify this butterfly"), and back (the answer). Images generate at propose time so the user previews them before accepting. LIMIT 5 cards per call. Do NOT use it for plain text Q&A — use propose_deck_with_cards for those.
-- propose_cards_from_media creates IDENTIFICATION cards from media the user ATTACHED to the chat (images and/or audio) — the front is the uploaded media itself and the back is YOUR identification. This is the inverse of propose_image_cards (which generates an image). You have already seen/heard the attachments; for each card pass mediaIndex (0-based, in attachment order), identifyLabel ("Identify this mushroom"), and back (your answer). Use it whenever the user attaches photos/recordings and asks to "make identification flashcards from these." If nothing is attached, tell the user to attach the media first.
-- propose_sound_id_cards creates SOUND-IDENTIFICATION cards — the front is a real-world SOUND (bird call, animal, instrument, engine) and the back names it. Use it when the study goal is recognizing a NON-SPEECH sound by ear. For each card: soundPrompt (precise description of the sound to source), identifyLabel (front instruction, e.g. "Identify this bird"), back (the answer). IMPORTANT: automatic sound sourcing isn't available yet, so these currently commit as TEXT prompts without a real clip — only use this tool when the user explicitly wants sound-ID cards, and tell them that to attach real audio today they should upload clips and use "cards from media". This is NOT for pronunciation (use the audio directive) or images (propose_image_cards).
-- SPOKEN AUDIO on cards (propose_deck_with_cards 'audio' directive): any card in propose_deck_with_cards can carry a spoken clip by adding an 'audio' field of shape { side, hideText? }. The spoken text is whatever you wrote on that side — never repeat it elsewhere. Three patterns:
-  • Pronunciation (most common): a non-English vocab term → audio: { side: "front" } so the word is shown AND spoken (hear it, recall the meaning on the back). For reverse/production cards where the spoken word is the ANSWER, use side: "back".
-  • Listening comprehension: the learner must understand by EAR (e.g. hear a Chinese sentence and recall its meaning) → audio: { side: "front", hideText: true }. The front then shows ONLY a play button; put the transcription + translation on the back.
-  • The audio is NOT generated at propose time — the user picks a voice/provider in a follow-up window, then generation runs (opt-in, no auto-spend). Audio rides alongside ordinary cards; a single propose_deck_with_cards batch may mix audio and silent cards.
-  Do NOT use audio for plain English Q&A unless the user explicitly asks for spoken English.${
-    autoPronounceDefault
-      ? `\n  • DEFAULT BEHAVIOR: when the deck is non-English vocabulary (or scientific/Latin names), ADD audio:{ side: "front" } to every card by DEFAULT — the user has opted into automatic pronunciation. Only omit it if the user says they don't want audio. (Generation is still opt-in; you're only attaching the directive.)`
-      : ""
-  }
-
-Workflow:
-
-1. ALWAYS call list_decks first when the user mentions flashcards, so you can prefer an existing deck and populate similarExistingPaths with near-matches.
-2. Pick a path that reflects the topic's natural hierarchy. If the user asks for "Spanish irregular verbs," the right path is "spanish/irregular-verbs" — NOT "general/irregular-verbs." Use a domain-named parent (language, subject, skill) when the topic has one.
-   - EVERY deck MUST have a named root SKILL — the first segment of the path. The skill is the broad subject the cards belong to (the language, the course, the domain): "spanish", "latin", "biology", "anatomy". The deeper segments are sub-skills. NEVER propose a bare single-segment leaf like name:"Irregular Verbs" with no parentDeckPath when the cards clearly belong to a broader skill — that produces an orphan deck the user sees as "No Skill Category". Instead set name:"Irregular Verbs" + parentDeckPath:"spanish" so the full path is "spanish/irregular-verbs".
-   - The ONLY time a single-segment root path is correct is when the user's topic IS the whole skill (e.g. "make me a Latin deck" → name:"Latin", no parent). When in doubt, infer the skill from the subject matter (a set of Latin vocabulary → skill "latin") rather than dropping the card at the root with no skill.
-   - NEVER emit an empty, whitespace, or placeholder ("untitled", "general", "skill", "deck") name for any path segment. Every segment is a real, human-meaningful name.
-3. Call propose_deck_with_cards ONCE with the appropriate deck info and cards. The commit step in the UI handles the three cases atomically:
-   a. Leaf exists → cards are added to it directly.
-   b. Leaf doesn't exist, parent exists → commit creates the leaf and adds cards.
-   c. Leaf doesn't exist, parent (or grandparent) also doesn't exist → commit walks the path and creates each missing ancestor, then the leaf, then adds cards.
-   You do NOT need to call propose_deck for missing parents — the propose_deck_with_cards commit handles it. Calling propose_deck for a parent that propose_deck_with_cards is already going to create produces a confusing chat (two cards, redundant clicks).
-4. After your propose_deck_with_cards call, stop and wait. The chat UI is the confirmation surface — clicking "Create deck & add" or "Add selected" are how the user commits. You don't loop back, and you should NOT ask the user to confirm in text ("please confirm" / "shall I create"). The card itself is the confirmation affordance. If the user wants a different deck name, they can edit the deck path inline on the card — you don't need to re-propose unless the user asks for a different topic.
-
-Card content guidance:
-- The FRONT side of every card is the TERM being tested. Keep it concise — the term itself, nothing more. Do NOT add definitions, example sentences, or context to the front. The user wants to see the bare prompt and recall the answer.
-- The BACK side is where the explanation lives — translation, definition, mnemonic, etc.
-- For LANGUAGE flashcards (the deck path or topic names a language: Spanish, Japanese, French, Latin, Mandarin, Arabic, etc.) ALWAYS include pronunciation on the BACK:
-  - Non-Latin scripts: add the romanization/transliteration (Japanese: kana → romaji; Mandarin: → pinyin with tone marks; Arabic: → transliteration; Cyrillic: → Latin transliteration).
-  - Latin-script languages with non-obvious pronunciation: add IPA or a simple phonetic respelling (French silent letters, English idioms, German umlauts).
-  - Format: put the translation on the first line and pronunciation in parentheses or on a second line. Example for "hacer" (Spanish): front = "hacer", back = "to do / to make\\n(ah-SAIR)".
-- For non-language cards (history, math, science, etc.) keep both sides focused on the concept; no pronunciation needed.
-- Use frontLabel/backLabel to override the defaults when it clarifies the card — e.g. for language cards: frontLabel "Term", backLabel "Translation".
-
-Hard rules:
-- propose_deck_with_cards limit: 10 cards per call (Zod-enforced). If the user asks for MORE than 10, propose 10, set requestedCount to the true count, and end your turn with "Showing first 10 of N requested — accept these and I'll propose the rest." Do NOT chain propose_deck_with_cards calls unprompted.
-- When the user has a note open, set sourceContentId on proposed cards to that note's id so cards link back to their source.
-- When the user revises a deck you already proposed in the conversation (renames it, retopics it, moves it under a different parent), the simplest fix is for the user to edit the deck path directly on the existing card. They can do that without involving you. If the user asks YOU to revise, just call propose_deck_with_cards again with the new deck info — the earlier proposal stays visible in chat history; the new one is the actionable one.${
-          editableContentId
-            ? `\n\nThe user is currently viewing a document (ID: ${editableContentId}). You have editor tools available to read and edit this document.
-
-IMPORTANT EDITING RULES:
-- When the document has existing content, ALWAYS use apply_diff to make targeted changes or APPEND new content. NEVER use replace_document unless the user explicitly asks you overwrite the entire document.
-- To add content (descriptions, text, images), APPEND it after the existing content using apply_diff. Do NOT overwrite what is already there.
-- When asked to edit, always: 1) Read the document first with read_first_chunk, 2) Plan your approach if the edit is complex, 3) Apply changes with apply_diff for targeted edits, 4) Call finish_with_summary when done.
-- Only use replace_document for blank/empty documents or when the user explicitly requests a full rewrite.
-
-When you generate an image, the user can insert it into the document at their cursor position.`
-            : isChatContent
-            ? `\n\nThe user is chatting with you on a full-page chat (ID: ${contentId}). DATA-MODEL FACT YOU MUST KNOW: this chat HAS a notes panel ("Add notes" — a TipTap editor below the conversation) keyed to the chat's own contentId. Writing to it is exactly the same as updating any other content's notes — call \`updateNote\` with the chat's contentId as the \`contentId\` argument. Do NOT create a separate file.
-
-NOTE-TOOL RULES IN CHAT CONTEXT:
-- "add a note to this chat", "create a note on this chat", "put X in the chat notes", "update the note in this chat" all mean: update the notes panel attached to THIS chat. Use \`updateNote({ contentId: "${contentId}", content: "<markdown>" })\`. NEVER set \`title\` — that would rename the chat.
-- For "create a NEW note in a folder" (separate file), use \`createNote\`. It defaults to the chat's parent folder.
-- For "update my Sourdough note" etc. (named other note), use \`searchNotes\` to find the id, then \`updateNote\`.
-- Tooling distinguishes by contentId — same tool, different target.
-- Title-arg rule: never set \`title\` unless the user EXPLICITLY says "rename this to X". Topic-derived titles are a bug. (The tool will hard-ignore \`title\` when the target is this chat, but still follow the rule.)`
-            : ""
-        }${userContextSection}${mentionedContext}`,
+        system: buildSystemPrompt({
+          hasImageTools: "generate_image" in tools,
+          hasFlashcardTools: "list_decks" in tools,
+          editableContentId,
+          isChatContent,
+          chatContentId: isChatContent ? contentId : undefined,
+          autoPronounceDefault,
+          userContextSection,
+          mentionedContext,
+        }),
         onStepFinish: (step) => {
           // Tool-call auto-association interceptor (Session 4b).
           // After each model step, scan the step's tool calls for any

--- a/app/api/people/groups/route.ts
+++ b/app/api/people/groups/route.ts
@@ -5,6 +5,24 @@ import { createPeopleGroup } from "@/lib/domain/people";
 import { requireAuth } from "@/lib/infrastructure/auth/middleware";
 import { logger } from "@/lib/core/logger";
 
+export async function GET(_request: NextRequest) {
+  try {
+    const session = await requireAuth();
+    const groups = await prisma.peopleGroup.findMany({
+      where: { ownerId: session.user.id },
+      select: { id: true, name: true, parentGroupId: true, isDefault: true },
+      orderBy: { name: "asc" },
+    });
+    return NextResponse.json({ success: true, data: { groups } });
+  } catch (error) {
+    logger.error({ layer: "content", event: "people_group_list:caught", summary: "GET caught", error });
+    return NextResponse.json(
+      { success: false, error: { code: "SERVER_ERROR", message: "Failed to list People groups" } },
+      { status: 500 }
+    );
+  }
+}
+
 interface CreatePeopleGroupRequest {
   name?: string;
   parentGroupId?: string | null;

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,0 +1,56 @@
+/**
+ * /community — placeholder Community page.
+ *
+ * Forum / chat channels are not live yet. Coming soon.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  PlatformShell,
+  MarketingPageHeader,
+  PlaceholderGrid,
+} from "@/components/home/platform-chrome";
+
+export const metadata: Metadata = {
+  title: "Community",
+  description:
+    "Connect with other gardeners — share workflows, templates, and published gardens. Coming soon.",
+};
+
+export default function Page() {
+  return (
+    <PlatformShell>
+      <MarketingPageHeader
+        eyebrow="Connect"
+        title="Community"
+        lede="Gardens grow better together. We're building places to swap workflows, templates, and published gardens — here's what's coming."
+      />
+      <section className="max-w-6xl mx-auto px-6 pb-12">
+        <PlaceholderGrid
+          items={[
+            { title: "Discussion forum", body: "Ask questions, share setups, and trade ideas with other gardeners." },
+            { title: "Chat", body: "A real-time space to talk through workflows and get quick help." },
+            { title: "Showcase", body: "Browse published gardens for inspiration — and show off your own." },
+          ]}
+        />
+      </section>
+      <section className="max-w-6xl mx-auto px-6 pb-24">
+        <div className="rounded-xl border border-white/8 bg-white/[0.03] p-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <div>
+            <h2 className="text-base font-semibold mb-1">Want to be first in?</h2>
+            <p className="text-sm text-white/50">
+              Reach out and we&apos;ll let you know the moment the community opens.
+            </p>
+          </div>
+          <Link
+            href="/contact"
+            className="flex-shrink-0 px-4 py-2.5 rounded-lg border border-white/15 text-white/80 text-sm font-medium hover:border-white/30 hover:text-white transition-colors"
+          >
+            Get in touch
+          </Link>
+        </div>
+      </section>
+    </PlatformShell>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,56 @@
+/**
+ * /contact — placeholder Contact page.
+ *
+ * Email contact methods. A real contact form can replace the mailto cards
+ * later. Email addresses are placeholders — swap for real inboxes pre-launch.
+ */
+
+import type { Metadata } from "next";
+import { PlatformShell, MarketingPageHeader } from "@/components/home/platform-chrome";
+
+export const metadata: Metadata = {
+  title: "Contact",
+  description: "Get in touch with the NoteTrellis team — support and general inquiries.",
+};
+
+const CHANNELS = [
+  {
+    label: "General",
+    email: "hello@notetrellis.com",
+    body: "Questions, feedback, partnerships, or just to say hello.",
+  },
+  {
+    label: "Support",
+    email: "support@notetrellis.com",
+    body: "Trouble with your account, your editor, or your published site.",
+  },
+];
+
+export default function Page() {
+  return (
+    <PlatformShell>
+      <MarketingPageHeader
+        eyebrow="Support"
+        title="Contact us"
+        lede="We'd love to hear from you. A contact form is coming; for now, email is the fastest way to reach us."
+      />
+      <section className="max-w-3xl mx-auto px-6 pb-24">
+        <div className="grid gap-3 sm:grid-cols-2">
+          {CHANNELS.map((c) => (
+            <a
+              key={c.email}
+              href={`mailto:${c.email}`}
+              className="rounded-xl border border-white/8 bg-white/[0.03] p-5 hover:border-emerald-500/30 transition-colors block"
+            >
+              <p className="text-xs font-medium uppercase tracking-widest text-emerald-400/70 mb-2">
+                {c.label}
+              </p>
+              <p className="text-sm text-white/50 leading-relaxed mb-3">{c.body}</p>
+              <span className="text-sm font-medium text-emerald-300">{c.email}</span>
+            </a>
+          ))}
+        </div>
+      </section>
+    </PlatformShell>
+  );
+}

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,0 +1,45 @@
+/**
+ * /docs — placeholder Documentation hub.
+ *
+ * Linked from the marketing footer. Real docs are pending; this renders an
+ * intentional "coming soon" catalog so the footer has no dead links.
+ */
+
+import type { Metadata } from "next";
+import {
+  PlatformShell,
+  MarketingPageHeader,
+  PlaceholderGrid,
+} from "@/components/home/platform-chrome";
+
+export const metadata: Metadata = {
+  title: "Documentation",
+  description:
+    "Learn how to grow your digital garden with NoteTrellis — guides for the editor, linking, recall, and publishing.",
+};
+
+export default function Page() {
+  return (
+    <PlatformShell>
+      <MarketingPageHeader
+        eyebrow="Learn"
+        title="Documentation"
+        lede="Everything you need to grow a digital garden — from your first note to a published site. We're writing these now; here's what's on the way."
+      />
+      <section className="max-w-6xl mx-auto px-6 pb-24">
+        <PlaceholderGrid
+          items={[
+            { title: "Getting started", body: "Create your first note, find your way around the workspace, and plant the seed of your garden." },
+            { title: "The editor", body: "Slash commands, callouts, blocks, diagrams, and everything you can compose on a page." },
+            { title: "Linking & backlinks", body: "Wiki-links, the backlinks panel, and the outline — the connective tissue of your notes." },
+            { title: "Organizing your garden", body: "Folders, tags, content types, and folder views for shaping your space without rigidity." },
+            { title: "Flashcards & recall", body: "Spaced repetition, cloze deletions, and Anki import for making knowledge stick." },
+            { title: "Publishing", body: "Turn notes into pages, connect a custom domain, and grow ideas in public." },
+            { title: "AI & automation", body: "Chat over your notes with your own keys, generate flashcards, and read notes aloud." },
+            { title: "Import & export", body: "Bring data in and take it out — Markdown, HTML, and lossless JSON. Your data stays yours." },
+          ]}
+        />
+      </section>
+    </PlatformShell>
+  );
+}

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -1,0 +1,25 @@
+/**
+ * /features — the NoteTrellis feature catalog.
+ *
+ * The "what": every feature category, each tagged with the lifecycle stage it
+ * serves. Companion to /notes-system (the "why" — philosophy + lifecycle loop).
+ * Renders the full-bleed dark marketing chrome via the shared PlatformShell.
+ */
+
+import type { Metadata } from "next";
+import { FeaturesPage } from "@/components/home/FeaturesPage";
+
+export const metadata: Metadata = {
+  title: "Features",
+  description:
+    "The complete NoteTrellis feature catalog — capture, connect, cultivate, and share. Every capability behind the digital-garden notes system.",
+  openGraph: {
+    title: "Features · NoteTrellis",
+    description:
+      "Everything in the garden: the full catalog of NoteTrellis features, grouped by what each part of the system is for.",
+  },
+};
+
+export default function Page() {
+  return <FeaturesPage />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -147,6 +147,14 @@ body:has(.embed-layout-page) {
   overflow: hidden !important;
 }
 
+/* Hide default nav + remove padding for the platform marketing page (notetrellis.com) */
+body:has(.platform-home-page) .notes-route-hides-default-nav {
+  display: none !important;
+}
+body:has(.platform-home-page) main {
+  padding-top: 0 !important;
+}
+
 /* Position toaster below navbar on notes routes (top-right corner) */
 /* Sonner uses [data-sonner-toaster] as the main container */
 body:has(.notes-layout-page) [data-sonner-toaster][data-y-position="top"] {
@@ -390,7 +398,7 @@ nav a,
 nav a:visited,
 nav a:link {
   text-decoration: none !important;
-  color: inherit !important;
+  color: inherit;
 }
 
 nav a:hover {
@@ -464,6 +472,10 @@ nav[class*="fixed"] {
 }
 .ProseMirror.flashcard-editor-tight p {
   margin: 0;
+}
+
+.ProseMirror.dg-editor-edge-to-edge > :first-child {
+  margin-top: 0;
 }
 
 .dark .ProseMirror {

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -1,0 +1,42 @@
+/**
+ * /guides — placeholder Guides hub.
+ *
+ * Task-oriented walkthroughs (vs. /docs reference material). Coming soon.
+ */
+
+import type { Metadata } from "next";
+import {
+  PlatformShell,
+  MarketingPageHeader,
+  PlaceholderGrid,
+} from "@/components/home/platform-chrome";
+
+export const metadata: Metadata = {
+  title: "Guides",
+  description:
+    "Step-by-step walkthroughs for getting the most out of NoteTrellis — from your first note to your first published garden.",
+};
+
+export default function Page() {
+  return (
+    <PlatformShell>
+      <MarketingPageHeader
+        eyebrow="Learn"
+        title="Guides"
+        lede="Hands-on walkthroughs that take you from zero to a thriving garden, one task at a time. These are in the works."
+      />
+      <section className="max-w-6xl mx-auto px-6 pb-24">
+        <PlaceholderGrid
+          items={[
+            { title: "Plant your first note", body: "Capture an idea, format it, and save — the five-minute tour of the editor." },
+            { title: "Build a web of links", body: "Use [[wiki-links]] and backlinks to turn loose notes into a connected network." },
+            { title: "Set up daily notes", body: "Make a frictionless home for daily thinking with periodic notes and summaries." },
+            { title: "Turn notes into flashcards", body: "Generate cards from a note and let spaced repetition do the remembering." },
+            { title: "Publish to your domain", body: "Connect a custom domain and ship a note as a polished public page." },
+            { title: "Bring your own AI keys", body: "Wire up your provider keys and start chatting over your own notes." },
+          ]}
+        />
+      </section>
+    </PlatformShell>
+  );
+}

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,0 +1,58 @@
+/**
+ * /help — placeholder Help Center.
+ *
+ * Topic categories + a fallback route to /contact. Coming soon.
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  PlatformShell,
+  MarketingPageHeader,
+  PlaceholderGrid,
+} from "@/components/home/platform-chrome";
+
+export const metadata: Metadata = {
+  title: "Help Center",
+  description:
+    "Answers to common NoteTrellis questions — accounts, the editor, publishing, and your data.",
+};
+
+export default function Page() {
+  return (
+    <PlatformShell>
+      <MarketingPageHeader
+        eyebrow="Support"
+        title="Help Center"
+        lede="Answers to the questions that come up most. We're still stocking the shelves — for now, reach out and we'll help directly."
+      />
+      <section className="max-w-6xl mx-auto px-6 pb-12">
+        <PlaceholderGrid
+          items={[
+            { title: "Account & billing", body: "Signing in, managing your account, and questions about plans." },
+            { title: "Editor & notes", body: "Writing, formatting, linking, and organizing your content." },
+            { title: "Publishing & domains", body: "Going public, connecting domains, and troubleshooting your site." },
+            { title: "Data & privacy", body: "Storage, export, bring-your-own-keys, and how your data is handled." },
+          ]}
+          columns={2}
+        />
+      </section>
+      <section className="max-w-6xl mx-auto px-6 pb-24">
+        <div className="rounded-xl border border-white/8 bg-white/[0.03] p-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <div>
+            <h2 className="text-base font-semibold mb-1">Still stuck?</h2>
+            <p className="text-sm text-white/50">
+              Can&apos;t find what you need? We&apos;re happy to help directly.
+            </p>
+          </div>
+          <Link
+            href="/contact"
+            className="flex-shrink-0 px-4 py-2.5 rounded-lg bg-emerald-500 text-black text-sm font-medium hover:bg-emerald-400 transition-colors"
+          >
+            Contact us
+          </Link>
+        </div>
+      </section>
+    </PlatformShell>
+  );
+}

--- a/app/notes-system/page.tsx
+++ b/app/notes-system/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * /notes-system — the NoteTrellis philosophy page.
+ *
+ * The "why" behind the product: a notes system is a way of tending ideas, not
+ * a pile of documents. Companion to /features (the "what" — the full catalog).
+ */
+
+import type { Metadata } from "next";
+import { NotesSystemPage } from "@/components/home/NotesSystemPage";
+
+export const metadata: Metadata = {
+  title: "The Notes System",
+  description:
+    "A note isn't a document — it's a living thing. The philosophy behind NoteTrellis: capture, connect, cultivate, and share the ideas you tend over time.",
+  openGraph: {
+    title: "The Notes System · NoteTrellis",
+    description:
+      "Most note apps are filing cabinets. NoteTrellis is a way of tending ideas — capture, connect, cultivate, share.",
+  },
+};
+
+export default function Page() {
+  return <NotesSystemPage />;
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,34 @@
+/**
+ * /privacy — placeholder Privacy Policy.
+ *
+ * Draft scaffold via the shared LegalDocument. Replace body copy with
+ * reviewed legal text before launch.
+ */
+
+import type { Metadata } from "next";
+import { PlatformShell, LegalDocument } from "@/components/home/platform-chrome";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: "How NoteTrellis collects, uses, and protects your information.",
+};
+
+export default function Page() {
+  return (
+    <PlatformShell>
+      <LegalDocument
+        title="Privacy Policy"
+        effectiveDate="—"
+        sections={[
+          { heading: "Overview", body: "NoteTrellis is built around the idea that your notes are yours. This page explains, in plain terms, what information we handle and why. This is placeholder copy pending legal review." },
+          { heading: "What we collect", body: "Account details you provide (such as your email), the content you create, and basic usage data needed to run and improve the service." },
+          { heading: "How we use your information", body: "To operate your account, sync and publish your content, provide support, and keep the service secure. We do not sell your personal information." },
+          { heading: "Your data is yours", body: "You can export your content at any time, and you may connect your own cloud storage and your own AI provider keys — keeping your files and AI usage under your control." },
+          { heading: "Cookies & local storage", body: "We use essential cookies and browser storage to keep you signed in and remember preferences like your theme. Details will be itemized here." },
+          { heading: "Changes to this policy", body: "We'll update this page as the service evolves and note the effective date above when we do." },
+          { heading: "Contact", body: "Questions about privacy? Reach us via the Contact page and we'll be glad to help." },
+        ]}
+      />
+    </PlatformShell>
+  );
+}

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,0 +1,65 @@
+/**
+ * /status — placeholder System Status board.
+ *
+ * Static "all operational" placeholder. A real status page would pull live
+ * health from monitoring; this gives the footer link an honest, intentional
+ * destination until that exists.
+ */
+
+import type { Metadata } from "next";
+import { PlatformShell, MarketingPageHeader } from "@/components/home/platform-chrome";
+
+export const metadata: Metadata = {
+  title: "System Status",
+  description: "Current operational status of NoteTrellis services.",
+};
+
+const SERVICES = [
+  { name: "App & Editor", note: "Workspace, editing, and sync" },
+  { name: "Publishing", note: "Public pages and custom domains" },
+  { name: "Real-time Collaboration", note: "Live co-editing and presence" },
+  { name: "AI Services", note: "Chat, generation, and transcription" },
+  { name: "Storage & Uploads", note: "File storage and downloads" },
+];
+
+export default function Page() {
+  return (
+    <PlatformShell>
+      <MarketingPageHeader
+        eyebrow="Support"
+        title="System Status"
+        lede="Live operational status for NoteTrellis services. This is a placeholder board; live health monitoring is on the way."
+      />
+      <section className="max-w-3xl mx-auto px-6 pb-24">
+        {/* Overall banner */}
+        <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/[0.07] px-5 py-4 flex items-center gap-3 mb-8">
+          <span className="w-2.5 h-2.5 rounded-full bg-emerald-400 flex-shrink-0" aria-hidden="true" />
+          <span className="text-sm font-medium text-emerald-300">
+            All systems operational
+          </span>
+        </div>
+
+        {/* Per-service rows */}
+        <ul className="rounded-xl border border-white/8 bg-white/[0.03] divide-y divide-white/5">
+          {SERVICES.map((svc) => (
+            <li key={svc.name} className="flex items-center justify-between gap-4 px-5 py-4">
+              <div>
+                <p className="text-sm font-medium">{svc.name}</p>
+                <p className="text-xs text-white/40">{svc.note}</p>
+              </div>
+              <span className="flex items-center gap-2 flex-shrink-0">
+                <span className="w-2 h-2 rounded-full bg-emerald-400" aria-hidden="true" />
+                <span className="text-xs text-white/50">Operational</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <p className="text-xs text-white/30 mt-6">
+          Status shown is illustrative. Subscribe to incident updates once live
+          monitoring is available.
+        </p>
+      </section>
+    </PlatformShell>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,35 @@
+/**
+ * /terms — placeholder Terms of Service.
+ *
+ * Draft scaffold via the shared LegalDocument. Replace body copy with
+ * reviewed legal text before launch.
+ */
+
+import type { Metadata } from "next";
+import { PlatformShell, LegalDocument } from "@/components/home/platform-chrome";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description: "The terms that govern your use of NoteTrellis.",
+};
+
+export default function Page() {
+  return (
+    <PlatformShell>
+      <LegalDocument
+        title="Terms of Service"
+        effectiveDate="—"
+        sections={[
+          { heading: "Overview", body: "These terms govern your use of NoteTrellis. By using the service you agree to them. This is placeholder copy pending legal review." },
+          { heading: "Using NoteTrellis", body: "You're responsible for your account and for keeping your credentials secure. You must be able to form a binding contract to use the service." },
+          { heading: "Your content", body: "You own the content you create. You grant us the limited permissions needed to store, sync, and — where you choose to publish — display it." },
+          { heading: "Acceptable use", body: "Don't use NoteTrellis to break the law, infringe others' rights, or disrupt the service for other people. Specific prohibited uses will be listed here." },
+          { heading: "Publishing", body: "When you publish a page or connect a domain, you're responsible for the content you make public and for your rights to any material it contains." },
+          { heading: "Availability & changes", body: "We work to keep the service reliable but provide it on an \"as is\" basis. We may update features and these terms; material changes will be noted above." },
+          { heading: "Termination", body: "You may stop using the service and export your data at any time. We may suspend accounts that violate these terms." },
+          { heading: "Contact", body: "Questions about these terms? Reach us via the Contact page." },
+        ]}
+      />
+    </PlatformShell>
+  );
+}

--- a/components/content/OutlinePanel.tsx
+++ b/components/content/OutlinePanel.tsx
@@ -128,16 +128,27 @@ export function OutlinePanel({
                 style={{ paddingLeft: `${12 + indentation}px` }}
                 title={`Jump to: ${heading.text}`}
               >
-                {/* Heading level indicator (visual only) */}
-                <span
-                  className={`shrink-0 inline-block rounded-full ${
-                    isActive ? "bg-gold-primary" : "bg-gray-400"
-                  }`}
-                  style={{
-                    width: heading.level === 1 ? "6px" : heading.level === 2 ? "4px" : "3px",
-                    height: heading.level === 1 ? "6px" : heading.level === 2 ? "4px" : "3px",
-                  }}
-                />
+                {/* Heading level / type indicator */}
+                {heading.kind === "accordion" ? (
+                  <span
+                    className={`shrink-0 text-[8px] leading-none ${
+                      isActive ? "text-gold-primary" : "text-gray-400"
+                    }`}
+                    aria-label="accordion"
+                  >
+                    ▶
+                  </span>
+                ) : (
+                  <span
+                    className={`shrink-0 inline-block rounded-full ${
+                      isActive ? "bg-gold-primary" : "bg-gray-400"
+                    }`}
+                    style={{
+                      width: heading.level === 1 ? "6px" : heading.level === 2 ? "4px" : "3px",
+                      height: heading.level === 1 ? "6px" : heading.level === 2 ? "4px" : "3px",
+                    }}
+                  />
+                )}
 
                 {/* Heading text - truncate if too long */}
                 <span className="truncate">{heading.text}</span>

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -210,6 +210,10 @@ interface ChatMessageProps {
   onBranch?: (messageId: string) => void;
   /** Disable edit/regenerate/branch (e.g. while a turn is streaming). */
   actionsDisabled?: boolean;
+  /** Revert a specific edit by tool call ID — called when the user clicks "Undo" on an edit chip. */
+  onRevertEdit?: (toolCallId: string) => void;
+  /** Set of tool call IDs for which a pre-edit snapshot is available (drives undo button visibility). */
+  revertableToolIds?: ReadonlySet<string>;
 }
 
 export const ChatMessage = memo(function ChatMessage({
@@ -221,6 +225,8 @@ export const ChatMessage = memo(function ChatMessage({
   onRegenerate,
   onBranch,
   actionsDisabled = false,
+  onRevertEdit,
+  revertableToolIds,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
   const isAssistant = message.role === "assistant";
@@ -628,9 +634,12 @@ export const ChatMessage = memo(function ChatMessage({
               <ToolCallBubble
                 key={i}
                 toolName={toolPart.toolName}
+                toolCallId={toolPart.toolCallId}
                 state={toolPart.state}
                 args={toolPart.input}
                 result={toolPart.output}
+                isRevertable={revertableToolIds?.has(toolPart.toolCallId) ?? false}
+                onRevertEdit={onRevertEdit}
               />
             );
           }
@@ -1412,19 +1421,26 @@ function parseDeckWithCardsProposal(result: unknown): DeckWithCardsProposalPaylo
  */
 function ToolCallBubble({
   toolName,
+  toolCallId,
   state,
   args: _args,
   result,
+  isRevertable = false,
+  onRevertEdit,
 }: {
   toolName: string;
+  toolCallId?: string;
   state: string;
   args: unknown;
   result?: unknown;
+  isRevertable?: boolean;
+  onRevertEdit?: (toolCallId: string) => void;
 }) {
   const isRunning = state === "input-streaming" || state === "input-available";
   const hasResult = state === "output-available";
   const [expanded, setExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [reverted, setReverted] = useState(false);
 
   // Canonical string form of the result for display + clipboard.
   const resultString = useMemo(() => {
@@ -1474,6 +1490,22 @@ function ToolCallBubble({
     () => toolActionLabel(toolName, isRunning),
     [toolName, isRunning],
   );
+
+  // True when this tool result is an edit payload (apply_diff, replace_document, insert_image).
+  const isEditPayload = useMemo(
+    () =>
+      hasResult &&
+      typeof result === "string" &&
+      result.startsWith("{") &&
+      result.includes('"__editPayload"'),
+    [hasResult, result],
+  );
+
+  const handleRevert = useCallback(() => {
+    if (!toolCallId) return;
+    onRevertEdit?.(toolCallId);
+    setReverted(true);
+  }, [toolCallId, onRevertEdit]);
 
   const handleCopy = useCallback(async () => {
     if (!resultString) return;
@@ -1549,6 +1581,32 @@ function ToolCallBubble({
           <pre className="max-h-60 overflow-auto px-3 pb-2 text-[11px] font-mono leading-relaxed text-gray-600 dark:text-gray-300 whitespace-pre-wrap break-words">
             {resultString}
           </pre>
+        </div>
+      )}
+      {isEditPayload && (
+        <div className="border-t border-black/[0.06] dark:border-white/[0.06] flex items-center gap-2 px-3 py-1.5">
+          {!reverted ? (
+            <button
+              type="button"
+              onClick={handleRevert}
+              disabled={!isRevertable}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-[11px] transition-colors",
+                isRevertable
+                  ? "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-black/[0.04] dark:hover:bg-white/[0.06] cursor-pointer"
+                  : "text-gray-400 dark:text-gray-600 cursor-default",
+              )}
+              title={isRevertable ? "Restore document to its state before this edit" : "Applying edit…"}
+            >
+              <RotateCcw className="h-3 w-3 shrink-0" />
+              Undo
+            </button>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 text-[11px] text-emerald-600 dark:text-emerald-400">
+              <Check className="h-3 w-3 shrink-0" />
+              Reverted
+            </span>
+          )}
         </div>
       )}
     </div>

--- a/components/content/ai/ChatPanel.tsx
+++ b/components/content/ai/ChatPanel.tsx
@@ -36,6 +36,7 @@ import { useContentStore } from "@/state/content-store";
 import { detectMixedProvider } from "@/lib/design/system/ai-providers";
 import type { AIProviderId } from "@/lib/domain/ai/types";
 import type { UIMessage } from "ai";
+import type { JSONContent } from "@tiptap/core";
 
 interface ChatPanelProps {
   contentId?: string | null;
@@ -303,6 +304,24 @@ export function ChatPanel({
     contentIdRef.current = contentId;
   }, [contentId]);
 
+  // Revert snapshots — keyed by toolCallId, holds the document state before each edit.
+  // Ref for the map (stable read in the revert callback) + state for the Set of IDs
+  // (drives ChatMessage re-renders so the undo button appears as edits complete).
+  const revertSnapshotsRef = useRef<Map<string, { snapshot: JSONContent; action: string }>>(new Map());
+  const [revertableToolIds, setRevertableToolIds] = useState<ReadonlySet<string>>(new Set());
+
+  const revertEdit = useCallback((toolCallId: string) => {
+    const entry = revertSnapshotsRef.current.get(toolCallId);
+    if (!entry) return;
+    const editor = useEditorInstanceStore.getState().getEditor(contentIdRef.current);
+    if (!editor) {
+      toast.error("Editor not available — open the document and try again.");
+      return;
+    }
+    editor.commands.setContent(entry.snapshot);
+    toast.success("Reverted to before this edit");
+  }, []);
+
   // Create orchestrator on mount, destroy on unmount
   useEffect(() => {
     const orchestrator = new AiEditOrchestrator(
@@ -318,6 +337,13 @@ export function ChatPanel({
         onEditResult: (result) => {
           if (!result.success && result.error) {
             toast.error(result.error);
+          }
+          if (result.success && result.snapshot && result.toolCallId) {
+            revertSnapshotsRef.current.set(result.toolCallId, {
+              snapshot: result.snapshot,
+              action: result.action,
+            });
+            setRevertableToolIds(new Set(revertSnapshotsRef.current.keys()));
           }
         },
       }
@@ -361,7 +387,7 @@ export function ChatPanel({
             const payload = parseEditPayload(outputStr);
             if (payload) {
               processedToolIdsRef.current.add(toolPart.toolCallId);
-              orchestratorRef.current.enqueue(payload);
+              orchestratorRef.current.enqueue({ ...payload, toolCallId: toolPart.toolCallId });
             }
           }
         }
@@ -560,6 +586,8 @@ export function ChatPanel({
                   onRegenerate={(id) => void regenerateMessage(id)}
                   onBranch={(id) => void handleBranch(id)}
                   actionsDisabled={isActive}
+                  onRevertEdit={revertEdit}
+                  revertableToolIds={revertableToolIds}
                 />
               );
             })}

--- a/components/content/ai/FlashcardCardProposalList.tsx
+++ b/components/content/ai/FlashcardCardProposalList.tsx
@@ -778,7 +778,7 @@ export function FlashcardCardProposalList({
             the deck-status hint all update in sync with what the
             user types. "/" creates a sub-deck.
           */}
-          <div className="flex items-center gap-1.5 text-[11px] text-gray-500 dark:text-gray-400">
+          <div className="flex items-center gap-1.5 text-[11px] text-gray-500 dark:text-gray-300">
             <span className="shrink-0">Target deck:</span>
             <DeckPathField
               value={pathDraft}
@@ -790,7 +790,7 @@ export function FlashcardCardProposalList({
               resetValueOnBlankBlur={payload.deck.proposedPath}
             />
           </div>
-          <div className="text-[11px] text-gray-400 dark:text-gray-500">
+          <div className="text-[11px] text-gray-500 dark:text-gray-400">
             <span className="font-mono">{effectivePath || "(empty path)"}</span>
             {" — "}
             <span>{deckStatusLine}</span>
@@ -808,7 +808,7 @@ export function FlashcardCardProposalList({
             )}
           </div>
           {payload.sourceContentId && (
-            <div className="text-[11px] text-gray-500 dark:text-gray-400">
+            <div className="text-[11px] text-gray-500 dark:text-gray-300">
               Source: linked to the open note
             </div>
           )}
@@ -836,12 +836,12 @@ export function FlashcardCardProposalList({
             </div>
           </div>
           {payload.deck.rationale && (
-            <p className="text-gray-600 dark:text-gray-400">
+            <p className="text-gray-600 dark:text-gray-300">
               {payload.deck.rationale}
             </p>
           )}
           {payload.deck.similarExistingPaths.length > 0 && (
-            <div className="text-[11px] text-gray-500 dark:text-gray-400">
+            <div className="text-[11px] text-gray-500 dark:text-gray-300">
               <div className="mb-1">
                 Similar existing decks (tell the AI to use one instead):
               </div>
@@ -1062,14 +1062,14 @@ export function FlashcardCardProposalList({
                   aria-controls={`card-editor-${i}`}
                   title={row.expanded ? "Collapse" : `${frontPreview} → ${backPreview}`}
                 >
-                  <span className="mr-1 font-medium text-gray-500 dark:text-gray-400">
+                  <span className="mr-1 font-medium text-gray-500 dark:text-gray-300">
                     {i + 1}.
                   </span>
                   {frontPreview}
-                  <span className="mx-1 text-gray-400 dark:text-gray-500">
+                  <span className="mx-1 text-gray-400 dark:text-gray-400">
                     →
                   </span>
-                  <span className="text-gray-600 dark:text-gray-400">
+                  <span className="text-gray-600 dark:text-gray-300">
                     {backPreview}
                   </span>
                 </button>

--- a/components/content/ai/FlashcardDeckProposalCard.tsx
+++ b/components/content/ai/FlashcardDeckProposalCard.tsx
@@ -204,7 +204,7 @@ export function FlashcardDeckProposalCard({
               resetValueOnBlankBlur={payload.proposedPath}
             />
           </div>
-          <div className="text-[11px] text-gray-400 dark:text-gray-500">
+          <div className="text-[11px] text-gray-500 dark:text-gray-400">
             <span className="font-mono">{effectivePath || "(empty path)"}</span>
             {" · Parent: "}
             <span>{parentLabel}</span>
@@ -229,7 +229,7 @@ export function FlashcardDeckProposalCard({
       </p>
 
       {payload.similarExistingPaths.length > 0 && (
-        <div className="text-[11px] text-gray-500 dark:text-gray-400">
+        <div className="text-[11px] text-gray-500 dark:text-gray-300">
           <div className="mb-1">
             Similar existing decks (tell the AI to use one instead):
           </div>

--- a/components/content/blocks/JsonArrayEditor.tsx
+++ b/components/content/blocks/JsonArrayEditor.tsx
@@ -27,6 +27,8 @@ export interface JsonArrayItemField {
   min?: number;
   max?: number;
   tooltip?: string;
+  /** Only render this field when another field in the same item equals a given value. */
+  showWhen?: { key: string; value: string };
 }
 
 // ─── Compact inline image field ───────────────────────────────────────────────
@@ -301,7 +303,9 @@ function ItemRow({
           gridTemplateColumns: `repeat(${gridCols}, minmax(0, 1fr))`,
         }}
       >
-        {schema.map((field) => (
+        {schema.filter((field) =>
+          !field.showWhen || String(item[field.showWhen.key] ?? "") === field.showWhen.value
+        ).map((field) => (
           <div
             key={field.key}
             style={field.type === "textarea" || field.type === "image" || field.type === "icon" ? { gridColumn: "1 / -1" } : undefined}

--- a/components/content/content/MainPanelContent.tsx
+++ b/components/content/content/MainPanelContent.tsx
@@ -2022,58 +2022,60 @@ export function MainPanelContent({ paneId, initialContent = null }: MainPanelCon
     const editorElement = (
       <div className="flex flex-col h-full">
         {/* Note title header with debug toggle */}
-        <div className="flex-none px-6 pt-6 pb-4 flex items-start justify-between shadow-[0_4px_8px_-2px_rgba(15,23,42,0.08),0_10px_24px_-6px_rgba(15,23,42,0.05)]">
-          {isTitleEditing ? (
-            <input
-              ref={titleInputRef}
-              type="text"
-              value={titleDraft}
-              onChange={(e) => setTitleDraft(e.target.value)}
-              onBlur={handleTitleCommit}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") { e.preventDefault(); handleTitleCommit(); }
-                if (e.key === "Escape") { e.preventDefault(); setIsTitleEditing(false); }
-              }}
-              className="flex-1 text-3xl font-semibold text-foreground bg-transparent border-b border-primary/40 focus:border-primary focus:outline-none mb-0 mr-4"
-            />
-          ) : (
-            <div className="mr-4 flex min-w-0 flex-1 items-start gap-3">
-              <h1
-                className={`min-w-0 text-3xl font-semibold text-foreground mb-0 transition-opacity ${
-                  isReadOnlyPageTemplate
-                    ? "cursor-default"
-                    : "cursor-text hover:opacity-80"
-                }`}
-                title={
-                  contentType === "page-template"
-                    ? isReadOnlyPageTemplate
-                      ? "System template (read-only)"
-                      : "Click to rename template"
-                    : "Click to rename"
-                }
-                onClick={isReadOnlyPageTemplate ? undefined : handleTitleEditStart}
-              >
-                {noteTitle}
-              </h1>
-              {contentType === "page-template" && templateWarningText ? (
-                <TooltipProvider delayDuration={150}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-300/80 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800">
-                        <AlertTriangle className="h-3.5 w-3.5" />
-                        Template
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="max-w-xs text-xs">
-                      {templateWarningText}
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              ) : null}
-            </div>
-          )}
-          {process.env.NODE_ENV === "development" && !isMultiPane && <DebugViewToggle />}
-        </div>
+        {!isEmbedMode && (
+          <div className="flex-none px-6 pt-6 pb-4 flex items-start justify-between shadow-[0_4px_8px_-2px_rgba(15,23,42,0.08),0_10px_24px_-6px_rgba(15,23,42,0.05)]">
+            {isTitleEditing ? (
+              <input
+                ref={titleInputRef}
+                type="text"
+                value={titleDraft}
+                onChange={(e) => setTitleDraft(e.target.value)}
+                onBlur={handleTitleCommit}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") { e.preventDefault(); handleTitleCommit(); }
+                  if (e.key === "Escape") { e.preventDefault(); setIsTitleEditing(false); }
+                }}
+                className="flex-1 text-3xl font-semibold text-foreground bg-transparent border-b border-primary/40 focus:border-primary focus:outline-none mb-0 mr-4"
+              />
+            ) : (
+              <div className="mr-4 flex min-w-0 flex-1 items-start gap-3">
+                <h1
+                  className={`min-w-0 text-3xl font-semibold text-foreground mb-0 transition-opacity ${
+                    isReadOnlyPageTemplate
+                      ? "cursor-default"
+                      : "cursor-text hover:opacity-80"
+                  }`}
+                  title={
+                    contentType === "page-template"
+                      ? isReadOnlyPageTemplate
+                        ? "System template (read-only)"
+                        : "Click to rename template"
+                      : "Click to rename"
+                  }
+                  onClick={isReadOnlyPageTemplate ? undefined : handleTitleEditStart}
+                >
+                  {noteTitle}
+                </h1>
+                {contentType === "page-template" && templateWarningText ? (
+                  <TooltipProvider delayDuration={150}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-300/80 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800">
+                          <AlertTriangle className="h-3.5 w-3.5" />
+                          Template
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" className="max-w-xs text-xs">
+                        {templateWarningText}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                ) : null}
+              </div>
+            )}
+            {process.env.NODE_ENV === "development" && !isMultiPane && <DebugViewToggle />}
+          </div>
+        )}
 
         {contentType === "page-template" && templateWarningText ? (
           <div className="mx-6 mb-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
@@ -2114,6 +2116,8 @@ export function MainPanelContent({ paneId, initialContent = null }: MainPanelCon
             collaborationEnabled={contentType === "note" ? collaborationEnabled : false}
             collaborationRuntime={collaborationRuntime}
             onCollaborationSyncChange={handleCollaborationSyncChange}
+            compact={isEmbedMode}
+            edgeToEdge={isEmbedMode}
           />
         </div>
       </div>

--- a/components/content/context-menu/editor-actions.tsx
+++ b/components/content/context-menu/editor-actions.tsx
@@ -563,6 +563,46 @@ function buildSnippetSaveMenu(
   return items;
 }
 
+/**
+ * Trigger a browser download from a Blob.
+ */
+function triggerBlobDownload(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Download an image — either from the server (via contentId) or directly from its URL.
+ */
+async function downloadImage(src: string, contentId: string | null) {
+  try {
+    if (contentId) {
+      const res = await fetch(`/api/content/content/${contentId}/download?download=true`);
+      if (!res.ok) throw new Error("Download failed");
+      const blob = await res.blob();
+      const disposition = res.headers.get("content-disposition") ?? "";
+      const fileNameMatch = disposition.match(/filename="([^"]+)"/);
+      const fileName = fileNameMatch?.[1] ?? `image-${contentId}`;
+      triggerBlobDownload(blob, fileName);
+    } else {
+      const res = await fetch(src);
+      if (!res.ok) throw new Error("Download failed");
+      const blob = await res.blob();
+      const fileName = src.split("/").pop()?.split("?")[0] ?? "image";
+      triggerBlobDownload(blob, fileName);
+    }
+    toast.success("Image downloaded");
+  } catch {
+    toast.error("Failed to download image");
+  }
+}
+
 /** Resolve a wiki-link title to a content ID, then open in the given pane. */
 async function resolveWikiLinkAndOpen(targetTitle: string, paneId: WorkspacePaneId) {
   const { layoutMode, openContentInPane, setLayoutMode } = useContentStore.getState();
@@ -644,6 +684,24 @@ export const editorActionProvider: ContextMenuActionProvider = (ctx) => {
         ],
       });
     }
+  }
+
+  // --- Image actions (Download) ---
+  const imageWrapper = contextTarget?.closest?.(".image-resize-wrapper");
+  const imgEl = imageWrapper?.querySelector?.("img") ?? null;
+  const imageSrc = imgEl?.getAttribute("src") ?? null;
+  const imageContentId = imgEl?.getAttribute("data-content-id") ?? null;
+
+  if (imageSrc) {
+    sections.push({
+      actions: [
+        {
+          id: "download-image",
+          label: "Download Image",
+          onClick: () => { void downloadImage(imageSrc, imageContentId); },
+        },
+      ],
+    });
   }
 
   // Capture selection NOW, before any menu interaction

--- a/components/content/editor/MarkdownEditor.tsx
+++ b/components/content/editor/MarkdownEditor.tsx
@@ -187,6 +187,8 @@ export interface MarkdownEditorProps {
   }) => void;
   /** Compact mode for secondary/embedded editors (less padding, smaller prose) */
   compact?: boolean;
+  /** Edge-to-edge mode for the browser-extension iframe note surface */
+  edgeToEdge?: boolean;
   /** Placeholder text when editor is empty */
   placeholder?: string;
   /** Custom class name */
@@ -215,6 +217,7 @@ export function MarkdownEditor({
   collaborationRuntime = null,
   onCollaborationSyncChange,
   compact = false,
+  edgeToEdge = false,
   className = "",
 }: MarkdownEditorProps) {
   const openMenu = useContextMenuStore((s) => s.openMenu);
@@ -436,7 +439,9 @@ export function MarkdownEditor({
     editorProps: {
       attributes: {
         class: [
-          compact
+          edgeToEdge
+            ? "prose prose-sm max-w-none focus:outline-none min-h-[120px] px-2 pt-1 pb-1 dg-editor-edge-to-edge"
+            : compact
             ? "prose prose-sm max-w-none focus:outline-none min-h-[120px] px-4 pt-2 pb-2"
             : "prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none focus:outline-none min-h-[500px] px-6 pt-3 pb-4",
           effectiveEditable ? "block-editing-active" : "",

--- a/components/content/external/ExternalLinkDialog.tsx
+++ b/components/content/external/ExternalLinkDialog.tsx
@@ -34,6 +34,7 @@ export function ExternalLinkDialog({
   const [name, setName] = useState(initialName);
   const [url, setUrl] = useState(initialUrl);
   const [urlCopied, setUrlCopied] = useState(false);
+  const [urlError, setUrlError] = useState<string | null>(null);
 
   // Reset state when dialog opens/closes
   useEffect(() => {
@@ -44,6 +45,27 @@ export function ExternalLinkDialog({
       setUrlCopied(false);
     }
   }, [open, initialName, initialUrl]);
+
+  const validateUrl = (raw: string): string | null => {
+    const trimmed = raw.trim();
+    if (!trimmed || trimmed === "https://") return null;
+    let finalUrl = trimmed;
+    if (!finalUrl.match(/^https?:\/\//i)) finalUrl = `https://${finalUrl}`;
+    try {
+      const parsed = new URL(finalUrl);
+      if (parsed.protocol !== "https:") {
+        return "URL must use HTTPS. HTTP is disabled for security.";
+      }
+    } catch {
+      return "Invalid URL format.";
+    }
+    return null;
+  };
+
+  const handleUrlChange = (value: string) => {
+    setUrl(value);
+    if (urlError) setUrlError(validateUrl(value));
+  };
 
   const handleSubmit = () => {
     if (!name.trim()) {
@@ -60,6 +82,12 @@ export function ExternalLinkDialog({
     let finalUrl = url.trim();
     if (!finalUrl.match(/^https?:\/\//i)) {
       finalUrl = `https://${finalUrl}`;
+    }
+
+    const clientError = validateUrl(url.trim());
+    if (clientError) {
+      setUrlError(clientError);
+      return;
     }
 
     onConfirm({ name: name.trim(), url: finalUrl });
@@ -151,11 +179,13 @@ export function ExternalLinkDialog({
               <label className="block text-sm font-medium text-gray-900 mb-2">
                 URL
               </label>
+              <div className="space-y-1">
               <div className="flex gap-2">
                 <input
                   type="text"
                   value={url}
-                  onChange={(e) => setUrl(e.target.value)}
+                  onChange={(e) => handleUrlChange(e.target.value)}
+                  onBlur={() => setUrlError(validateUrl(url))}
                   onKeyDown={(e) => {
                     if (e.key === "Enter" && !e.shiftKey) {
                       e.preventDefault();
@@ -163,7 +193,7 @@ export function ExternalLinkDialog({
                     }
                   }}
                   placeholder="https://example.com"
-                  className="flex-1 px-3 py-2 bg-white/80 border border-gray-900/20 rounded-lg text-sm text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  className={`flex-1 px-3 py-2 bg-white/80 border rounded-lg text-sm text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary/50 ${urlError ? "border-red-400" : "border-gray-900/20"}`}
                 />
                 <button
                   onClick={handleCopyUrl}
@@ -176,6 +206,10 @@ export function ExternalLinkDialog({
                     <Copy className="h-4 w-4 text-gray-700" />
                   )}
                 </button>
+              </div>
+              {urlError && (
+                <p className="text-xs text-red-500">{urlError}</p>
+              )}
               </div>
             </div>
           </div>

--- a/components/content/external/ExternalLinkViewer.tsx
+++ b/components/content/external/ExternalLinkViewer.tsx
@@ -216,22 +216,22 @@ export function ExternalLinkViewer({
           )}
           <div className="p-4 space-y-2">
             {previewData?.title && (
-              <h3 className="text-lg font-semibold text-gray-900">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                 {previewData.title}
               </h3>
             )}
             {previewData?.description && (
-              <p className="text-sm text-gray-700 line-clamp-3">
+              <p className="text-sm text-gray-700 dark:text-gray-300 line-clamp-3">
                 {previewData.description}
               </p>
             )}
             {previewData?.siteName && (
-              <p className="text-xs text-gray-600">{previewData.siteName}</p>
+              <p className="text-xs text-gray-600 dark:text-gray-400">{previewData.siteName}</p>
             )}
 
             {/* Show info about missing fields if any */}
             {missingFields && (missingFields.title || missingFields.description) && (
-              <p className="text-xs text-gray-500 italic pt-2 border-t border-gray-900/10">
+              <p className="text-xs text-gray-500 dark:text-gray-400 italic pt-2 border-t border-gray-900/10 dark:border-white/10">
                 This site provides limited preview metadata
                 {missingFields.title && missingFields.description && " (no title or description)"}
                 {missingFields.title && !missingFields.description && " (no title)"}
@@ -270,10 +270,10 @@ export function ExternalLinkViewer({
             <ExternalLink className="h-5 w-5 text-gray-600 mt-0.5 flex-shrink-0" />
           )}
           <div className="flex-1 min-w-0">
-            <div className="text-sm font-medium text-gray-900 mb-1">
+            <div className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">
               External Link
             </div>
-            <div className="text-xs text-gray-700 break-all">{url}</div>
+            <div className="text-xs text-gray-700 dark:text-gray-300 break-all">{url}</div>
             <div className="mt-3 flex flex-wrap gap-2">
               {readingStatus && (
                 <span className="inline-block px-2 py-0.5 bg-amber-500/15 text-amber-600 text-xs rounded-full">
@@ -311,7 +311,7 @@ export function ExternalLinkViewer({
                 </span>
               )}
             </div>
-            <div className="mt-3 space-y-1 text-xs text-gray-600">
+            <div className="mt-3 space-y-1 text-xs text-gray-600 dark:text-gray-400">
               {sourceDomain && <div>Domain: {sourceDomain}</div>}
               {!sourceDomain && sourceHostname && <div>Host: {sourceHostname}</div>}
               {savedAt && (
@@ -334,13 +334,13 @@ export function ExternalLinkViewer({
               )}
             </div>
             {description && (
-              <p className="mt-3 text-sm text-gray-700 whitespace-pre-wrap">
+              <p className="mt-3 text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
                 {description}
               </p>
             )}
             {previewData?.description &&
               previewData.description !== description && (
-              <p className="mt-3 text-xs text-gray-700 line-clamp-3">
+              <p className="mt-3 text-xs text-gray-700 dark:text-gray-300 line-clamp-3">
                 {previewData.description}
               </p>
               )}
@@ -360,7 +360,7 @@ export function ExternalLinkViewer({
         <button
           onClick={() => handleRefreshPreview()}
           disabled={isRefreshing}
-          className="flex items-center gap-2 px-4 py-2 bg-gray-900/10 hover:bg-gray-900/20 border border-gray-900/20 rounded-lg text-sm font-medium text-gray-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center gap-2 px-4 py-2 bg-gray-900/10 hover:bg-gray-900/20 dark:bg-white/10 dark:hover:bg-white/15 border border-gray-900/20 dark:border-white/15 rounded-lg text-sm font-medium text-gray-900 dark:text-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <RefreshCw
             className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}

--- a/components/content/people/PeopleCreateDialog.tsx
+++ b/components/content/people/PeopleCreateDialog.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import { toast } from "sonner";
 import { clientLogger } from "@/lib/core/logger/client";
+
+interface PeopleGroup {
+  id: string;
+  name: string;
+  parentGroupId: string | null;
+  isDefault: boolean;
+}
 
 export interface CreatedPersonData {
   personId: string;
@@ -44,6 +51,8 @@ export function PeopleCreateDialog({
   onCreatedWithData,
 }: PeopleCreateDialogProps) {
   const [name, setName] = useState(initialName);
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(primaryGroupId ?? null);
+  const [groups, setGroups] = useState<PeopleGroup[]>([]);
   const [givenName, setGivenName] = useState("");
   const [familyName, setFamilyName] = useState("");
   const [email, setEmail] = useState("");
@@ -64,6 +73,24 @@ export function PeopleCreateDialog({
 
   const isPerson = mode === "person";
 
+  useEffect(() => {
+    if (!isPerson) return;
+    fetch("/api/people/groups", { credentials: "include" })
+      .then((r) => r.json())
+      .then((result: { success: boolean; data?: { groups: PeopleGroup[] } }) => {
+        if (result.success && result.data) {
+          setGroups(result.data.groups);
+          // Default to the first non-default group if no primaryGroupId was passed
+          if (!selectedGroupId) {
+            const first = result.data.groups.find((g) => !g.isDefault) ?? result.data.groups[0];
+            if (first) setSelectedGroupId(first.id);
+          }
+        }
+      })
+      .catch(() => { /* groups dropdown is optional — silent */ });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPerson]);
+
   const submit = async (event: React.FormEvent) => {
     event.preventDefault();
     const trimmedName = name.trim();
@@ -82,7 +109,7 @@ export function PeopleCreateDialog({
           isPerson
             ? {
                 displayName: trimmedName,
-                primaryGroupId,
+                primaryGroupId: selectedGroupId,
                 givenName: givenName.trim() || null,
                 familyName: familyName.trim() || null,
                 email: email.trim() || null,
@@ -176,6 +203,25 @@ export function PeopleCreateDialog({
 
           {isPerson ? (
             <>
+              {groups.length > 0 && (
+                <label className="block">
+                  <span className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">
+                    Group
+                  </span>
+                  <select
+                    value={selectedGroupId ?? ""}
+                    onChange={(e) => setSelectedGroupId(e.target.value || null)}
+                    className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition-colors focus:border-gold-primary/60 dark:border-white/10 dark:bg-white/5 dark:text-gray-100"
+                  >
+                    <option value="">No group</option>
+                    {groups.map((g) => (
+                      <option key={g.id} value={g.id}>
+                        {g.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
               <div className="grid grid-cols-2 gap-3">
                 <TextField label="Given name" value={givenName} onChange={setGivenName} placeholder="Optional" />
                 <TextField label="Family name" value={familyName} onChange={setFamilyName} placeholder="Optional" />

--- a/components/content/toolbar/ContentToolbar.tsx
+++ b/components/content/toolbar/ContentToolbar.tsx
@@ -25,6 +25,8 @@ import { PUBLISHING_EXTENSION_ID } from "@/extensions/publishing/manifest";
 import { PublishStatusPill } from "@/extensions/publishing/components/toolbar/PublishStatusPill";
 import { ReadAloudButton } from "@/components/content/tts/ReadAloudButton";
 import { SPEED_READER_EXTENSION_ID } from "@/extensions/speed-reader/manifest";
+import { SendToTabButton } from "@/extensions/browser-bookmarks/components/SendToTabButton";
+import { BROWSER_BOOKMARKS_EXTENSION_ID } from "@/extensions/browser-bookmarks/manifest";
 import {
   SPEED_READER_OPEN_EVENT,
   type SpeedReaderOpenEventDetail,
@@ -144,6 +146,8 @@ export function ContentToolbar({ contentId: contentIdProp }: ContentToolbarProps
 
   const showPublishPill = publishingEnabled && sourceContentId;
   const showSpeedRead = speedReaderEnabled && !!sourceContentId;
+  const browserBookmarksEnabled = useIsExtensionEnabled(BROWSER_BOOKMARKS_EXTENSION_ID);
+  const showSendToTab = browserBookmarksEnabled && !!sourceContentId;
 
   const openSpeedReader = useCallback(() => {
     if (!sourceContentId) return;
@@ -159,7 +163,8 @@ export function ContentToolbar({ contentId: contentIdProp }: ContentToolbarProps
     visibleSourceFlashcardCount === 0 &&
     !showPublishPill &&
     !canReadAloud &&
-    !showSpeedRead
+    !showSpeedRead &&
+    !showSendToTab
   ) {
     return null;
   }
@@ -211,6 +216,9 @@ export function ContentToolbar({ contentId: contentIdProp }: ContentToolbarProps
         >
           <Zap className="h-4 w-4" />
         </button>
+      )}
+      {showSendToTab && (
+        <SendToTabButton contentId={sourceContentId} contentKind="note" />
       )}
       {/* Tools with order >= 70: import, export */}
       {tools.filter((t) => t.definition.order >= 70).map((tool) => {

--- a/components/content/viewer/ExternalViewer.tsx
+++ b/components/content/viewer/ExternalViewer.tsx
@@ -66,8 +66,20 @@ export function ExternalViewer({
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="border-b border-white/10 px-6 py-4">
-        <h1 className="text-2xl font-semibold text-white">{title}</h1>
+      <div className="flex items-center justify-between border-b border-border px-6 py-4">
+        <h1 className="text-2xl font-semibold text-foreground">{title}</h1>
+        <button
+          type="button"
+          onClick={() =>
+            window.dispatchEvent(
+              new CustomEvent("edit-external-link", { detail: { id: contentId } })
+            )
+          }
+          className="flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          title="Edit URL or name"
+        >
+          Edit
+        </button>
       </div>
 
       {/* Content */}

--- a/components/home/FeaturesPage.tsx
+++ b/components/home/FeaturesPage.tsx
@@ -1,0 +1,411 @@
+/**
+ * FeaturesPage — the full feature catalog at /features.
+ *
+ * The "what" of NoteTrellis: every feature category, each tagged with the
+ * lifecycle stage (Capture · Connect · Cultivate · Share) it serves. Its
+ * companion, NotesSystemPage (/notes-system), is the "why" — the philosophy
+ * and the lifecycle loop those stages come from.
+ *
+ * Pure server component (no `"use client"`) with inline SVG on the shared
+ * PlatformShell — the marketing surface ships zero JS.
+ */
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { PlatformShell, MarketingPageHeader } from "@/components/home/platform-chrome";
+
+// ----------------------------------------------------------------------------
+// Feature catalog — every category, every feature.
+// ----------------------------------------------------------------------------
+
+interface Feature {
+  name: string;
+  desc: string;
+}
+
+interface Category {
+  id: string;
+  stage: string;
+  title: string;
+  lede: string;
+  icon: ReactNode;
+  features: Feature[];
+}
+
+const CATEGORIES: Category[] = [
+  {
+    id: "capture",
+    stage: "Capture",
+    title: "Get ideas in, frictionlessly",
+    lede: "The fastest path from a fleeting thought to a durable note. If capture has friction, the idea is already gone.",
+    icon: <IconPencil />,
+    features: [
+      { name: "IDE-style editor", desc: "A rich TipTap editor with a panel-based workspace — built for writing, not just typing." },
+      { name: "Slash commands", desc: "Type / to drop in headings, callouts, blocks, diagrams, and more without leaving the keyboard." },
+      { name: "Daily & periodic notes", desc: "One keystroke opens today's note — a frictionless home for whatever's on your mind." },
+      { name: "Browser bookmarks extension", desc: "Clip pages, highlights, and links from anywhere on the web straight into your garden." },
+      { name: "External links + previews", desc: "Paste any URL and get a rich Open Graph card with title, image, and description." },
+      { name: "File uploads", desc: "Drop in images, PDFs, and documents — stored in your own cloud, attached to your notes." },
+      { name: "Voice to text", desc: "Speak a thought and have it transcribed into the note — capture at the speed of talking." },
+    ],
+  },
+  {
+    id: "connect",
+    stage: "Connect",
+    title: "The connective tissue",
+    lede: "Ideas matter in relation to each other. Links turn a folder of files into a network that thinks with you.",
+    icon: <IconLink />,
+    features: [
+      { name: "Wiki-links", desc: "Type [[ to link any note, with live autocomplete. The core gesture of a real garden." },
+      { name: "Backlinks", desc: "Every note shows what links to it — discover context you didn't know you'd built." },
+      { name: "Outline panel", desc: "A live table of contents from your headings, for navigating long notes at a glance." },
+      { name: "Person mentions", desc: "Mention people to weave notes and the humans they're about into one graph." },
+      { name: "Inline timestamps", desc: "Clickable inline dates and times — anchor a thought to a moment." },
+    ],
+  },
+  {
+    id: "structure",
+    stage: "Connect",
+    title: "Organize without rigidity",
+    lede: "Structure should serve the ideas, not cage them. Shape your space, then reshape it whenever the work changes.",
+    icon: <IconTree />,
+    features: [
+      { name: "Hierarchy & drag-to-reorder", desc: "A universal content tree — folders, notes, files — rearranged by dragging." },
+      { name: "Folder views", desc: "View any folder as a list, a grid, or a Kanban board, whichever fits the work." },
+      { name: "Tags", desc: "Colored, inline tag pills that cut across the hierarchy to group ideas by theme." },
+      { name: "Mixed content types", desc: "Notes, files, code, HTML, and external links all live as first-class nodes." },
+      { name: "Custom icons & colors", desc: "Give important nodes a visual identity so your tree reads at a glance." },
+      { name: "Trash & restore", desc: "Soft-delete keeps a safety net — nothing's truly gone until you say so." },
+    ],
+  },
+  {
+    id: "compose",
+    stage: "Cultivate",
+    title: "Express ideas richly",
+    lede: "An idea half-expressed is half-understood. Reach for the right block — prose, diagram, table, or panel.",
+    icon: <IconBlocks />,
+    features: [
+      { name: "Callouts", desc: "Obsidian-style note, tip, warning, danger, info, and success blocks." },
+      { name: "Layout blocks", desc: "Accordions, tabs, columns, card panels, and section headers to structure a page." },
+      { name: "Diagrams", desc: "Embed and edit Excalidraw sketches, Mermaid diagrams, and diagrams.net flowcharts inline." },
+      { name: "Code blocks", desc: "Syntax-highlighted code, kept right alongside the prose that explains it." },
+      { name: "Resizable images", desc: "Drag to resize, wrap, and lay out images with float and width presets." },
+      { name: "Templates & snippets", desc: "Save selections as reusable templates or snippets and drop them in anywhere." },
+    ],
+  },
+  {
+    id: "recall",
+    stage: "Cultivate",
+    title: "Make knowledge stick",
+    lede: "Notes you never revisit aren't knowledge — they're storage. The system brings ideas back at the right moment.",
+    icon: <IconCards />,
+    features: [
+      { name: "Spaced-repetition flashcards", desc: "FSRS-scheduled review turns notes into durable memory, surfacing cards just before you'd forget." },
+      { name: "Anki import", desc: "Bring decades of decks with you — import .apkg files and keep your history." },
+      { name: "Cloze deletions", desc: "Hide parts of a sentence to test recall in context, not in isolation." },
+      { name: "Audio cards", desc: "Pronunciation and listening cards for language and anything spoken." },
+      { name: "Speed reader", desc: "RSVP reading streams words one at a time to push through long material fast." },
+      { name: "Full-text search", desc: "Find any note instantly, with filters to narrow by type, tag, and more." },
+    ],
+  },
+  {
+    id: "collaborate",
+    stage: "Cultivate",
+    title: "Think together",
+    lede: "Some ideas only grow in conversation. Edit the same note, at the same time, from anywhere.",
+    icon: <IconUsers />,
+    features: [
+      { name: "Real-time collaboration", desc: "Conflict-free co-editing powered by CRDTs — everyone stays in sync." },
+      { name: "Live presence", desc: "See collaborators' cursors and selections move as they work." },
+      { name: "Multi-pane workspace", desc: "Open several notes side by side and work across them at once." },
+      { name: "Conflict-safe saves", desc: "Edits reconcile cleanly even across flaky connections — no lost work." },
+    ],
+  },
+  {
+    id: "ai",
+    stage: "Cultivate",
+    title: "An assistant that knows your garden",
+    lede: "AI that works on your notes — drafting, summarizing, quizzing, illustrating — on your terms, with your keys.",
+    icon: <IconSparkles />,
+    features: [
+      { name: "AI chat (bring your own key)", desc: "Chat over your notes using your own provider keys — your data, your models." },
+      { name: "Multi-model routing", desc: "Route features to the best model, with automatic fallback chains when one is down." },
+      { name: "Context-aware", desc: "Pull the current note or selection into chat so answers fit what you're working on." },
+      { name: "AI tools", desc: "Generate flashcards, get folder-organization help, and surface follow-up questions." },
+      { name: "Read-aloud (TTS)", desc: "Have any note or selection read to you in a natural voice." },
+      { name: "Image generation", desc: "Create and drop AI images directly into your notes." },
+    ],
+  },
+  {
+    id: "people-time",
+    stage: "Connect",
+    title: "Knowledge in context",
+    lede: "Ideas live in a world of people and dates. Keep that context attached to the notes it belongs to.",
+    icon: <IconCalendar />,
+    features: [
+      { name: "People & contacts", desc: "Lightweight CRM — profiles for the people your notes are about." },
+      { name: "Workplaces", desc: "Organize people and notes by the organizations they belong to." },
+      { name: "Calendar", desc: "Events and quick-add scheduling, woven into your knowledge space." },
+      { name: "Periodic notes", desc: "Daily and weekly notes with activity summaries that track what changed." },
+    ],
+  },
+  {
+    id: "share",
+    stage: "Share",
+    title: "Grow ideas in public",
+    lede: "A digital garden is meant to be seen. Publish polished pages to your own corner of the web.",
+    icon: <IconGlobe />,
+    features: [
+      { name: "Publishing system", desc: "Turn any note into a published page — write once, ship it live." },
+      { name: "Bring your own domain", desc: "Connect a custom domain, claim a free subdomain, or use a permanent fallback URL." },
+      { name: "Publishing blocks", desc: "Hero, pricing, stats, testimonials, and more — composed building blocks for real pages." },
+      { name: "Theme-aware rendering", desc: "Published pages render correctly in both light and dark — no invisible text." },
+      { name: "Multiple sites", desc: "Run several independent sites from one account, each with its own domain and content." },
+    ],
+  },
+  {
+    id: "data",
+    stage: "Share",
+    title: "Own your data",
+    lede: "A second brain you can't take with you isn't yours. Your notes, your storage, your keys — always portable.",
+    icon: <IconDownload />,
+    features: [
+      { name: "Bring your own storage", desc: "Store files in your own Cloudflare R2, AWS S3, or Vercel Blob — not ours." },
+      { name: "Lossless export", desc: "Export to Markdown, HTML, or lossless JSON, with wiki-links and callouts preserved." },
+      { name: "Metadata sidecars", desc: "Exports carry tags, link targets, and structure so nothing semantic is dropped." },
+      { name: "Bring your own AI keys", desc: "Use your own provider accounts — no rented intelligence, no lock-in." },
+    ],
+  },
+  {
+    id: "craft",
+    stage: "Cultivate",
+    title: "Crafted to live in",
+    lede: "You spend hours here. The surface itself should feel calm, fast, and yours.",
+    icon: <IconLayers />,
+    features: [
+      { name: "Liquid Glass design", desc: "A layered glass design system with depth, blur, and intent — quiet, not loud." },
+      { name: "Light & dark", desc: "A considered dark mode with no flash of the wrong theme on load." },
+      { name: "Resizable panels", desc: "A three-panel layout you can size to the shape of your work." },
+      { name: "Keyboard & context menus", desc: "Right-click actions and shortcuts everywhere, so your hands stay on the keys." },
+    ],
+  },
+];
+
+// ----------------------------------------------------------------------------
+// Page
+// ----------------------------------------------------------------------------
+
+export function FeaturesPage() {
+  return (
+    <PlatformShell>
+      <MarketingPageHeader
+        eyebrow="Features"
+        title="Everything in the garden"
+        lede="The complete catalog, grouped by what each part of the system is for. Every category ties back to a stage in the notes system."
+      />
+
+      <section className="max-w-3xl mx-auto px-6 -mt-6 mb-4">
+        <Link
+          href="/notes-system"
+          className="text-sm text-emerald-400/80 hover:text-emerald-300 transition-colors"
+        >
+          ← New here? Start with the notes system
+        </Link>
+      </section>
+
+      {/* ---- Full feature catalog ---- */}
+      <section id="features" className="max-w-6xl mx-auto px-6 pb-24 scroll-mt-24">
+        <div className="space-y-16">
+          {CATEGORIES.map((cat) => (
+            <CategoryBlock key={cat.id} category={cat} />
+          ))}
+        </div>
+      </section>
+
+      {/* ---- Closing CTA ---- */}
+      <section className="max-w-3xl mx-auto px-6 pb-24">
+        <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.06] p-10 text-center">
+          <h2 className="text-2xl md:text-3xl font-bold mb-3">
+            Start tending your ideas.
+          </h2>
+          <p className="text-white/60 mb-8 max-w-md mx-auto">
+            Plant your first note today. Your garden grows with you — and goes
+            wherever you do.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="px-5 py-3 rounded-lg bg-emerald-500 text-black font-medium hover:bg-emerald-400 transition-colors"
+            >
+              Start your garden
+            </Link>
+            <Link
+              href="/notes-system"
+              className="px-5 py-3 rounded-lg border border-white/15 text-white/80 hover:border-white/30 hover:text-white transition-colors"
+            >
+              The notes system
+            </Link>
+          </div>
+        </div>
+      </section>
+    </PlatformShell>
+  );
+}
+
+function CategoryBlock({ category }: { category: Category }) {
+  return (
+    <div>
+      <div className="flex items-start gap-4 mb-6">
+        <div className="flex-shrink-0 w-11 h-11 rounded-lg border border-emerald-500/20 bg-emerald-500/10 flex items-center justify-center text-emerald-400">
+          {category.icon}
+        </div>
+        <div>
+          <p className="text-xs font-medium uppercase tracking-widest text-emerald-400/70 mb-1">
+            {category.stage}
+          </p>
+          <h3 className="text-xl font-semibold leading-tight">{category.title}</h3>
+          <p className="text-sm text-white/50 mt-1.5 max-w-2xl leading-relaxed">
+            {category.lede}
+          </p>
+        </div>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {category.features.map((f) => (
+          <div
+            key={f.name}
+            className="rounded-xl border border-white/8 bg-white/[0.03] p-4 hover:border-white/15 transition-colors"
+          >
+            <h4 className="text-sm font-semibold mb-1.5">{f.name}</h4>
+            <p className="text-[13px] text-white/50 leading-relaxed">{f.desc}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ----------------------------------------------------------------------------
+// Inline category glyphs — simple stroke icons, currentColor, server-safe.
+// ----------------------------------------------------------------------------
+
+function svgProps() {
+  return {
+    width: 20,
+    height: 20,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.6,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+  };
+}
+
+function IconPencil() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+    </svg>
+  );
+}
+
+function IconLink() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <path d="M10 13a5 5 0 0 0 7 0l2-2a5 5 0 0 0-7-7l-1 1" />
+      <path d="M14 11a5 5 0 0 0-7 0l-2 2a5 5 0 0 0 7 7l1-1" />
+    </svg>
+  );
+}
+
+function IconTree() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <path d="M6 4h12" />
+      <path d="M6 4v6a2 2 0 0 0 2 2h8" />
+      <path d="M14 12h2a2 2 0 0 1 2 2v6" />
+      <circle cx="6" cy="20" r="1.6" />
+      <circle cx="18" cy="20" r="1.6" />
+    </svg>
+  );
+}
+
+function IconBlocks() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <rect x="3" y="3" width="8" height="8" rx="1.5" />
+      <rect x="13" y="3" width="8" height="5" rx="1.5" />
+      <rect x="13" y="11" width="8" height="10" rx="1.5" />
+      <rect x="3" y="14" width="8" height="7" rx="1.5" />
+    </svg>
+  );
+}
+
+function IconCards() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <rect x="3" y="6" width="14" height="14" rx="2" />
+      <path d="M7 3h11a2 2 0 0 1 2 2v11" />
+    </svg>
+  );
+}
+
+function IconUsers() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <circle cx="9" cy="8" r="3.2" />
+      <path d="M3.5 20a5.5 5.5 0 0 1 11 0" />
+      <path d="M16 5.2a3.2 3.2 0 0 1 0 5.6" />
+      <path d="M16.5 14.6A5.5 5.5 0 0 1 20.5 20" />
+    </svg>
+  );
+}
+
+function IconSparkles() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <path d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6Z" />
+      <path d="M18 14l.8 2.2L21 17l-2.2.8L18 20l-.8-2.2L15 17l2.2-.8Z" />
+    </svg>
+  );
+}
+
+function IconCalendar() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <rect x="3" y="4.5" width="18" height="16" rx="2" />
+      <path d="M3 9h18" />
+      <path d="M8 2.5v4M16 2.5v4" />
+    </svg>
+  );
+}
+
+function IconGlobe() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M3 12h18" />
+      <path d="M12 3a14 14 0 0 1 0 18a14 14 0 0 1 0-18Z" />
+    </svg>
+  );
+}
+
+function IconDownload() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <path d="M12 3v12" />
+      <path d="M7 11l5 5 5-5" />
+      <path d="M5 21h14" />
+    </svg>
+  );
+}
+
+function IconLayers() {
+  return (
+    <svg {...svgProps()} aria-hidden="true">
+      <path d="M12 3l9 5-9 5-9-5 9-5Z" />
+      <path d="M3 13l9 5 9-5" />
+    </svg>
+  );
+}

--- a/components/home/NotesSystemPage.tsx
+++ b/components/home/NotesSystemPage.tsx
@@ -1,0 +1,108 @@
+/**
+ * NotesSystemPage — the philosophy page at /notes-system.
+ *
+ * The "why" behind NoteTrellis: a notes system is a way of *tending* ideas
+ * over time, not a pile of documents. Opens with the thesis, then walks the
+ * lifecycle loop ideas move through:
+ *
+ *   Capture → Connect → Cultivate → Share
+ *
+ * Its companion, FeaturesPage (/features), is the "what" — the full catalog of
+ * features, each tagged with the lifecycle stage it serves.
+ *
+ * Pure server component on the shared PlatformShell — zero JS.
+ */
+
+import Link from "next/link";
+import { PlatformShell } from "@/components/home/platform-chrome";
+
+interface Stage {
+  verb: string;
+  gloss: string;
+}
+
+const LIFECYCLE: Stage[] = [
+  { verb: "Capture", gloss: "Get the thought down before it evaporates." },
+  { verb: "Connect", gloss: "Link it into the web of what you already know." },
+  { verb: "Cultivate", gloss: "Return, review, and refine — so ideas mature and resurface when you need them." },
+  { verb: "Share", gloss: "Share your harvest." },
+];
+
+export function NotesSystemPage() {
+  return (
+    <PlatformShell>
+      {/* ---- Hero: the thesis ---- */}
+      <section className="max-w-3xl mx-auto px-6 pt-24 pb-16">
+        <p className="text-sm font-medium uppercase tracking-widest text-emerald-400/80 mb-5">
+          The Notes System
+        </p>
+        <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6">
+          A note isn&apos;t a document.{" "}
+          <span className="text-emerald-400">It&apos;s a living thing.</span>
+        </h1>
+        <p className="text-xl text-white/60 max-w-2xl leading-relaxed">
+          Most note apps are filing cabinets — you put things in and they sit
+          there. NoteTrellis is a way of <em className="text-white/80 not-italic font-medium">tending</em>{" "}
+          ideas: capturing them fast, linking them into what you already know,
+          returning to let them mature, and sharing the best ones with the world.
+          Every feature serves that one philosophy.
+        </p>
+      </section>
+
+      {/* ---- The lifecycle loop ---- */}
+      <section id="notes-system" className="max-w-6xl mx-auto px-6 pb-20 scroll-mt-24">
+        <div className="border-t border-white/5 pt-14">
+          <h2 className="text-2xl font-semibold mb-3">How ideas move through the garden</h2>
+          <p className="text-white/50 max-w-2xl mb-10">
+            Knowledge isn&apos;t captured once and finished. It cycles. Every
+            feature in NoteTrellis lives somewhere on this loop.
+          </p>
+          <ol className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {LIFECYCLE.map((stage, i) => (
+              <li
+                key={stage.verb}
+                className="rounded-xl border border-white/8 bg-white/[0.03] p-5"
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-xs font-mono text-emerald-400/70">
+                    {String(i + 1).padStart(2, "0")}
+                  </span>
+                  <span className="text-emerald-400/40">→</span>
+                </div>
+                <h3 className="text-base font-semibold mb-1.5">{stage.verb}</h3>
+                <p className="text-sm text-white/50 leading-relaxed">{stage.gloss}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      {/* ---- Bridge to the features catalog ---- */}
+      <section className="max-w-3xl mx-auto px-6 pb-24">
+        <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.06] p-10 text-center">
+          <h2 className="text-2xl md:text-3xl font-bold mb-3">
+            See the philosophy become features.
+          </h2>
+          <p className="text-white/60 mb-8 max-w-md mx-auto">
+            Every capability in NoteTrellis maps back to a stage in this loop.
+            Explore the full catalog to see how.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <Link
+              href="/features"
+              className="px-5 py-3 rounded-lg bg-emerald-500 text-black font-medium hover:bg-emerald-400 transition-colors"
+            >
+              Explore all features →
+            </Link>
+            <Link
+              href="/sign-up"
+              className="px-5 py-3 rounded-lg border border-white/15 text-white/80 hover:border-white/30 hover:text-white transition-colors"
+            >
+              Start your garden
+            </Link>
+          </div>
+        </div>
+      </section>
+    </PlatformShell>
+  );
+}

--- a/components/home/PlatformHome.tsx
+++ b/components/home/PlatformHome.tsx
@@ -6,40 +6,41 @@
  * the platform's own marketing/sign-up entry point, not someone's published
  * site. Bundle-isolated from PersonalHome / DefaultTenantIndex so visitors
  * to the platform domain don't download any tenant-data fetching code.
- *
- * Future surface for: feature pitch, screenshots, pricing tiers, customer
- * logos. V1 keeps it minimal — hero + sign-up CTA + a glance at the value
- * prop. Adding sections here doesn't touch any other home route.
  */
 
 import Link from "next/link";
+import { PlatformHeader, PlatformFooter } from "@/components/home/platform-chrome";
 
 export function PlatformHome() {
   return (
-    <div className="min-h-screen bg-[#0a0a0a] text-white">
-      <header className="border-b border-white/5">
-        <div className="max-w-5xl mx-auto px-6 py-5 flex items-center justify-between">
-          <Link href="/" className="text-base font-semibold tracking-tight">
-            NoteTrellis
-          </Link>
-          <nav className="flex items-center gap-6 text-sm text-white/60">
-            <Link
-              href="/sign-in"
-              className="hover:text-white/90 transition-colors"
-            >
-              Sign in
-            </Link>
-            <Link
-              href="/sign-up"
-              className="px-3 py-1.5 rounded-md bg-white text-black hover:bg-white/90 transition-colors"
-            >
-              Create account
-            </Link>
-          </nav>
-        </div>
-      </header>
+    <div className="min-h-screen bg-[#0a0a0a] text-white relative overflow-hidden">
+      {/* Sentinel — CSS :has() selector suppresses the root NavBar for this page only */}
+      <div className="platform-home-page" aria-hidden="true" style={{ display: "none" }} />
 
-      <main className="max-w-3xl mx-auto px-6 py-24">
+      {/* Background: subtle dot grid */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        aria-hidden="true"
+        style={{
+          backgroundImage: "radial-gradient(circle, rgba(255,255,255,0.045) 1px, transparent 1px)",
+          backgroundSize: "28px 28px",
+        }}
+      />
+      {/* Background: soft emerald radial glow anchored to top-center */}
+      <div
+        className="absolute top-0 left-1/2 -translate-x-1/2 w-[900px] h-[600px] pointer-events-none"
+        aria-hidden="true"
+        style={{
+          background:
+            "radial-gradient(ellipse 70% 55% at 50% 0%, rgba(16, 185, 129, 0.11) 0%, transparent 72%)",
+        }}
+      />
+
+      <PlatformHeader />
+
+      {/* Plain wrapper, not <main> — the root layout already provides the
+          single <main> landmark; a second one is an a11y violation. */}
+      <div className="relative max-w-3xl mx-auto px-6 py-24">
         <section className="mb-24">
           <h1 className="text-5xl md:text-6xl font-bold tracking-tight mb-6">
             A trellis for your{" "}
@@ -63,10 +64,16 @@ export function PlatformHome() {
             >
               Sign in
             </Link>
+            <Link
+              href="/features"
+              className="px-2 py-3 text-sm text-white/55 hover:text-white/90 transition-colors"
+            >
+              See all features →
+            </Link>
           </div>
         </section>
 
-        <section className="grid md:grid-cols-3 gap-6 mb-24">
+        <section id="features" className="grid md:grid-cols-3 gap-6 mb-24">
           <FeatureCard
             title="Write once, publish anywhere"
             body="Author in a powerful IDE-style editor. Publish to your own domain, a subpath, or a NoteTrellis subdomain — your choice."
@@ -81,10 +88,8 @@ export function PlatformHome() {
           />
         </section>
 
-        <section className="border-t border-white/5 pt-16">
-          <h2 className="text-2xl font-semibold mb-3">
-            How sites work
-          </h2>
+        <section id="notes-system" className="border-t border-white/5 pt-16 mb-24">
+          <h2 className="text-2xl font-semibold mb-3">How sites work</h2>
           <p className="text-white/50 mb-8 max-w-2xl">
             Every NoteTrellis account starts with one site. Each site can have
             its own custom hostname, its own published items, and its own URL
@@ -101,37 +106,31 @@ export function PlatformHome() {
             <li className="flex gap-3">
               <span className="text-emerald-400 mt-0.5">→</span>
               <span>
-                <code className="font-mono text-white/90">
-                  yourname.notetrellis.com
-                </code>{" "}
+                <code className="font-mono text-white/90">yourname.notetrellis.com</code>{" "}
                 — a free subdomain we provision instantly.
               </span>
             </li>
             <li className="flex gap-3">
               <span className="text-emerald-400 mt-0.5">→</span>
               <span>
-                <code className="font-mono text-white/90">
-                  notetrellis.com/u/yourname
-                </code>{" "}
-                — a permanent fallback URL that works even before DNS is
-                configured.
+                <code className="font-mono text-white/90">notetrellis.com/u/yourname</code>{" "}
+                — a permanent fallback URL that works even before DNS is configured.
               </span>
             </li>
           </ul>
         </section>
-      </main>
 
-      <footer className="border-t border-white/5 mt-12">
-        <div className="max-w-5xl mx-auto px-6 py-8 flex items-center justify-between text-xs text-white/30">
-          <span>NoteTrellis</span>
-          <Link
-            href="/sign-in"
-            className="hover:text-white/60 transition-colors"
-          >
-            Sign in
-          </Link>
-        </div>
-      </footer>
+        <section id="about" className="border-t border-white/5 pt-16">
+          <h2 className="text-2xl font-semibold mb-3">About NoteTrellis</h2>
+          <p className="text-white/50 max-w-2xl">
+            NoteTrellis is a digital garden platform built for writers, researchers,
+            and knowledge workers who think in networks, not documents. Every note
+            is a node. Every link is a branch. Your garden grows with you.
+          </p>
+        </section>
+      </div>
+
+      <PlatformFooter />
     </div>
   );
 }

--- a/components/home/platform-chrome.tsx
+++ b/components/home/platform-chrome.tsx
@@ -1,0 +1,346 @@
+/**
+ * Shared marketing chrome for the NoteTrellis platform surfaces.
+ *
+ * The platform landing (`PlatformHome`) and the features page
+ * (`FeaturesPage`) must present an identical header and footer so navigation
+ * feels like one cohesive marketing site. Extracting them here keeps the two
+ * pages in lockstep — change the nav once, both surfaces update.
+ *
+ * These are server components (no `"use client"`) using inline SVG, so the
+ * marketing surface ships zero JS for its chrome.
+ */
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+/** Brand logo — the digital-garden tree mark. */
+export function PlatformNavIcon() {
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src="/digital-garden-tree.svg"
+      alt="NoteTrellis logo"
+      width={56}
+      height={56}
+      style={{ width: "100%", height: "100%" }}
+    />
+  );
+}
+
+/**
+ * Shared sticky-feeling top nav.
+ *
+ * Section links resolve against the landing page (`/`) so they work from any
+ * marketing surface — e.g. clicking "Notes System" from /features jumps back
+ * to the landing's `#notes-system` anchor. The features page gets its own
+ * dedicated link.
+ */
+export function PlatformHeader() {
+  return (
+    <header className="relative border-b border-white/5">
+      <div className="max-w-6xl mx-auto px-6 py-5 flex items-center justify-between">
+        {/* Brand mark */}
+        <Link href="/" className="flex items-center gap-4 group">
+          <div className="w-14 h-14 flex-shrink-0">
+            <PlatformNavIcon />
+          </div>
+          <div>
+            <div className="text-[17px] font-semibold tracking-tight text-white leading-tight">
+              NoteTrellis
+            </div>
+            <div className="text-[12px] text-white/40 leading-tight">
+              Digital Knowledge Garden
+            </div>
+          </div>
+        </Link>
+
+        {/* Nav links + auth */}
+        <div className="flex items-center gap-8">
+          <nav className="hidden md:flex items-center gap-7 text-sm text-white/55">
+            <Link href="/notes-system" className="hover:text-white/90 transition-colors">
+              Notes System
+            </Link>
+            <Link href="/features" className="hover:text-white/90 transition-colors">
+              Features
+            </Link>
+            <Link href="/#about" className="hover:text-white/90 transition-colors">
+              About
+            </Link>
+          </nav>
+          <div className="flex items-center gap-4 text-sm">
+            <Link
+              href="/sign-in"
+              className="text-white/55 hover:text-white/90 transition-colors"
+            >
+              Sign in
+            </Link>
+            <Link
+              href="/sign-up"
+              className="px-4 py-2 rounded-md bg-emerald-500 text-black hover:bg-emerald-400 transition-colors font-medium"
+            >
+              Get started
+            </Link>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+/** Shared site footer. */
+export function PlatformFooter() {
+  return (
+    <footer className="relative border-t border-white/5 mt-16">
+      <div className="max-w-6xl mx-auto px-6 py-14">
+        {/* Footer columns */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-10 mb-12">
+          {/* Brand column */}
+          <div className="col-span-2 md:col-span-1">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-8 h-8 flex-shrink-0 opacity-80">
+                <PlatformNavIcon />
+              </div>
+              <span className="text-sm font-semibold text-white/80">NoteTrellis</span>
+            </div>
+            <p className="text-xs text-white/35 leading-relaxed max-w-[180px]">
+              A digital garden platform for growing your ideas in public.
+            </p>
+          </div>
+
+          {/* Product */}
+          <FooterColumn
+            heading="Product"
+            links={[
+              { label: "Features", href: "/features" },
+              { label: "Notes System", href: "/notes-system" },
+              { label: "Publishing", href: "/sign-up" },
+              { label: "Pricing", href: "/#pricing" },
+              { label: "Changelog", href: "/#changelog" },
+            ]}
+          />
+
+          {/* Learn */}
+          <FooterColumn
+            heading="Learn"
+            links={[
+              { label: "How it works", href: "/notes-system" },
+              { label: "Documentation", href: "/docs" },
+              { label: "Guides", href: "/guides" },
+              { label: "About", href: "/#about" },
+            ]}
+          />
+
+          {/* Help */}
+          <FooterColumn
+            heading="Help"
+            links={[
+              { label: "Help Center", href: "/help" },
+              { label: "Community", href: "/community" },
+              { label: "Status", href: "/status" },
+              { label: "Contact", href: "/contact" },
+            ]}
+          />
+        </div>
+
+        {/* Footer bottom bar */}
+        <div className="border-t border-white/5 pt-6 flex flex-col md:flex-row items-center justify-between gap-3 text-xs text-white/25">
+          <span>© {new Date().getFullYear()} NoteTrellis. All rights reserved.</span>
+          <div className="flex items-center gap-5">
+            <Link href="/privacy" className="hover:text-white/50 transition-colors">
+              Privacy Policy
+            </Link>
+            <Link href="/terms" className="hover:text-white/50 transition-colors">
+              Terms of Service
+            </Link>
+            <Link href="/sign-in" className="hover:text-white/50 transition-colors">
+              Sign in
+            </Link>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function FooterColumn({
+  heading,
+  links,
+}: {
+  heading: string;
+  links: { label: string; href: string }[];
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold text-white/50 uppercase tracking-widest mb-4">
+        {heading}
+      </p>
+      <ul className="space-y-2.5">
+        {links.map((link) => (
+          <li key={link.href}>
+            <Link
+              href={link.href}
+              className="text-sm text-white/35 hover:text-white/70 transition-colors"
+            >
+              {link.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ----------------------------------------------------------------------------
+// Marketing page shell + primitives.
+//
+// The full dark, full-bleed canvas (sentinel + dot grid + emerald glow +
+// header + footer) shared by the lighter marketing/legal/support pages
+// (docs, guides, help, community, status, contact, privacy, terms). Wrapping
+// here means those pages stay one thin file each, and a background tweak
+// lands everywhere at once.
+//
+// The two flagship pages (PlatformHome, FeaturesPage) still inline their own
+// canvas — they predate this shell and carry bespoke hero layout. They can
+// adopt PlatformShell later; kept as-is for now to avoid churning tested code.
+// ----------------------------------------------------------------------------
+
+/** Full-bleed dark marketing canvas with shared header + footer. */
+export function PlatformShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] text-white relative overflow-hidden">
+      {/* Sentinel — CSS :has() selector suppresses the root NavBar for this page only */}
+      <div className="platform-home-page" aria-hidden="true" style={{ display: "none" }} />
+
+      {/* Background: subtle dot grid */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        aria-hidden="true"
+        style={{
+          backgroundImage: "radial-gradient(circle, rgba(255,255,255,0.045) 1px, transparent 1px)",
+          backgroundSize: "28px 28px",
+        }}
+      />
+      {/* Background: soft emerald radial glow anchored to top-center */}
+      <div
+        className="absolute top-0 left-1/2 -translate-x-1/2 w-[900px] h-[600px] pointer-events-none"
+        aria-hidden="true"
+        style={{
+          background:
+            "radial-gradient(ellipse 70% 55% at 50% 0%, rgba(16, 185, 129, 0.11) 0%, transparent 72%)",
+        }}
+      />
+
+      <PlatformHeader />
+      {/* Plain wrapper, not <main> — the root layout already provides the
+          single <main> landmark; a second one is an a11y violation. */}
+      <div className="relative">{children}</div>
+      <PlatformFooter />
+    </div>
+  );
+}
+
+/** Consistent page intro: eyebrow + title + lede. */
+export function MarketingPageHeader({
+  eyebrow,
+  title,
+  lede,
+}: {
+  eyebrow?: string;
+  title: string;
+  lede: string;
+}) {
+  return (
+    <section className="max-w-3xl mx-auto px-6 pt-24 pb-12">
+      {eyebrow ? (
+        <p className="text-sm font-medium uppercase tracking-widest text-emerald-400/80 mb-5">
+          {eyebrow}
+        </p>
+      ) : null}
+      <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-5">{title}</h1>
+      <p className="text-lg text-white/60 max-w-2xl leading-relaxed">{lede}</p>
+    </section>
+  );
+}
+
+/** A small "Soon" pill for not-yet-built placeholder content. */
+export function SoonBadge() {
+  return (
+    <span className="flex-shrink-0 text-[10px] font-medium uppercase tracking-wider text-emerald-400/80 border border-emerald-500/20 bg-emerald-500/10 rounded px-1.5 py-0.5">
+      Soon
+    </span>
+  );
+}
+
+export interface PlaceholderItem {
+  title: string;
+  body: string;
+  /** Show the "Soon" pill. Defaults to true. */
+  soon?: boolean;
+}
+
+/** A responsive grid of placeholder cards, each optionally flagged "Soon". */
+export function PlaceholderGrid({
+  items,
+  columns = 3,
+}: {
+  items: PlaceholderItem[];
+  columns?: 2 | 3;
+}) {
+  const colClass = columns === 2 ? "sm:grid-cols-2" : "sm:grid-cols-2 lg:grid-cols-3";
+  return (
+    <div className={`grid gap-3 ${colClass}`}>
+      {items.map((item) => (
+        <div
+          key={item.title}
+          className="rounded-xl border border-white/8 bg-white/[0.03] p-5 hover:border-white/15 transition-colors"
+        >
+          <div className="flex items-start justify-between gap-2 mb-2">
+            <h3 className="text-base font-semibold leading-tight">{item.title}</h3>
+            {(item.soon ?? true) ? <SoonBadge /> : null}
+          </div>
+          <p className="text-sm text-white/50 leading-relaxed">{item.body}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export interface LegalSection {
+  heading: string;
+  body: string;
+}
+
+/** Shared scaffold for placeholder legal documents (privacy, terms). */
+export function LegalDocument({
+  title,
+  effectiveDate,
+  sections,
+}: {
+  title: string;
+  effectiveDate: string;
+  sections: LegalSection[];
+}) {
+  return (
+    <section className="max-w-3xl mx-auto px-6 pt-24 pb-24">
+      <p className="text-sm font-medium uppercase tracking-widest text-emerald-400/80 mb-5">
+        Legal
+      </p>
+      <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-3">{title}</h1>
+      <p className="text-sm text-white/40 mb-8">Last updated {effectiveDate}</p>
+
+      <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.06] px-4 py-3 text-sm text-amber-200/80 mb-10">
+        Placeholder draft — not a binding legal document. Final terms will be
+        published before launch.
+      </div>
+
+      <div className="space-y-8">
+        {sections.map((s) => (
+          <div key={s.heading}>
+            <h2 className="text-lg font-semibold mb-2">{s.heading}</h2>
+            <p className="text-[15px] text-white/55 leading-relaxed">{s.body}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/docs/notes-feature/guides/publishing/PUBLISHING-BLOCK-GUIDE.md
+++ b/docs/notes-feature/guides/publishing/PUBLISHING-BLOCK-GUIDE.md
@@ -1,0 +1,303 @@
+# Publishing Block Development Guide
+
+**Purpose:** Standardize publishing block development and prevent common errors
+**Audience:** Developers and AI assistants building new publishing blocks
+**Last Updated:** 2026-06-18
+
+---
+
+## Block Inventory
+
+All 24 current publishing blocks. Each must satisfy every column.
+
+| Block | File | Fixture JSON | Playwright baseline | CSS in globals.css | Notes |
+|---|---|---|---|---|---|
+| bookmark-card | ✅ | ✅ | ✅ | ✅ | |
+| cta-banner | ✅ | ✅ | ✅ | ✅ | |
+| faq-accordion | ✅ | ✅ | ✅ | ✅ | |
+| feature-list | ✅ | ✅ | ✅ | ✅ | |
+| gallery | ✅ | ✅ | ✅ | ✅ | |
+| hero-image | ✅ | ✅ | ✅ | ✅ | Visual block; `ttsSkip: true` |
+| logo-strip | ✅ | ✅ | ✅ | ✅ | |
+| metrics-strip | ✅ | ✅ | ✅ | ✅ | |
+| newsletter-signup | ✅ | ✅ | ✅ | ✅ | |
+| person-card | ✅ | ✅ | ✅ | ✅ | |
+| post-card | ✅ | ✅ | ✅ | ✅ | |
+| pricing-card | ✅ | ✅ | ✅ | ✅ | |
+| process-steps | ✅ | ✅ | ✅ | ✅ | |
+| project-card | ✅ | ✅ | ✅ | ✅ | |
+| recent-posts | ✅ | ✅ | ✅ | ✅ | Server render only; no post-processor yet |
+| skill-badges | ✅ | ✅ | ✅ | ✅ | |
+| social-links | ✅ | ✅ | ✅ | ✅ | |
+| spacer | ✅ | ✅ | ✅ | ✅ | Minimal reference block |
+| stat-block | ✅ | ✅ | ✅ | ✅ | |
+| stats-table | ✅ | ✅ | ✅ | ✅ | |
+| tag-cloud | ✅ | ✅ | ✅ | ✅ | |
+| testimonial-card | ✅ | ✅ | ✅ | ✅ | |
+| timeline | ✅ | ✅ | ✅ | ✅ | |
+| video-embed | ✅ | ✅ | ✅ | ✅ | |
+
+When adding a new block, append a row here with the block name and ❌ for each column. Check off columns as you complete each step.
+
+---
+
+## Development Checklist
+
+Use this for every new block. Check items off as you go.
+
+### Step 1 — Block file
+
+- [ ] Created `extensions/publishing/blocks/<block-name>.ts`
+- [ ] Schema defined via `createBlockSchema("blockType", { ... })`
+- [ ] `registerBlock({ type, label, description, iconName, family, group, contentModel, atom, attrsSchema, defaultAttrs, slashCommand, searchTerms })` called
+- [ ] `addAttributes()` helper defined using `dataAttr()` for every custom attr
+- [ ] `export const MyBlock = Node.create({ ... addNodeView() ... })` — client extension with editor preview
+- [ ] `export const ServerMyBlock = Node.create({ ... renderHTML() ... })` — server extension emitting semantic HTML
+- [ ] `renderHTML` reads `HTMLAttributes["data-<kebab-key>"]` (not camelCase) for every attr
+- [ ] Visual-only block? Add `ttsSkip: true` to `registerBlock()`
+
+### Step 2 — Server-runtime registration
+
+- [ ] Import `ServerMyBlock` added to `extensions/publishing/server-runtime.ts`
+- [ ] `ServerMyBlock` added to `editorServerExtensions` array in same file
+- [ ] `pnpm publishing:schema:check` passes
+
+### Step 3 — CSS
+
+- [ ] CSS added to `app/globals.css` under a named comment block (`/* ─── My Block ... */`)
+- [ ] Selector prefix is `.public-prose .block-my-block` (not bare `.block-my-block`)
+- [ ] No unconditional extreme colors: any `color:#fff` / `rgba(255,255,255,…)` or `color:#000`–`#333` has a `.dark .public-prose .block-*` companion rule
+- [ ] `pnpm publishing:audit:themes` run; any flagged candidates reviewed and resolved
+
+### Step 4 — Playwright fixture
+
+- [ ] `tests/e2e/_fixtures/publishing/<block-name>.json` created with representative (non-empty) attr values
+- [ ] Block name added to `PUBLISHING_FIXTURE_BLOCKS` in `tests/e2e/_fixtures/publishing/index.ts`
+- [ ] `pnpm dev` running; baselines captured with `pnpm test:e2e:update -- --grep "<block-name>"`
+- [ ] Light and dark PNG snapshots reviewed (not just generated)
+- [ ] Fixture JSON + both PNGs committed
+
+### Step 5 — Quality gates
+
+- [ ] `pnpm publishing:audit:defaults` run (informational; review any drift)
+- [ ] `pnpm typecheck` clean
+- [ ] `pnpm lint` — zero new warnings
+- [ ] `pnpm build` passes
+- [ ] `pnpm test:e2e` passes (no regressions on existing blocks)
+- [ ] Block inserted via slash command in browser and properties panel verified
+- [ ] Published page inspected to confirm server render matches editor preview
+
+### Step 6 — Post-merge
+
+- [ ] **Hocuspocus redeployed** via Cloud Build (`cloudbuild.hocuspocus.yaml`) — Vercel does NOT do this. Without a redeploy, the running Cloud Run instance serializes unknown block types as `unsupportedBlock` placeholders, corrupting collaborative documents.
+- [ ] Inventory table above updated (all ✅)
+
+---
+
+## Known Footguns
+
+### `dataAttr()` is required — don't hand-roll attribute access
+
+The server extension reads attrs from `HTMLAttributes["data-<kebab-key>"]`. The `dataAttr()` helper in `addAttributes()` ensures the camelCase attr is correctly mapped to the kebab data attribute. Hand-rolling this was the source of a bug in `hero-image.ts` where `ctaText`/`ctaUrl` silently dropped from every block because `attrs["cta-text"]` returned `undefined`.
+
+**Rule:** Always use `dataAttr("camelKey")` in `addAttributes()`. Never write `{ default: "" }` directly for attrs that have a data attribute counterpart.
+
+### Dark-mode-first CSS causes invisible blocks on light pages
+
+Eight publishing blocks shipped with `color: #fff` or similar unconditional white text — invisible on light-mode published pages. This was found and fixed after the fact (commits `61cb06c`, `4410c2d`).
+
+**Rule:** Every `.public-prose .block-*` rule that uses a hardcoded extreme color must have a `.dark .public-prose .block-*` companion. Use `pnpm publishing:audit:themes` to catch candidates before review.
+
+### Hocuspocus must be redeployed — Vercel doesn't do it
+
+The Next.js app and the Hocuspocus server are separate deployments. Vercel auto-deploys the Next.js app on push. The Hocuspocus Cloud Run service does not auto-redeploy. A block type unknown to the running Hocuspocus instance is serialized as `unsupportedBlock` via the `sanitizeTipTapJsonWithExtensions()` safety net — this corrupts documents in collaborative sessions.
+
+**Rule:** After any block addition merges to main, trigger a Cloud Build run (`cloudbuild.hocuspocus.yaml`).
+
+### `renderHTML` in the server extension reads kebab keys, not camel
+
+In `addAttributes()`, you define `ctaText: dataAttr("ctaText")`. In `renderHTML`, TipTap passes this back as `HTMLAttributes["data-cta-text"]` (auto-kebab'd). Read it as `HTMLAttributes["data-cta-text"]`, not `HTMLAttributes["data-ctaText"]` or `HTMLAttributes["ctaText"]`.
+
+### Fixture images should be inline data-URIs
+
+Network images in fixture JSON are fragile in CI. Use an inline SVG data-URI as a placeholder (see `hero-image.json`). This keeps fixtures self-contained and snapshot-stable across environments.
+
+---
+
+## Block File Template
+
+Minimal complete block (copy, replace `MyBlock` / `myBlock` / `my-block`):
+
+```ts
+/**
+ * MyBlock — Publishing Block
+ *
+ * One sentence description.
+ *
+ * Attrs:
+ * - title    heading text
+ * - variant  "a" | "b"
+ */
+
+import { Node, mergeAttributes } from "@tiptap/core";
+import { z } from "zod";
+import { createBlockSchema } from "@/lib/domain/blocks/schema";
+import { registerBlock } from "@/lib/domain/blocks/registry";
+import { blockIdAttr, dataAttr } from "@/lib/domain/blocks/data-attr";
+import { createBlockNodeView } from "@/lib/domain/blocks/node-view-factory";
+
+const { schema, defaults } = createBlockSchema("myBlock", {
+  title: z.string().default("").describe("Block heading"),
+  variant: z.enum(["a", "b"]).default("a").describe("Visual variant"),
+});
+
+registerBlock({
+  type: "myBlock",
+  label: "My Block",
+  description: "One sentence describing the block",
+  iconName: "LayoutTemplate",   // lucide icon name
+  family: "content",            // "content" | "layout" | "form"
+  group: "publishing",
+  contentModel: null,
+  atom: true,
+  attrsSchema: schema,
+  defaultAttrs: defaults(),
+  slashCommand: "/my-block",
+  searchTerms: ["my-block", "block"],
+});
+
+function myBlockAttrs() {
+  return {
+    blockId: blockIdAttr,
+    blockType: { default: "myBlock" },
+    title: dataAttr("title"),
+    variant: dataAttr("variant", { default: "a" }),
+  };
+}
+
+// ─── Client extension ─────────────────────────────────────────────────────────
+
+export const MyBlock = Node.create({
+  name: "myBlock",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: true,
+  addAttributes: myBlockAttrs,
+  parseHTML() { return [{ tag: 'div[data-block-type="myBlock"]' }]; },
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes(HTMLAttributes, { "data-block-type": "myBlock" })];
+  },
+  addNodeView() {
+    return createBlockNodeView({
+      blockType: "myBlock",
+      label: "My Block",
+      iconName: "LayoutTemplate",
+      atom: true,
+      renderContent(node, contentDom) {
+        contentDom.innerHTML = `<p style="margin:0">${node.attrs.title as string || "My Block"}</p>`;
+      },
+      updateContent(node, contentDom) {
+        contentDom.innerHTML = `<p style="margin:0">${node.attrs.title as string || "My Block"}</p>`;
+        return true;
+      },
+    });
+  },
+});
+
+// ─── Server extension ─────────────────────────────────────────────────────────
+
+export const ServerMyBlock = Node.create({
+  name: "myBlock",
+  group: "block",
+  atom: true,
+  addAttributes: myBlockAttrs,
+  parseHTML() { return [{ tag: 'div[data-block-type="myBlock"]' }]; },
+  renderHTML({ HTMLAttributes }) {
+    // Read kebab-case data attributes — TipTap auto-kebabs camelCase attr names
+    const title = (HTMLAttributes["data-title"] as string) || "";
+    const variant = (HTMLAttributes["data-variant"] as string) || "a";
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, {
+        class: `block-my-block block-my-block--${variant}`,
+        "data-block-type": "myBlock",
+      }),
+      ["h2", { class: "block-my-block-title" }, title],
+    ];
+  },
+});
+```
+
+**Fixture JSON** (`tests/e2e/_fixtures/publishing/my-block.json`):
+
+```json
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "myBlock",
+      "attrs": {
+        "blockType": "myBlock",
+        "title": "Example heading for snapshot",
+        "variant": "a"
+      }
+    }
+  ]
+}
+```
+
+**CSS** (`app/globals.css`):
+
+```css
+/* ─── My Block ───────────────────────────────────────────────────────────── */
+.public-prose .block-my-block {
+  margin: 2em 0;
+  padding: 2rem;
+  border-radius: 8px;
+  background: #f9fafb;
+}
+.public-prose .block-my-block-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #111827;
+}
+/* Dark mode companions — required for any hardcoded light color above */
+.dark .public-prose .block-my-block { background: #1f2937; }
+.dark .public-prose .block-my-block-title { color: #f9fafb; }
+```
+
+---
+
+## Reference: Block registry fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | `string` | Must match `Node.create({ name })` exactly |
+| `label` | `string` | Display name in slash command menu |
+| `description` | `string` | Shown in block picker tooltip |
+| `iconName` | `string` | Lucide icon name |
+| `family` | `"content" \| "layout" \| "form"` | Determines sort group in slash menu |
+| `group` | `string` | Sub-group within family |
+| `contentModel` | `null \| "inline"` | `null` = atom block; `"inline"` = wraps inline content |
+| `atom` | `boolean` | Set `true` when `contentModel: null` |
+| `attrsSchema` | Zod schema | From `createBlockSchema()` |
+| `defaultAttrs` | object | From `defaults()` returned by `createBlockSchema()` |
+| `slashCommand` | `string` | The `/` prefix for the slash command |
+| `searchTerms` | `string[]` | Additional search keywords |
+| `ttsSkip` | `boolean?` | `true` for visual blocks with no narratable content |
+
+---
+
+## CI Gates Reference
+
+| Gate | Script | Hard? | When |
+|---|---|---|---|
+| Block + Server* export check | `pnpm publishing:schema:check` | ✅ Hard | PR touches `extensions/publishing/` |
+| Zod defaults vs renderHTML fallback drift | `pnpm publishing:audit:defaults` | ℹ️ Info | Same |
+| CSS extreme colors without dark companion | `pnpm publishing:audit:themes` | ℹ️ Info | Same |
+| Per-block Playwright snapshots | `pnpm test:e2e` | ✅ Hard | PR touches publishing surface |
+| TypeScript + lint | `pnpm typecheck && pnpm lint` | ✅ Hard | Every PR |
+
+Bypass Playwright gate temporarily: set repo var `PUBLISHING_VISUAL_GATE=skip`.

--- a/extensions/browser-bookmarks/browser-extension/popup.html
+++ b/extensions/browser-bookmarks/browser-extension/popup.html
@@ -52,6 +52,15 @@
           <button id="launch-note" class="btn-primary">Launch Note</button>
           <button id="open-tree" class="btn-secondary">Open in Tree</button>
         </div>
+
+        <button id="quick-capture-btn" class="btn-quick-capture">
+          <svg width="13" height="13" viewBox="0 0 13 13" fill="none" aria-hidden="true">
+            <rect x="0.75" y="0.75" width="8.5" height="8.5" rx="1.25" stroke="currentColor" stroke-width="1.25" stroke-dasharray="2.2 1.5"/>
+            <path d="M8.75 8.75L12.25 12.25" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+            <path d="M8.5 8.5L12.5 10.8L10.8 11.6L9.8 13.2L8.5 8.5Z" fill="currentColor"/>
+          </svg>
+          Quick Capture
+        </button>
       </div>
 
       <!-- Footer -->

--- a/extensions/browser-bookmarks/browser-extension/src/background/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/background/index.js
@@ -609,6 +609,21 @@ async function getCurrentTabSyncState() {
   };
 }
 
+async function startQuickCaptureInActiveTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) throw new Error("No active tab is available");
+  try {
+    await chrome.tabs.sendMessage(tab.id, { type: "dg-quick-capture" });
+    return { started: true, tabId: tab.id };
+  } catch (error) {
+    throw new Error(
+      error instanceof Error
+        ? `Quick Capture is not available on this page: ${error.message}`
+        : "Quick Capture is not available on this page"
+    );
+  }
+}
+
 async function showTreePanelInActiveTab() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab?.id) {
@@ -1483,10 +1498,56 @@ chrome.bookmarks.onRemoved.addListener((id, removeInfo) => {
   });
 });
 
+// ── MRU tab tracking ─────────────────────────────────────────────────────────
+// Ordered most-recent-first. Ephemeral (service-worker memory only) — resets
+// on MV3 restart, self-populates as the user browses. Only tabs the user
+// explicitly activates/focuses are tracked; background/preloaded tabs are not.
+const MRU_TABS_MAX = 10;
+const mruTabs = [];
+
+function isIneligibleMruUrl(url) {
+  if (!url) return true;
+  return (
+    url.startsWith("chrome://") ||
+    url.startsWith("chrome-extension://") ||
+    url.startsWith("about:") ||
+    url.startsWith("edge://") ||
+    url.startsWith("vivaldi://")
+  );
+}
+
+function updateMruTab(tabId, tab) {
+  if (!tab?.url || isIneligibleMruUrl(tab.url)) return;
+  const idx = mruTabs.findIndex((t) => t.tabId === tabId);
+  if (idx !== -1) mruTabs.splice(idx, 1);
+  mruTabs.unshift({
+    tabId,
+    title: tab.title || "",
+    favIconUrl: tab.favIconUrl || null,
+    url: tab.url,
+    lastViewedAt: new Date().toISOString(),
+  });
+  if (mruTabs.length > MRU_TABS_MAX) mruTabs.length = MRU_TABS_MAX;
+}
+
+function pruneMruTab(tabId) {
+  const idx = mruTabs.findIndex((t) => t.tabId === tabId);
+  if (idx !== -1) mruTabs.splice(idx, 1);
+}
+
 chrome.tabs.onActivated.addListener(({ tabId }) => {
   chrome.tabs.get(tabId, (tab) => {
     if (chrome.runtime.lastError || !tab?.url) return;
     void updateTabBadge(tabId, tab.url);
+    updateMruTab(tabId, tab);
+  });
+});
+
+chrome.windows.onFocusChanged.addListener((windowId) => {
+  if (windowId === chrome.windows.WINDOW_ID_NONE) return;
+  chrome.tabs.query({ active: true, windowId }, ([tab]) => {
+    if (chrome.runtime.lastError || !tab) return;
+    updateMruTab(tab.id, tab);
   });
 });
 
@@ -1500,6 +1561,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 // that reuses the id starts clean.
 chrome.tabs.onRemoved.addListener((tabId) => {
   void chrome.storage.session.remove(`${TAB_PANELS_KEY_PREFIX}${tabId}`);
+  pruneMruTab(tabId);
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -1585,6 +1647,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
     if (message.type === "show-tree-panel") {
       sendResponse({ ok: true, data: await showTreePanelInActiveTab() });
+      return;
+    }
+    if (message.type === "start-quick-capture") {
+      sendResponse({ ok: true, data: await startQuickCaptureInActiveTab() });
       return;
     }
     if (message.type === "open-content-in-active-tab") {
@@ -1732,6 +1798,55 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       return;
     }
     sendResponse({ ok: false, error: "Unknown message type" });
+    if (message.type === "get-recent-viewed-tabs") {
+      const config = await getConfig();
+      const appOrigin = config.appBaseUrl
+        ? (() => { try { return new URL(config.appBaseUrl).origin; } catch { return null; } })()
+        : null;
+      const tabs = mruTabs.filter((t) => {
+        if (!appOrigin) return true;
+        try { return new URL(t.url).origin !== appOrigin; } catch { return true; }
+      });
+      sendResponse({ ok: true, data: tabs });
+      return;
+    }
+
+    if (message.type === "send-note-to-tabs") {
+      const { contentId, contentKind = "note", tabIds = [] } = message.payload || {};
+      const results = await Promise.all(
+        tabIds.map(async (tabId) => {
+          const entry = mruTabs.find((t) => t.tabId === tabId);
+          try {
+            await new Promise((resolve, reject) => {
+              chrome.tabs.sendMessage(
+                tabId,
+                { type: "dg-associate-and-open", payload: { contentId, contentKind } },
+                (response) => {
+                  if (chrome.runtime.lastError) {
+                    reject(new Error(chrome.runtime.lastError.message));
+                  } else if (!response?.ok) {
+                    reject(new Error(response?.error || "Overlay unavailable"));
+                  } else {
+                    resolve(response);
+                  }
+                }
+              );
+            });
+            return { tabId, success: true, title: entry?.title || "" };
+          } catch (error) {
+            return {
+              tabId,
+              success: false,
+              title: entry?.title || "",
+              error: error instanceof Error ? error.message : "Failed",
+            };
+          }
+        })
+      );
+      sendResponse({ ok: true, data: results });
+      return;
+    }
+
   })().catch((error) => {
     sendResponse({ ok: false, error: error.message || "Unknown error" });
   });

--- a/extensions/browser-bookmarks/browser-extension/src/overlay/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/overlay/index.js
@@ -10,6 +10,12 @@ const DG_OVERLAY_STALE_MS = 5 * 60 * 1000;
 // How long to wait for the background service worker before giving up
 const DG_RUNTIME_MSG_TIMEOUT_MS = 10000;
 
+// chrome.storage.local keys for persistent UI state
+const DG_STORAGE_WORKSPACE_KEY = "dgSelectedWorkspaceId";
+const DG_STORAGE_TREE_SORT_KEY = "dgTreeSortMode";
+const DG_STORAGE_TREE_EXPANDED_PREFIX = "dgTreeExpanded:";
+const DG_STORAGE_RECENTLY_VIEWED_KEY = "dgRecentlyViewed";
+
 function runtimeMessage(message) {
   return new Promise((resolve, reject) => {
     let settled = false;
@@ -169,6 +175,22 @@ function treeIconMarkup(node, isOpen) {
   }
 
   return svg('<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/>');
+}
+
+function treeNodeTitle(node) {
+  const candidates = [
+    node.title,
+    node.name,
+    node.displayName,
+    node.contentTitle,
+    node.label,
+    node.slug,
+  ];
+  const value = candidates.find(
+    (candidate) => typeof candidate === "string" && candidate.trim()
+  );
+  if (value) return value.trim();
+  return `Untitled ${node.contentType || "content"}`;
 }
 
 function initials(label) {
@@ -818,9 +840,9 @@ function overlayStyles() {
     .dg-tree-kind { width: 15px; height: 15px; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; color: rgba(255,255,255,0.62); }
     .dg-tree-svg { width: 15px; height: 15px; display: block; }
     .dg-tree-emoji { font-size: 13px; line-height: 1; }
-    .dg-tree-meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
-    .dg-tree-title { color: rgba(255,255,255,0.88); font-size: 12px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .dg-tree-subtitle { color: rgba(255,255,255,0.4); font-size: 10px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .dg-tree-meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; width: 0; flex: 1 1 auto; }
+    .dg-tree-title { display: block; color: rgba(255,255,255,0.88); font-size: 12px; font-weight: 500; line-height: 1.25; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .dg-tree-subtitle { display: block; color: rgba(255,255,255,0.4); font-size: 10px; line-height: 1.2; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .dg-tree-actions { display: flex; align-items: center; gap: 3px; flex-shrink: 0; opacity: 0; transition: opacity 0.12s; }
     .dg-tree-row:hover .dg-tree-actions { opacity: 1; }
 
@@ -862,6 +884,9 @@ function overlayStyles() {
     .dg-panel-content {
       height: calc(100% - 53px); display: flex; flex-direction: column;
       gap: 12px; padding: 14px; overflow: auto;
+    }
+    .dg-floating-panel[data-content-kind="note"] .dg-panel-content {
+      gap: 0; padding: 0; overflow: hidden;
     }
     .dg-panel-content[data-loading="true"] { opacity: 0.62; pointer-events: none; }
     .dg-editor-stack { display: flex; flex-direction: column; gap: 12px; min-height: 0; flex: 1; }
@@ -1157,7 +1182,7 @@ function schedulePersist(state, contentId) {
 // That means in-tab navigation (browsing the same site) drops them. To keep a
 // note open while the user explores, we ALSO snapshot the currently-open panels
 // to tab-scoped session storage (via the background, keyed by sender.tab.id)
-// and restore them on every page load — independent of the URL.
+// and restore them when navigating within the same hostname.
 function scheduleTabPersist(state) {
   if (state.tabPersistTimer) clearTimeout(state.tabPersistTimer);
   state.tabPersistTimer = setTimeout(() => {
@@ -1169,6 +1194,7 @@ function scheduleTabPersist(state) {
         kind: panel.kind,
         title: panel.title || null,
         state: panel.state,
+        host: window.location.hostname,
         // Embedded panels anchor to a page element that won't exist after
         // navigation — restore them as floating.
         layoutMode: panel.layoutMode === "embedded" ? "floating" : panel.layoutMode,
@@ -1185,7 +1211,7 @@ function scheduleTabPersist(state) {
   }, 250);
 }
 
-// Re-open the panels that were open in this tab, regardless of the current URL.
+// Re-open the panels that were open in this tab on the same hostname.
 // Runs after restorePanelsFromState, so resource-bound panels win and we only
 // add the ones not already open (dedupe by contentId).
 async function restoreTabStickyPanels(state) {
@@ -1196,8 +1222,13 @@ async function restoreTabStickyPanels(state) {
     return;
   }
   if (!Array.isArray(descriptors)) return;
+  const currentHost = window.location.hostname;
   for (const descriptor of descriptors) {
     if (!descriptor?.contentId || state.openPanels.has(descriptor.contentId)) {
+      continue;
+    }
+    // Skip panels opened on a different hostname — they belong to another site.
+    if (descriptor.host && descriptor.host !== currentHost) {
       continue;
     }
     const item = { id: descriptor.contentId, title: descriptor.title || null };
@@ -1404,6 +1435,14 @@ async function loadContentTree(state, { workspaceId = null, force = false } = {}
   });
   state.loadedForWorkspaceId = workspaceId || null;
   state.fetchedAt = { ...state.fetchedAt, tree: Date.now() };
+
+  // Restore persisted folder expansion for this workspace
+  const storageKey = `${DG_STORAGE_TREE_EXPANDED_PREFIX}${workspaceId || "all"}`;
+  const stored = await chrome.storage.local.get(storageKey).catch(() => ({}));
+  state.expandedTreeIds = Array.isArray(stored[storageKey])
+    ? new Set(stored[storageKey])
+    : new Set();
+
   return state.contentTree;
 }
 
@@ -1498,7 +1537,7 @@ function renderFlashcardSection(state) {
       ` : ""}
       <button class="dg-flashcard-side-btn${hasSel ? " dg-flashcard-side-btn--secondary" : ""}" type="button"
         data-action="flashcard-type-manually" style="width:100%">
-        Type manually →
+        Add flashcard
       </button>
     `;
   } else if (fc.phase === "has-front") {
@@ -1836,11 +1875,137 @@ function renderConnectionsPopover(state) {
   `;
 }
 
+function relativeTime(isoString) {
+  const diff = Date.now() - new Date(isoString).getTime();
+  const secs = Math.floor(diff / 1000);
+  if (secs < 60) return "just now";
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+function trackRecentlyViewed(state, contentId) {
+  const now = new Date().toISOString();
+  const prev = (state.recentlyViewed || []).filter((e) => e.id !== contentId);
+  state.recentlyViewed = [{ id: contentId, viewedAt: now }, ...prev].slice(0, 50);
+  chrome.storage.local.set({ [DG_STORAGE_RECENTLY_VIEWED_KEY]: state.recentlyViewed });
+}
+
+function flattenTreeByDate(nodes, pathParts = [], parentFolderId = null) {
+  const results = [];
+  for (const node of nodes) {
+    if (node.contentType === "folder") {
+      flattenTreeByDate(node.children || [], [...pathParts, node.title], node.id).forEach((n) =>
+        results.push(n)
+      );
+    } else {
+      results.push({ ...node, _path: pathParts.join(" / "), _parentFolderId: parentFolderId });
+    }
+  }
+  return results;
+}
+
+function renderSortedList(state, visibleTree) {
+  const mode = state.treeSortMode; // "updated" | "viewed"
+  const allFlat = flattenTreeByDate(visibleTree);
+
+  // Sibling counts for /+N — computed from full list before filtering
+  const siblingCounts = {};
+  allFlat.forEach((n) => {
+    const key = n._parentFolderId || "__root__";
+    siblingCounts[key] = (siblingCounts[key] || 0) + 1;
+  });
+
+  // Apply optional folder filter
+  const folderFilter = state.recentFolderFilter;
+  let flat = folderFilter ? allFlat.filter((n) => n._parentFolderId === folderFilter) : allFlat;
+  let filterLabel = null;
+  if (folderFilter && flat.length > 0 && flat[0]._path) {
+    const parts = flat[0]._path.split(" / ");
+    filterLabel = parts[parts.length - 1] || flat[0]._path;
+  }
+
+  // Sort
+  if (mode === "updated") {
+    flat.sort((a, b) => {
+      if (!a.updatedAt && !b.updatedAt) return 0;
+      if (!a.updatedAt) return 1;
+      if (!b.updatedAt) return -1;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    });
+  } else if (mode === "viewed") {
+    const viewedMap = new Map(
+      (state.recentlyViewed || []).map((e, i) => [e.id, { viewedAt: e.viewedAt, rank: i }])
+    );
+    flat.sort((a, b) => {
+      const va = viewedMap.get(a.id);
+      const vb = viewedMap.get(b.id);
+      if (va && vb) return va.rank - vb.rank;
+      if (va) return -1;
+      if (vb) return 1;
+      if (!a.updatedAt && !b.updatedAt) return 0;
+      if (!a.updatedAt) return 1;
+      if (!b.updatedAt) return -1;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    });
+  }
+
+  if (flat.length === 0) {
+    return mode === "viewed"
+      ? `<div class="dg-status">No content viewed yet. Open notes from the tree to start tracking views.</div>`
+      : `<div class="dg-status">No items found.</div>`;
+  }
+
+  const filterHeader = folderFilter && filterLabel
+    ? `<div class="dg-status" style="display:flex;align-items:center;gap:8px;">
+        <button class="dg-mini-action" type="button" data-clear-folder-filter>← All</button>
+        <span style="font-size:11px;opacity:0.65;">📁 ${escapeHtml(filterLabel)}</span>
+      </div>`
+    : "";
+
+  return filterHeader + flat.map((node) => {
+    const sibCount = (siblingCounts[node._parentFolderId || "__root__"] || 1) - 1;
+    const viewed = mode === "viewed"
+      ? (state.recentlyViewed || []).find((e) => e.id === node.id)
+      : null;
+    const timeLabel = mode === "updated" && node.updatedAt
+      ? ` · ${escapeHtml(relativeTime(node.updatedAt))}`
+      : mode === "viewed" && viewed
+        ? ` · seen ${escapeHtml(relativeTime(viewed.viewedAt))}`
+        : "";
+    const siblingAffordances = !folderFilter && sibCount > 0 ? `
+      <button class="dg-mini-action" type="button" data-filter-by-folder="${escapeHtml(node._parentFolderId || "")}" title="Show ${sibCount} more from this folder">/+${sibCount}</button>
+      <button class="dg-mini-action" type="button" data-create-tree-item="note" data-parent-content="${escapeHtml(node._parentFolderId || "")}" title="Create a note in this folder">+N Sibling</button>
+    ` : "";
+    return `
+      <div class="dg-tree-row" style="--depth:0">
+        <button class="dg-tree-expand" type="button">•</button>
+        <span class="dg-tree-kind">${treeIconMarkup(node, false)}</span>
+        <div class="dg-tree-meta">
+          <div class="dg-tree-title" title="${escapeHtml(node.title)}">${escapeHtml(node.title)}</div>
+          <div class="dg-tree-subtitle">${node._path ? escapeHtml(node._path) : escapeHtml(node.contentType)}${timeLabel}</div>
+        </div>
+        <div class="dg-tree-actions">
+          ${siblingAffordances}
+          <button class="dg-mini-action" type="button" data-associate-content="${escapeHtml(node.id)}" data-content-kind="${escapeHtml(node.contentType)}">Open</button>
+        </div>
+      </div>
+    `;
+  }).join("");
+}
+
 function renderTreeRows(state, nodes, depth = 0) {
   return nodes
     .map((node) => {
       const isFolder = node.contentType === "folder";
       const expanded = state.expandedTreeIds.has(node.id);
+      const title = treeNodeTitle(node);
       const children =
         isFolder && expanded && node.children?.length
           ? renderTreeRows(state, node.children, depth + 1)
@@ -1854,7 +2019,7 @@ function renderTreeRows(state, nodes, depth = 0) {
             }>${isFolder ? (expanded ? "▾" : "▸") : "•"}</button>
             <span class="dg-tree-kind">${treeIconMarkup(node, expanded)}</span>
             <div class="dg-tree-meta">
-              <div class="dg-tree-title">${escapeHtml(node.title)}</div>
+              <div class="dg-tree-title" title="${escapeHtml(title)}">${escapeHtml(title)}</div>
               <div class="dg-tree-subtitle">${escapeHtml(node.contentType)}</div>
             </div>
             <div class="dg-tree-actions">
@@ -1888,6 +2053,8 @@ function renderTreePopover(state) {
   const container = state.popoverBodies.tree;
   if (!container) return;
   const visibleTree = state.contentTree;
+  const mode = state.treeSortMode; // "default" | "updated" | "viewed"
+
   if (!visibleTree || visibleTree.length === 0) {
     container.innerHTML = `
       <div class="dg-status">
@@ -1899,19 +2066,45 @@ function renderTreePopover(state) {
     `;
     return;
   }
+
+  const sortBtn = (id, label) => {
+    const isActive = mode === id;
+    const activeStyle = isActive
+      ? ' style="background:rgba(91,175,255,0.18);border-color:rgba(91,175,255,0.45);"'
+      : "";
+    return `<button class="dg-mini-action" type="button" data-tree-sort-mode="${id}"${activeStyle} title="${isActive ? "Return to folder tree" : `Sort by ${label.toLowerCase()}`}">${escapeHtml(label)}</button>`;
+  };
+
+  const statusText = mode === "updated"
+    ? "Sorted by last updated."
+    : mode === "viewed"
+      ? "Sorted by last viewed."
+      : "Create content at the root, or use the compact actions on folders to add nested items.";
+
+  const createBtns = mode === "default" ? `
+    <button class="dg-mini-action" type="button" data-create-tree-item="folder">+ Folder</button>
+    <button class="dg-mini-action" type="button" data-create-tree-item="note">+ Note</button>
+    <button class="dg-mini-action" type="button" data-create-tree-item="external">+ Link</button>
+  ` : "";
+
   container.innerHTML = `
     <div class="dg-status">
-      <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;">
-        <span>Create content at the root, or use the compact actions on folders to add nested items.</span>
-        <span style="display:flex;gap:6px;">
-          <button class="dg-mini-action" type="button" data-reload-tree title="Refresh file tree">↻</button>
-          <button class="dg-mini-action" type="button" data-create-tree-item="folder">+ Folder</button>
-          <button class="dg-mini-action" type="button" data-create-tree-item="note">+ Note</button>
-          <button class="dg-mini-action" type="button" data-create-tree-item="external">+ Link</button>
-        </span>
+      <div style="display:flex;flex-direction:column;gap:6px;">
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;">
+          <span>${statusText}</span>
+          <span style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+            <button class="dg-mini-action" type="button" data-reload-tree title="Refresh file tree">↻</button>
+            ${createBtns}
+          </span>
+        </div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+          ${sortBtn("default", "File Tree")}
+          ${sortBtn("updated", "Last Updated")}
+          ${sortBtn("viewed", "Last Viewed")}
+        </div>
       </div>
     </div>
-    ${renderTreeRows(state, visibleTree)}
+    ${mode === "default" ? renderTreeRows(state, visibleTree) : renderSortedList(state, visibleTree)}
   `;
 }
 
@@ -2323,6 +2516,7 @@ function createContentPanel(state, item, kind, persisted = null) {
 
   const container = document.createElement("section");
   container.className = "dg-floating-panel";
+  container.dataset.contentKind = kind;
   const title = item.title || (kind === "note" ? "Note" : kind === "embed" ? "Content" : "External link");
   const kindLabel = kind === "note" ? "Web note overlay" : kind === "embed" ? "Content overlay" : "External metadata overlay";
   container.innerHTML = `
@@ -2335,6 +2529,7 @@ function createContentPanel(state, item, kind, persisted = null) {
         <span class="dg-panel-ready" style="font-size:11px;color:rgba(255,255,255,0.46)"></span>
         <button class="dg-toolbar-button" type="button" data-panel-action="open-tree" title="Browse file tree">◂ Tree</button>
         <button class="dg-toolbar-button" type="button" data-panel-action="app" title="Open in app">↗</button>
+        <button class="dg-toolbar-button" type="button" data-panel-action="refresh" title="Refresh note">↺</button>
         <button class="dg-toolbar-button" type="button" data-panel-action="collapse" title="Collapse">—</button>
         <button class="dg-toolbar-button" type="button" data-panel-action="close" title="Close">×</button>
       </div>
@@ -2439,6 +2634,17 @@ function createContentPanel(state, item, kind, persisted = null) {
 
     if (action === "app") {
       openAppContent(state.config.appBaseUrl, panel.contentId, state.selectedWorkspaceId || null);
+      return;
+    }
+
+    if (action === "refresh") {
+      // Force a full iframe reload by clearing the cached content ID,
+      // then re-running openEmbedForPanel which will re-fetch the session
+      // token and reload the src from scratch.
+      if (state.iframePanel === panel) {
+        state.iframeContentId = null;
+      }
+      openEmbedForPanel(state, panel);
       return;
     }
 
@@ -2934,6 +3140,52 @@ function wireRootEvents(state) {
       })();
       return true;
     }
+
+    if (message?.type === "dg-associate-and-open") {
+      void (async () => {
+        try {
+          await associateAndOpen(
+            state,
+            message.payload?.contentId,
+            message.payload?.contentKind || "note"
+          );
+          sendResponse?.({ ok: true });
+        } catch (error) {
+          sendResponse?.({
+            ok: false,
+            error: error instanceof Error ? error.message : "Failed to open content",
+          });
+        }
+      })();
+      return true;
+    }
+
+    if (message?.type === "dg-refresh-embed") {
+      const panel = message.payload?.contentId
+        ? state.openPanels.get(message.payload.contentId)
+        : state.iframePanel;
+      if (panel) {
+        if (state.iframePanel === panel) state.iframeContentId = null;
+        openEmbedForPanel(state, panel);
+      }
+      sendResponse?.({ ok: true });
+      return true;
+    }
+
+    if (message?.type === "dg-quick-capture") {
+      try {
+        if (state.panelOpen) closeSnapPanel(state);
+        state.embedIframe?.blur();
+        startQuickCaptureMode();
+        sendResponse?.({ ok: true });
+      } catch (error) {
+        sendResponse?.({
+          ok: false,
+          error: error instanceof Error ? error.message : "Failed to start Quick Capture",
+        });
+      }
+      return true;
+    }
   });
 
   // ── Floating launcher button ───────────────────────────────────────────────
@@ -3028,6 +3280,7 @@ function wireRootEvents(state) {
   state.workspaceSelect.addEventListener("change", () => {
     const workspaceId = state.workspaceSelect.value || null;
     state.selectedWorkspaceId = workspaceId;
+    chrome.storage.local.set({ [DG_STORAGE_WORKSPACE_KEY]: workspaceId ?? "" });
     renderStatus(state.popoverBodies.tree, "Loading…");
     void loadContentTree(state, { workspaceId, force: true })
       .then(() => renderTreePopover(state))
@@ -3180,9 +3433,11 @@ function wireRootEvents(state) {
 
     const openButton = event.target.closest("[data-open-content]");
     if (openButton) {
+      const openContentId = openButton.getAttribute("data-open-content");
+      trackRecentlyViewed(state, openContentId);
       await openAssociatedContent(
         state,
-        openButton.getAttribute("data-open-content"),
+        openContentId,
         openButton.getAttribute("data-content-kind")
       );
       return;
@@ -3197,15 +3452,51 @@ function wireRootEvents(state) {
         state.expandedTreeIds.add(id);
       }
       renderTreePopover(state);
+      const wsKey = `${DG_STORAGE_TREE_EXPANDED_PREFIX}${state.selectedWorkspaceId || "all"}`;
+      chrome.storage.local.set({ [wsKey]: Array.from(state.expandedTreeIds) });
+      return;
+    }
+
+    const sortModeBtn = event.target.closest("[data-tree-sort-mode]");
+    if (sortModeBtn) {
+      const newMode = sortModeBtn.getAttribute("data-tree-sort-mode");
+      state.treeSortMode = newMode;
+      state.recentFolderFilter = null;
+      chrome.storage.local.set({ [DG_STORAGE_TREE_SORT_KEY]: state.treeSortMode });
+      if (state.treeSortMode === "updated") {
+        // Force fresh fetch to guarantee updatedAt is present on all nodes
+        renderStatus(state.popoverBodies.tree, "Loading…");
+        void loadContentTree(state, { workspaceId: state.selectedWorkspaceId || null, force: true })
+          .then(() => renderTreePopover(state))
+          .catch((e) => renderLoadError(state.popoverBodies.tree, e));
+      } else {
+        renderTreePopover(state);
+      }
+      return;
+    }
+
+    const filterFolderBtn = event.target.closest("[data-filter-by-folder]");
+    if (filterFolderBtn) {
+      state.recentFolderFilter = filterFolderBtn.getAttribute("data-filter-by-folder") || null;
+      renderTreePopover(state);
+      return;
+    }
+
+    const clearFilterBtn = event.target.closest("[data-clear-folder-filter]");
+    if (clearFilterBtn) {
+      state.recentFolderFilter = null;
+      renderTreePopover(state);
       return;
     }
 
     const associateButton = event.target.closest("[data-associate-content]");
     if (associateButton) {
       try {
+        const assocContentId = associateButton.getAttribute("data-associate-content");
+        trackRecentlyViewed(state, assocContentId);
         await associateAndOpen(
           state,
-          associateButton.getAttribute("data-associate-content"),
+          assocContentId,
           associateButton.getAttribute("data-content-kind")
         );
       } catch (error) {
@@ -3443,6 +3734,9 @@ async function initOverlay() {
     workspaces: [],
     selectedWorkspaceId: null,
     workspaceAutoSelected: false,
+    treeSortMode: "default",
+    recentFolderFilter: null,
+    recentlyViewed: [],
     isIdle: false,
     idleTimer: null,
     resourceContext: null,
@@ -3526,6 +3820,25 @@ async function initOverlay() {
   // Pre-load local flashcard history so it's ready when the panel opens
   loadLocalFlashcardHistory(hostname).then((h) => { state.localFlashcards = h; }).catch(() => { state.localFlashcards = []; });
 
+  // Restore persisted UI preferences before loading workspaces so that
+  // auto-select is correctly skipped when the user had a prior choice.
+  const storedUiPrefs = await chrome.storage.local.get([
+    DG_STORAGE_WORKSPACE_KEY,
+    DG_STORAGE_TREE_SORT_KEY,
+    DG_STORAGE_RECENTLY_VIEWED_KEY,
+  ]).catch(() => ({}));
+  if (storedUiPrefs[DG_STORAGE_WORKSPACE_KEY]) {
+    state.selectedWorkspaceId = storedUiPrefs[DG_STORAGE_WORKSPACE_KEY];
+  }
+  if (storedUiPrefs[DG_STORAGE_TREE_SORT_KEY]) {
+    // Normalize legacy "recent" value (renamed to "updated")
+    const stored = storedUiPrefs[DG_STORAGE_TREE_SORT_KEY];
+    state.treeSortMode = stored === "recent" ? "updated" : stored;
+  }
+  if (Array.isArray(storedUiPrefs[DG_STORAGE_RECENTLY_VIEWED_KEY])) {
+    state.recentlyViewed = storedUiPrefs[DG_STORAGE_RECENTLY_VIEWED_KEY];
+  }
+
   void loadWorkspaces(state).then(() => renderWorkspaceSelector(state));
 
   try {
@@ -3549,6 +3862,263 @@ async function initOverlay() {
 initOverlay().catch((error) => {
   console.warn("[DG Overlay] Failed to initialize overlay", error);
 });
+
+// ─── Quick Capture picker ─────────────────────────────────────────────────────
+
+function startQuickCaptureMode() {
+  if (document.getElementById("dg-quick-capture-root")) return;
+
+  const style = document.createElement("style");
+  style.id = "dg-qc-styles";
+  style.textContent = `
+    .dg-qc-highlight {
+      outline: 2px dashed rgba(100, 210, 230, 0.75) !important;
+      outline-offset: 2px !important;
+      background-color: rgba(100, 210, 230, 0.06) !important;
+    }
+    #dg-qc-banner {
+      position: fixed;
+      top: 12px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 2147483647;
+      background: rgba(10, 14, 20, 0.92);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      color: rgba(100, 210, 230, 0.95);
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 16px;
+      border-radius: 20px;
+      border: 1px solid rgba(100, 210, 230, 0.25);
+      pointer-events: none;
+      white-space: nowrap;
+      letter-spacing: 0.02em;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.45);
+    }
+    #dg-qc-cancel-btn {
+      pointer-events: auto;
+      cursor: pointer;
+      border-bottom: 1px dotted rgba(100, 210, 230, 0.5);
+      padding-bottom: 1px;
+      transition: opacity 0.12s;
+    }
+    #dg-qc-cancel-btn:hover { opacity: 0.65; }
+    #dg-qc-tooltip {
+      position: fixed;
+      z-index: 2147483647;
+      background: rgba(10, 14, 20, 0.9);
+      color: #f4f6f8;
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 11px;
+      font-weight: 500;
+      padding: 4px 9px;
+      border-radius: 5px;
+      border: 1px solid rgba(100, 210, 230, 0.22);
+      pointer-events: none;
+      white-space: nowrap;
+      letter-spacing: 0.01em;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.35);
+      opacity: 0;
+      transition: opacity 0.1s;
+    }
+    #dg-qc-tooltip.dg-qc-tip-visible { opacity: 1; }
+    #dg-qc-toast {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%) translateY(10px);
+      z-index: 2147483647;
+      background: rgba(10, 14, 20, 0.95);
+      color: #8fe0b3;
+      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 13px;
+      font-weight: 600;
+      padding: 8px 20px;
+      border-radius: 20px;
+      border: 1px solid rgba(143, 224, 179, 0.3);
+      box-shadow: 0 4px 24px rgba(0,0,0,0.5);
+      opacity: 0;
+      transition: opacity 0.2s, transform 0.2s;
+      pointer-events: none;
+    }
+    #dg-qc-toast.dg-qc-toast-in { opacity: 1; transform: translateX(-50%) translateY(0); }
+  `;
+  document.head.appendChild(style);
+
+  const root = document.createElement("span");
+  root.id = "dg-quick-capture-root";
+  root.style.display = "none";
+  document.body.appendChild(root);
+
+  const banner = document.createElement("div");
+  banner.id = "dg-qc-banner";
+  banner.innerHTML = 'Click any block to copy &nbsp;&nbsp;<span id="dg-qc-cancel-btn">Click here to cancel or press ESC</span>';
+  document.body.appendChild(banner);
+  banner.querySelector("#dg-qc-cancel-btn").addEventListener("click", (e) => {
+    e.stopPropagation();
+    cleanup();
+  });
+
+  const tooltip = document.createElement("div");
+  tooltip.id = "dg-qc-tooltip";
+  document.body.appendChild(tooltip);
+
+  const toast = document.createElement("div");
+  toast.id = "dg-qc-toast";
+  document.body.appendChild(toast);
+
+  // Steal keyboard focus from any iframe (panel, embeds) so keydown fires on main window
+  const focusTrap = document.createElement("input");
+  Object.assign(focusTrap.style, {
+    position: "fixed", top: "-9999px", left: "-9999px",
+    width: "1px", height: "1px", opacity: "0", pointerEvents: "none",
+  });
+  document.body.appendChild(focusTrap);
+  requestAnimationFrame(() => focusTrap.focus({ preventScroll: true }));
+
+  const prevCursor = document.body.style.cursor;
+  document.body.style.cursor = "crosshair";
+  let currentTarget = null;
+
+  const PICKABLE = new Set([
+    "article", "section", "main", "aside", "header", "footer", "nav",
+    "div", "p", "blockquote", "pre", "figure", "figcaption",
+    "ul", "ol", "li", "table", "tbody", "thead", "tr",
+    "h1", "h2", "h3", "h4", "h5", "h6", "details", "summary",
+  ]);
+  const TAG_LABELS = {
+    article: "Article", section: "Section", main: "Main", aside: "Aside",
+    header: "Header", footer: "Footer", nav: "Nav", p: "Paragraph",
+    blockquote: "Blockquote", pre: "Code block", figure: "Figure",
+    ul: "List", ol: "Ordered list", li: "List item", table: "Table",
+    h1: "Heading 1", h2: "Heading 2", h3: "Heading 3",
+    h4: "Heading 4", h5: "Heading 5", h6: "Heading 6",
+    div: "Block",
+  };
+
+  function findTarget(el) {
+    let cur = el;
+    while (cur && cur !== document.body) {
+      const tag = cur.tagName?.toLowerCase();
+      if (PICKABLE.has(tag)) {
+        const rect = cur.getBoundingClientRect();
+        if (rect.width >= 20 && rect.height >= 10) return cur;
+      }
+      cur = cur.parentElement;
+    }
+    return null;
+  }
+
+  function sanitizeHtml(el) {
+    const clone = el.cloneNode(true);
+    for (const sel of ["script", "style", "noscript", "svg", "canvas", "video", "audio", "iframe", "object", "embed"]) {
+      clone.querySelectorAll(sel).forEach((n) => n.remove());
+    }
+    clone.querySelectorAll("*").forEach((n) => {
+      for (const attr of Array.from(n.attributes)) {
+        if (attr.name.startsWith("on") || attr.name === "style") n.removeAttribute(attr.name);
+      }
+    });
+    return clone.innerHTML;
+  }
+
+  async function writeToClipboard(html, text) {
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/html": new Blob([html], { type: "text/html" }),
+          "text/plain": new Blob([text], { type: "text/plain" }),
+        }),
+      ]);
+    } catch {
+      const div = document.createElement("div");
+      div.contentEditable = "true";
+      div.innerHTML = html;
+      Object.assign(div.style, { position: "fixed", top: "-9999px", left: "-9999px", whiteSpace: "pre-wrap" });
+      document.body.appendChild(div);
+      try {
+        const sel = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(div);
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+        document.execCommand("copy");
+      } finally {
+        document.body.removeChild(div);
+        window.getSelection()?.removeAllRanges();
+      }
+    }
+  }
+
+  function showToast(msg, isError = false) {
+    toast.textContent = msg;
+    toast.style.color = isError ? "#ff8a8a" : "#8fe0b3";
+    toast.style.borderColor = isError ? "rgba(255,138,138,0.3)" : "rgba(143,224,179,0.3)";
+    toast.classList.add("dg-qc-toast-in");
+    setTimeout(() => toast.classList.remove("dg-qc-toast-in"), 2200);
+  }
+
+  function cleanup() {
+    if (currentTarget) { currentTarget.classList.remove("dg-qc-highlight"); currentTarget = null; }
+    document.body.style.cursor = prevCursor;
+    document.removeEventListener("mouseover", onMouseOver, true);
+    document.removeEventListener("mousemove", onMouseMove, true);
+    document.removeEventListener("click", onClick, true);
+    window.removeEventListener("keydown", onKeyDown, true);
+    setTimeout(() => { style.remove(); banner.remove(); tooltip.remove(); toast.remove(); focusTrap.remove(); root.remove(); }, 350);
+  }
+
+  function onMouseOver(e) {
+    const target = findTarget(e.target);
+    if (target === currentTarget) return;
+    currentTarget?.classList.remove("dg-qc-highlight");
+    currentTarget = target;
+    if (currentTarget) {
+      currentTarget.classList.add("dg-qc-highlight");
+      const tag = currentTarget.tagName.toLowerCase();
+      tooltip.textContent = `${TAG_LABELS[tag] || tag} · click to copy`;
+      tooltip.classList.add("dg-qc-tip-visible");
+    } else {
+      tooltip.classList.remove("dg-qc-tip-visible");
+    }
+  }
+
+  function onMouseMove(e) {
+    tooltip.style.left = `${e.clientX + 14}px`;
+    tooltip.style.top = `${e.clientY + 14}px`;
+    const rect = tooltip.getBoundingClientRect();
+    if (rect.right > window.innerWidth - 8) tooltip.style.left = `${e.clientX - rect.width - 10}px`;
+    if (rect.bottom > window.innerHeight - 8) tooltip.style.top = `${e.clientY - rect.height - 10}px`;
+  }
+
+  function onClick(e) {
+    if (!currentTarget) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const html = sanitizeHtml(currentTarget);
+    const text = currentTarget.innerText || currentTarget.textContent || "";
+    currentTarget.classList.remove("dg-qc-highlight");
+    const captured = currentTarget;
+    captured.style.outline = "2px solid rgba(143,224,179,0.7)";
+    captured.style.outlineOffset = "2px";
+    setTimeout(() => { captured.style.outline = ""; captured.style.outlineOffset = ""; }, 550);
+    cleanup();
+    writeToClipboard(html, text)
+      .then(() => showToast("✓ Copied to clipboard"))
+      .catch(() => showToast("Failed to copy", true));
+  }
+
+  function onKeyDown(e) {
+    if (e.key === "Escape") { e.preventDefault(); e.stopImmediatePropagation(); cleanup(); }
+  }
+
+  document.addEventListener("mouseover", onMouseOver, true);
+  document.addEventListener("mousemove", onMouseMove, true);
+  document.addEventListener("click", onClick, true);
+  window.addEventListener("keydown", onKeyDown, true);
+}
 
 // ─── Read aloud (TTS) playback ─────────────────────────────────
 // The background service worker has no DOM and can't play audio, so it hands us

--- a/extensions/browser-bookmarks/browser-extension/src/page-bridge.js
+++ b/extensions/browser-bookmarks/browser-extension/src/page-bridge.js
@@ -198,6 +198,23 @@ window.addEventListener("message", async (event) => {
       await postMessageToPage("trusted-install-cleared", payload);
       await dispatchResponseEvent("trusted-install-cleared", payload);
     }
+
+    if (event.data.type === "get-recent-viewed-tabs") {
+      const tabs = await sendRuntimeMessage({ type: "get-recent-viewed-tabs" });
+      await postMessageToPage("recent-viewed-tabs", { tabs });
+      await dispatchResponseEvent("recent-viewed-tabs", { tabs });
+      return;
+    }
+
+    if (event.data.type === "send-note-to-tabs") {
+      const results = await sendRuntimeMessage({
+        type: "send-note-to-tabs",
+        payload: event.data.payload,
+      });
+      await postMessageToPage("send-note-to-tabs-result", { results });
+      await dispatchResponseEvent("send-note-to-tabs-result", { results });
+      return;
+    }
   } catch (error) {
     await postMessageToPage("bridge-error", {
       message: error?.message || "Bridge request failed",
@@ -250,6 +267,23 @@ document.addEventListener("dg-browser-bookmarks-request", async (event) => {
       ensurePresenceNode(payload);
       await postMessageToPage("trusted-install-cleared", payload);
       await dispatchResponseEvent("trusted-install-cleared", payload);
+    }
+
+    if (detail.type === "get-recent-viewed-tabs") {
+      const tabs = await sendRuntimeMessage({ type: "get-recent-viewed-tabs" });
+      await postMessageToPage("recent-viewed-tabs", { tabs });
+      await dispatchResponseEvent("recent-viewed-tabs", { tabs });
+      return;
+    }
+
+    if (detail.type === "send-note-to-tabs") {
+      const results = await sendRuntimeMessage({
+        type: "send-note-to-tabs",
+        payload: detail.payload,
+      });
+      await postMessageToPage("send-note-to-tabs-result", { results });
+      await dispatchResponseEvent("send-note-to-tabs-result", { results });
+      return;
     }
   } catch (error) {
     await postMessageToPage("bridge-error", {

--- a/extensions/browser-bookmarks/browser-extension/src/popup/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/popup/index.js
@@ -508,6 +508,15 @@ document.getElementById("open-capture").addEventListener("click", () => {
   chrome.tabs.create({ url: chrome.runtime.getURL("capture.html") });
 });
 
+document.getElementById("quick-capture-btn").addEventListener("click", async () => {
+  try {
+    await sendMessage({ type: "start-quick-capture" });
+  } catch {
+    // Overlay unavailable on this page — close anyway
+  }
+  window.close();
+});
+
 connectionSelect().addEventListener("change", async (event) => {
   const value = event.target.value;
   if (!value) return;

--- a/extensions/browser-bookmarks/browser-extension/styles.css
+++ b/extensions/browser-bookmarks/browser-extension/styles.css
@@ -309,6 +309,36 @@ body {
   cursor: default;
 }
 
+/* ── Quick Capture ── */
+.btn-quick-capture {
+  width: 100%;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 7px 12px;
+  border: 1.5px dashed rgba(100, 210, 230, 0.32);
+  border-radius: var(--radius-md);
+  background: rgba(100, 210, 230, 0.04);
+  color: rgba(100, 210, 230, 0.72);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  letter-spacing: 0.02em;
+  transition: background 0.14s, border-color 0.14s, color 0.14s;
+}
+
+.btn-quick-capture:hover {
+  background: rgba(100, 210, 230, 0.09);
+  border-color: rgba(100, 210, 230, 0.55);
+  color: rgba(100, 210, 230, 0.95);
+}
+
+.btn-quick-capture:active {
+  background: rgba(100, 210, 230, 0.15);
+}
+
 /* ── Footer ── */
 .footer-links {
   display: flex;

--- a/extensions/browser-bookmarks/components/SendToTabButton.tsx
+++ b/extensions/browser-bookmarks/components/SendToTabButton.tsx
@@ -55,6 +55,8 @@ export function SendToTabButton({ contentId, contentKind = "note" }: Props) {
   const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
   const popoverRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  // No fetchTimeoutRef — the 5s fallback lives in a useEffect below so the
+  // React Compiler can track the timeout lifetime through the dependency array.
 
   // Position popover below the button, escaping any overflow containers via portal
   const updatePosition = useCallback(() => {
@@ -91,9 +93,8 @@ export function SendToTabButton({ contentId, contentKind = "note" }: Props) {
       if (detail?.source !== EXTENSION_SOURCE) return;
 
       if (detail.type === "recent-viewed-tabs") {
-        if (fetchTimeoutRef.current) clearTimeout(fetchTimeoutRef.current);
         setTabs(detail.payload?.tabs ?? []);
-        setLoading(false);
+        setLoading(false); // flipping loading→false cancels the 5s timeout via its useEffect cleanup
         // Pre-select the most recent tab
         const first = detail.payload?.tabs?.[0];
         if (first) setSelected(new Set([first.tabId]));
@@ -128,8 +129,6 @@ export function SendToTabButton({ contentId, contentKind = "note" }: Props) {
       document.removeEventListener("dg-browser-bookmarks-response", handler as EventListener);
   }, []);
 
-  const fetchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const handleOpen = useCallback(() => {
     if (!isExtensionInstalled()) {
       toast.info("Browser extension not detected", {
@@ -144,16 +143,21 @@ export function SendToTabButton({ contentId, contentKind = "note" }: Props) {
       setTabs([]);
       setSelected(new Set());
       sendBridgeMessage("get-recent-viewed-tabs");
-      // If the extension service worker doesn't respond within 5s, show an actionable message
-      fetchTimeoutRef.current = setTimeout(() => {
-        setLoading(false);
-        setTabs([]);
-      }, 5000);
-    } else {
-      if (fetchTimeoutRef.current) clearTimeout(fetchTimeoutRef.current);
     }
     setOpen(nextOpen);
   }, [open, updatePosition]);
+
+  // 5-second fallback: if no bridge response arrives, surface an actionable empty state.
+  // Cleanup fires when `loading` flips false (tabs arrived) or when `open` closes —
+  // cancelling the timer without a ref write in a callback.
+  useEffect(() => {
+    if (!open || !loading) return;
+    const id = setTimeout(() => {
+      setLoading(false);
+      setTabs([]);
+    }, 5000);
+    return () => clearTimeout(id);
+  }, [open, loading]);
 
   const toggleTab = useCallback((tabId: number) => {
     setSelected((prev) => {

--- a/extensions/browser-bookmarks/components/SendToTabButton.tsx
+++ b/extensions/browser-bookmarks/components/SendToTabButton.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { MonitorPlay } from "lucide-react";
+import { toast } from "sonner";
+
+const APP_SOURCE = "dg-browser-bookmarks-app";
+const EXTENSION_SOURCE = "dg-browser-bookmarks-extension";
+const PRESENCE_NODE_ID = "dg-browser-bookmarks-extension-presence";
+
+interface MruTab {
+  tabId: number;
+  title: string;
+  favIconUrl: string | null;
+  url: string;
+  lastViewedAt: string;
+}
+
+function isExtensionInstalled(): boolean {
+  return !!document.getElementById(PRESENCE_NODE_ID);
+}
+
+function sendBridgeMessage(type: string, payload?: unknown): void {
+  window.postMessage({ source: APP_SOURCE, type, payload }, window.location.origin);
+  document.dispatchEvent(
+    new CustomEvent("dg-browser-bookmarks-request", {
+      detail: { source: APP_SOURCE, type, payload },
+    })
+  );
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+interface Props {
+  contentId: string;
+  contentKind?: "note" | "external" | "embed";
+}
+
+export function SendToTabButton({ contentId, contentKind = "note" }: Props) {
+  const [open, setOpen] = useState(false);
+  const [tabs, setTabs] = useState<MruTab[]>([]);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Position popover below the button, escaping any overflow containers via portal
+  const updatePosition = useCallback(() => {
+    if (!buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setPopoverStyle({
+      position: "fixed",
+      top: rect.bottom + 6,
+      right: window.innerWidth - rect.right,
+      zIndex: 9999,
+      width: 288,
+    });
+  }, []);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        !popoverRef.current?.contains(e.target as Node) &&
+        !buttonRef.current?.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  // Listen for bridge responses
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.source !== EXTENSION_SOURCE) return;
+
+      if (detail.type === "recent-viewed-tabs") {
+        if (fetchTimeoutRef.current) clearTimeout(fetchTimeoutRef.current);
+        setTabs(detail.payload?.tabs ?? []);
+        setLoading(false);
+        // Pre-select the most recent tab
+        const first = detail.payload?.tabs?.[0];
+        if (first) setSelected(new Set([first.tabId]));
+        return;
+      }
+
+      if (detail.type === "send-note-to-tabs-result") {
+        setSending(false);
+        setOpen(false);
+        const results: Array<{ tabId: number; success: boolean; title: string; error?: string }> =
+          detail.payload?.results ?? [];
+        const succeeded = results.filter((r) => r.success);
+        const failed = results.filter((r) => !r.success);
+
+        if (succeeded.length > 0 && failed.length === 0) {
+          const names = succeeded.map((r) => r.title || "a page").join(", ");
+          toast.success(`Launched in ${succeeded.length === 1 ? names : `${succeeded.length} tabs`}`, {
+            description: succeeded.length > 1 ? names : undefined,
+          });
+        } else if (succeeded.length > 0 && failed.length > 0) {
+          toast.warning(`Sent to ${succeeded.length} tab${succeeded.length > 1 ? "s" : ""}`, {
+            description: `${failed.length} tab${failed.length > 1 ? "s" : ""} had no active overlay`,
+          });
+        } else {
+          toast.error("Could not launch — no active overlays on those pages");
+        }
+      }
+    };
+
+    document.addEventListener("dg-browser-bookmarks-response", handler as EventListener);
+    return () =>
+      document.removeEventListener("dg-browser-bookmarks-response", handler as EventListener);
+  }, []);
+
+  const fetchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleOpen = useCallback(() => {
+    if (!isExtensionInstalled()) {
+      toast.info("Browser extension not detected", {
+        description: "Install the Digital Garden extension to launch notes in browser tabs.",
+      });
+      return;
+    }
+    const nextOpen = !open;
+    if (nextOpen) {
+      updatePosition();
+      setLoading(true);
+      setTabs([]);
+      setSelected(new Set());
+      sendBridgeMessage("get-recent-viewed-tabs");
+      // If the extension service worker doesn't respond within 5s, show an actionable message
+      fetchTimeoutRef.current = setTimeout(() => {
+        setLoading(false);
+        setTabs([]);
+      }, 5000);
+    } else {
+      if (fetchTimeoutRef.current) clearTimeout(fetchTimeoutRef.current);
+    }
+    setOpen(nextOpen);
+  }, [open, updatePosition]);
+
+  const toggleTab = useCallback((tabId: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(tabId)) next.delete(tabId);
+      else next.add(tabId);
+      return next;
+    });
+  }, []);
+
+  const handleSend = useCallback(() => {
+    if (selected.size === 0) return;
+    setSending(true);
+    sendBridgeMessage("send-note-to-tabs", {
+      contentId,
+      contentKind,
+      tabIds: Array.from(selected),
+    });
+  }, [contentId, contentKind, selected]);
+
+  const popover = open
+    ? createPortal(
+        <div
+          ref={popoverRef}
+          style={popoverStyle}
+          className="overflow-hidden rounded-xl border border-border bg-popover shadow-lg"
+        >
+          <div className="border-b border-border px-3 py-2.5">
+            <p className="text-xs font-semibold text-foreground">Launch in browser tab</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Recent pages with the extension active
+            </p>
+          </div>
+
+          <div className="max-h-56 overflow-y-auto">
+            {loading && (
+              <p className="px-3 py-3 text-xs text-muted-foreground">Fetching recent tabs…</p>
+            )}
+            {!loading && tabs.length === 0 && (
+              <p className="px-3 py-3 text-xs text-muted-foreground">
+                No recent pages found — browse a few pages with the extension active, then try again.
+              </p>
+            )}
+            {tabs.map((tab) => (
+              <button
+                key={tab.tabId}
+                type="button"
+                onClick={() => toggleTab(tab.tabId)}
+                className="flex w-full items-center gap-2.5 px-3 py-2 text-left hover:bg-muted"
+              >
+                <div
+                  className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors ${
+                    selected.has(tab.tabId)
+                      ? "border-primary bg-primary"
+                      : "border-border bg-transparent"
+                  }`}
+                >
+                  {selected.has(tab.tabId) && (
+                    <svg viewBox="0 0 12 12" className="h-3 w-3 fill-primary-foreground">
+                      <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+                    </svg>
+                  )}
+                </div>
+                {tab.favIconUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={tab.favIconUrl} alt="" className="h-4 w-4 shrink-0 rounded-sm" />
+                ) : (
+                  <div className="h-4 w-4 shrink-0 rounded-sm bg-muted" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-medium text-foreground">
+                    {tab.title || "Untitled page"}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {relativeTime(tab.lastViewedAt)}
+                  </p>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {!loading && tabs.length > 0 && (
+            <div className="border-t border-border px-3 py-2">
+              <button
+                type="button"
+                disabled={selected.size === 0 || sending}
+                onClick={handleSend}
+                className="w-full rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {sending
+                  ? "Launching…"
+                  : `Launch in ${selected.size === 0 ? "selected" : selected.size === 1 ? "1 tab" : `${selected.size} tabs`}`}
+              </button>
+            </div>
+          )}
+        </div>,
+        document.body
+      )
+    : null;
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={handleOpen}
+        className="flex shrink-0 items-center gap-1.5 rounded-md px-1.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        title="Launch in browser tab"
+      >
+        <MonitorPlay className="h-4 w-4" />
+      </button>
+      {popover}
+    </>
+  );
+}

--- a/extensions/publishing/blocks/stats-table.ts
+++ b/extensions/publishing/blocks/stats-table.ts
@@ -12,9 +12,9 @@
  *
  * Attrs:
  * - caption    optional heading above the table
- * - items      JSON string: [{label, value, valueType?, highlight?}]
+ * - items      JSON string: [{label, value, valueType?, highlight?, pillColor?}]
+ *              pillColor per item: neutral | auto (djb2 hash) | blue | green | amber | purple | rose | teal | pastel
  * - variant    default | striped | bordered | compact | featured
- * - pillColor  neutral | blue | green | amber | purple | rose | teal | pastel | rainbow
  * - showBorder boolean — hides the block chrome border when false
  */
 
@@ -35,6 +35,7 @@ export interface StatsTableItem {
   value: string;
   valueType?: StatsValueType;
   highlight?: boolean;
+  pillColor?: string;
 }
 
 // ─── Value parsers ────────────────────────────────────────────────────────────
@@ -59,6 +60,31 @@ function parseRating(value: string): { filled: number; total: number } {
 function parseBool(value: string): boolean {
   return /^(true|yes|1|✓|y|on)$/i.test(value.trim());
 }
+
+// ─── Hash-based pill coloring ─────────────────────────────────────────────────
+
+const HASH_COLORS = ["blue", "green", "amber", "purple", "rose", "teal"] as const;
+type HashColor = typeof HASH_COLORS[number];
+
+/** djb2 hash: maps a pill label string to one of 6 semantic color names.
+ *  Same string always yields the same color across different stats blocks. */
+function hashPillText(text: string): HashColor {
+  let hash = 5381;
+  for (let i = 0; i < text.length; i++) {
+    hash = ((hash << 5) + hash + text.charCodeAt(i)) | 0;
+  }
+  return HASH_COLORS[Math.abs(hash) % HASH_COLORS.length];
+}
+
+/** Inline style tokens for hash-colored pills in the editor preview (no CSS class available). */
+const HASH_PILL_STYLES: Record<HashColor, { bg: string; fg: string; border: string }> = {
+  blue:   { bg: "rgba(59,130,246,0.15)",  fg: "#3b82f6", border: "rgba(59,130,246,0.3)" },
+  green:  { bg: "rgba(34,197,94,0.15)",   fg: "#16a34a", border: "rgba(34,197,94,0.3)" },
+  amber:  { bg: "rgba(245,158,11,0.15)",  fg: "#d97706", border: "rgba(245,158,11,0.3)" },
+  purple: { bg: "rgba(168,85,247,0.15)",  fg: "#9333ea", border: "rgba(168,85,247,0.3)" },
+  rose:   { bg: "rgba(244,63,94,0.15)",   fg: "#e11d48", border: "rgba(244,63,94,0.3)" },
+  teal:   { bg: "rgba(20,184,166,0.15)",  fg: "#0d9488", border: "rgba(20,184,166,0.3)" },
+};
 
 // ─── Schema ──────────────────────────────────────────────────────────────────
 
@@ -109,13 +135,27 @@ const { schema: statsTableSchema, defaults: statsTableDefaults } = createBlockSc
               { value: "true", label: "Highlighted" },
             ],
           },
+          {
+            key: "pillColor",
+            label: "Pill color",
+            type: "select",
+            tooltip: "Color for pills in this row. 'Auto' hashes each pill value to a consistent color across all stats blocks.",
+            showWhen: { key: "valueType", value: "pills" },
+            options: [
+              { value: "neutral", label: "Neutral (default)" },
+              { value: "auto", label: "Auto (by value)" },
+              { value: "blue", label: "Blue" },
+              { value: "green", label: "Green" },
+              { value: "amber", label: "Amber" },
+              { value: "purple", label: "Purple" },
+              { value: "rose", label: "Rose" },
+              { value: "teal", label: "Teal" },
+              { value: "pastel", label: "Pastel (rainbow)" },
+            ],
+          },
         ],
       }),
     variant: z.enum(["default", "striped", "bordered", "compact", "featured"]).default("default"),
-    pillColor: z
-      .enum(["neutral", "blue", "green", "amber", "purple", "rose", "teal", "pastel", "rainbow"])
-      .default("neutral")
-      .describe("Color theme applied to pill badges and ratings"),
     showBorder: z
       .boolean()
       .default(true)
@@ -147,7 +187,6 @@ function statsTableAttrs() {
     caption: dataAttr("caption", { default: "" }),
     items: dataAttr("items", { default: "[]" }),
     variant: dataAttr("variant", { default: "default" }),
-    pillColor: dataAttr("pill-color", { default: "neutral" }),
     showBorder: {
       default: true,
       parseHTML: (el: Element) => el.getAttribute("data-show-border") !== "false",
@@ -159,9 +198,20 @@ function statsTableAttrs() {
 
 // ─── Editor preview HTML (uses CSS vars for theme/dark-mode) ─────────────────
 
-function pillsHtml(value: string): string {
+function pillsHtml(value: string, pillColor = "neutral"): string {
+  const BASE = "display:inline-block;padding:1px 8px;margin:1px 3px 1px 0;border-radius:999px;font-size:11px;font-weight:500;white-space:nowrap;border:1px solid";
   return parsePills(value)
-    .map((p) => `<span style="display:inline-block;padding:1px 8px;margin:1px 3px 1px 0;border-radius:999px;font-size:11px;font-weight:500;background:var(--st-pill-bg);color:var(--st-pill-color);border:1px solid var(--st-pill-border);white-space:nowrap">${p}</span>`)
+    .map((p) => {
+      if (pillColor === "auto") {
+        const c = HASH_PILL_STYLES[hashPillText(p)];
+        return `<span style="${BASE} ${c.border};background:${c.bg};color:${c.fg}">${p}</span>`;
+      }
+      const named = HASH_PILL_STYLES[pillColor as HashColor];
+      if (named) {
+        return `<span style="${BASE} ${named.border};background:${named.bg};color:${named.fg}">${p}</span>`;
+      }
+      return `<span style="${BASE} var(--st-pill-border);background:var(--st-pill-bg);color:var(--st-pill-color)">${p}</span>`;
+    })
     .join("");
 }
 
@@ -183,7 +233,7 @@ function booleanHtml(value: string): string {
 function renderValueContent(item: StatsTableItem, isHighlight: boolean, variant: string): string {
   switch (item.valueType) {
     case "pills":
-      return `<span style="display:flex;flex-wrap:wrap;gap:2px;align-items:center">${pillsHtml(item.value)}</span>`;
+      return `<span style="display:flex;flex-wrap:wrap;gap:2px;align-items:center">${pillsHtml(item.value, item.pillColor ?? "neutral")}</span>`;
     case "rating":
       return ratingHtml(item.value);
     case "boolean":
@@ -270,18 +320,10 @@ export const StatsTable = Node.create({
       renderContent(node, contentDom) {
         contentDom.className = "block-stats-table-editor";
         const a = node.attrs as Record<string, string>;
-        if (a.pillColor && a.pillColor !== "neutral") {
-          contentDom.setAttribute("data-pill-color", a.pillColor);
-        }
         contentDom.innerHTML = editorHtml(parseItems(a.items), a.variant, a.caption);
       },
       updateContent(node, contentDom) {
         const a = node.attrs as Record<string, string>;
-        if (a.pillColor && a.pillColor !== "neutral") {
-          contentDom.setAttribute("data-pill-color", a.pillColor);
-        } else {
-          contentDom.removeAttribute("data-pill-color");
-        }
         contentDom.innerHTML = editorHtml(parseItems(a.items), a.variant, a.caption);
         return true;
       },
@@ -306,11 +348,6 @@ export const ServerStatsTable = Node.create({
     const items = parseItems(HTMLAttributes["data-items"] ?? "[]");
     const variant = (HTMLAttributes["data-variant"] ?? "default") as string;
     const caption = (HTMLAttributes["data-caption"] ?? "") as string;
-    const pillColor = (HTMLAttributes["data-pill-color"] ?? "neutral") as string;
-
-    const pillClass = pillColor !== "neutral"
-      ? `block-stats-table-pill block-stats-table-pill--${pillColor}`
-      : "block-stats-table-pill";
 
     const rows = items.map((item) => {
       const isPills = item.valueType === "pills";
@@ -322,12 +359,22 @@ export const ServerStatsTable = Node.create({
         isRating ? "block-stats-table-row--rating" : "",
       ].filter(Boolean).join(" ");
 
+      const rowPillColor = item.pillColor ?? "neutral";
+
       let valueChildren: unknown[];
       if (isPills) {
-        valueChildren = parsePills(item.value).map((p) => ["span", { class: pillClass }, p]);
+        if (rowPillColor === "auto") {
+          valueChildren = parsePills(item.value).map((p) => ["span", { class: `block-stats-table-pill block-stats-table-pill--${hashPillText(p)}` }, p]);
+        } else {
+          const pillClass = rowPillColor !== "neutral"
+            ? `block-stats-table-pill block-stats-table-pill--${rowPillColor}`
+            : "block-stats-table-pill";
+          valueChildren = parsePills(item.value).map((p) => ["span", { class: pillClass }, p]);
+        }
       } else if (isRating) {
         const { filled, total } = parseRating(item.value);
-        const dotClass = `block-stats-table-dot block-stats-table-dot--${pillColor !== "neutral" ? pillColor : "default"}`;
+        const dotColor = (rowPillColor !== "neutral" && rowPillColor !== "auto") ? rowPillColor : "default";
+        const dotClass = `block-stats-table-dot block-stats-table-dot--${dotColor}`;
         valueChildren = [
           ["span", { class: "block-stats-table-rating" },
             ...Array.from({ length: total }, (_, i) =>

--- a/lib/domain/ai/middleware/index.ts
+++ b/lib/domain/ai/middleware/index.ts
@@ -12,6 +12,8 @@ import {
 } from "ai";
 
 export { defaultSettingsMiddleware } from "./default-settings";
+export { rateLimitRetryMiddleware } from "./rate-limit-retry";
+export type { RateLimitRetryOptions } from "./rate-limit-retry";
 
 /** The concrete model type that wrapLanguageModel accepts. */
 type ConcreteModel = Parameters<typeof wrapLanguageModel>[0]["model"];

--- a/lib/domain/ai/middleware/rate-limit-retry.ts
+++ b/lib/domain/ai/middleware/rate-limit-retry.ts
@@ -1,0 +1,112 @@
+/**
+ * Cross-provider rate-limit retry middleware.
+ *
+ * Wraps both generate and stream calls. When a rate-limit error (HTTP 429 or
+ * provider-specific message) is detected before a response begins, the
+ * middleware waits — using the provider-supplied retry-after time when
+ * available, falling back to exponential backoff — then retries.
+ *
+ * Works with OpenAI, Anthropic, Google, Vercel AI Gateway, and any provider
+ * that either sets a Retry-After header or embeds the wait time in the error
+ * message. Does not retry errors that are not rate-limit related.
+ */
+
+import type { LanguageModelMiddleware } from "ai";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRateLimitError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  // Standard HTTP 429 — surfaced by AI SDK as statusCode on APICallError
+  if (
+    "statusCode" in error &&
+    (error as { statusCode: unknown }).statusCode === 429
+  ) {
+    return true;
+  }
+  if (error instanceof Error) {
+    const msg = error.message.toLowerCase();
+    return (
+      msg.includes("rate_limit") ||
+      msg.includes("rate limit") ||
+      msg.includes("resource_exhausted") || // Google
+      msg.includes("too many requests") ||
+      msg.includes("tokens per min") || // OpenAI TPM message
+      msg.includes("requests per min") // OpenAI RPM message
+    );
+  }
+  return false;
+}
+
+/**
+ * Extract a concrete wait duration from the error, if the provider gave one.
+ *
+ * Checks:
+ *  1. Retry-After / x-ratelimit-reset-requests response header
+ *  2. OpenAI error message format: "Please try again in 6.604s"
+ *
+ * Returns milliseconds, or null when nothing useful was found.
+ */
+function extractRetryAfterMs(error: unknown): number | null {
+  if (!error || typeof error !== "object") return null;
+
+  const headers = (
+    error as { responseHeaders?: Record<string, string> }
+  ).responseHeaders;
+  if (headers) {
+    const raw =
+      headers["retry-after"] ?? headers["x-ratelimit-reset-requests"];
+    if (raw) {
+      const seconds = parseFloat(raw);
+      if (!isNaN(seconds) && seconds > 0) return Math.ceil(seconds * 1000);
+    }
+  }
+
+  if (error instanceof Error) {
+    const match = error.message.match(/try again in ([\d.]+)s/i);
+    if (match?.[1]) return Math.ceil(parseFloat(match[1]) * 1000);
+  }
+
+  return null;
+}
+
+export interface RateLimitRetryOptions {
+  /** Maximum number of retries after the initial attempt. Default: 3 */
+  maxRetries?: number;
+  /** Base delay for exponential backoff when no retry-after hint is given. Default: 1000ms */
+  baseDelayMs?: number;
+  /** Upper bound on any computed delay. Default: 30_000ms */
+  maxDelayMs?: number;
+}
+
+export function rateLimitRetryMiddleware(
+  options: RateLimitRetryOptions = {},
+): LanguageModelMiddleware {
+  const { maxRetries = 3, baseDelayMs = 1000, maxDelayMs = 30_000 } = options;
+
+  async function withRetry<T>(fn: () => PromiseLike<T>): Promise<T> {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await fn();
+      } catch (error) {
+        const isLast = attempt === maxRetries;
+        if (!isRateLimitError(error) || isLast) throw error;
+
+        const suggested = extractRetryAfterMs(error);
+        const backoff = Math.min(baseDelayMs * Math.pow(2, attempt), maxDelayMs);
+        await sleep(suggested ?? backoff);
+      }
+    }
+    // Unreachable — the loop always either returns or throws. TypeScript needs
+    // this to be satisfied for the return type.
+    throw new Error("Rate limit retry exhausted");
+  }
+
+  return {
+    specificationVersion: "v3",
+    wrapGenerate: ({ doGenerate }) => withRetry(doGenerate),
+    wrapStream: ({ doStream }) => withRetry(doStream),
+  };
+}

--- a/lib/domain/ai/system-prompt.ts
+++ b/lib/domain/ai/system-prompt.ts
@@ -1,0 +1,113 @@
+/**
+ * AI Chat System Prompt
+ *
+ * Modular system prompt builder. Only sections relevant to the active tool
+ * set are included — keeping per-request token cost proportional to what the
+ * model actually needs for this turn.
+ *
+ * Sections:
+ *  BASE_PROMPT      — always included (~30 tokens)
+ *  IMAGE_SECTION    — when generate_image is in the active tool set
+ *  flashcardSection — when flashcard tools are active (cross-tool workflow rules)
+ *  editorSection    — when editor tools are active (document is open)
+ *  chatContentSection — when the chat is itself a content node (full-page chat)
+ *
+ * Tool-specific documentation (what each tool does, its arguments, limits)
+ * lives in the tool's own `description` and `inputSchema` field descriptions.
+ * This file only carries rules that span multiple tools or that govern
+ * conversation-level behavior (when to stop, how to format cards, etc.).
+ */
+
+// ─── Base ─────────────────────────────────────────────────────────────────
+
+const BASE_PROMPT = `\
+You are an AI assistant in Digital Garden, a personal knowledge management app.
+Be concise, accurate, and helpful. Prefer short responses unless the user asks for depth.\
+`;
+
+// ─── Image ────────────────────────────────────────────────────────────────
+
+const IMAGE_SECTION = `\
+## Image Generation
+Use the generate_image tool when asked to create, draw, or generate an image.
+Write specific, detailed prompts for best results.\
+`;
+
+// ─── Flashcards ───────────────────────────────────────────────────────────
+
+function flashcardSection(autoPronounceDefault: boolean): string {
+  const autoPronounce = autoPronounceDefault
+    ? `\n- DEFAULT: for non-English vocabulary (or scientific/Latin names), add audio:{ side: "front" } to every card unless the user says they don't want it. Generation is opt-in — you're only attaching the directive.`
+    : "";
+
+  return `\
+## Flashcards
+
+**Vocabulary:** "skill" and "deck" are interchangeable — both mean a flashcard deck. "sub-skill" = nested deck. Never name a deck "Skill" or "Deck" — name it after the actual topic.
+
+**Path hierarchy:** Every deck must have a named root skill as its first path segment — the language, course, or subject domain (e.g. "spanish", "biology", "anatomy"). When a user asks for "Spanish verb cards," the right path is "spanish/verbs", NOT "general/verbs". Infer the root skill from the topic; never use generic placeholders ("general", "misc", "other") as the root segment.
+
+**Card format:**
+- Front: the bare term being tested. No definitions, examples, or context on the front.
+- Back: translation, definition, or mnemonic.
+- Language decks: always include pronunciation on the back — romanization for non-Latin scripts (kana→romaji, →pinyin with tones, Arabic→transliteration), IPA or phonetic respelling for Latin-script languages with non-obvious pronunciation. Put the translation on line 1, pronunciation in parentheses on line 2.
+- Use frontLabel/backLabel when it clarifies the card (e.g. "Term" / "Translation").
+
+**Audio:** Add audio:{ side: "front" } to a card in propose_deck_with_cards to attach spoken pronunciation. Use hideText: true for listening-comprehension cards (the spoken text becomes the question; put the transcription on the back). Audio is generated later, after the user picks a voice — never auto-billed.${autoPronounce}
+
+**After proposing:** Once you call propose_deck_with_cards, stop. The proposal card in the chat UI is the confirmation — clicking "Create deck & add" is how the user commits. Do not ask "shall I create?" in text.\
+`;
+}
+
+// ─── Editor ───────────────────────────────────────────────────────────────
+
+function editorSection(contentId: string): string {
+  return `\
+## Document Editing (open document ID: ${contentId})
+You have tools to read and edit the currently open document.
+
+- Always call read_first_chunk before making any edits.
+- Use apply_diff for ALL targeted changes — adding, inserting, appending, or editing content. Adding a sentence or paragraph = apply_diff, not replace_document.
+- NEVER use replace_document unless the user explicitly asks to rewrite or overwrite the entire document.
+- Call finish_with_summary when you are done editing.
+- Generated images can be inserted at the user's cursor position.\
+`;
+}
+
+// ─── Chat content (full-page chat node) ──────────────────────────────────
+
+function chatContentSection(contentId: string): string {
+  return `\
+## Chat Notes Panel (this chat's ID: ${contentId})
+This chat has an attached notes panel (a TipTap editor keyed to this chat's contentId).
+- To write to the notes panel: updateNote({ contentId: "${contentId}", content: "..." }). Never set title — that renames the chat.
+- To create a separate new note: use createNote (defaults to this chat's parent folder).
+- To edit a different note by name: use searchNotes to find its id, then updateNote with that id.\
+`;
+}
+
+// ─── Builder ──────────────────────────────────────────────────────────────
+
+export interface SystemPromptContext {
+  hasImageTools: boolean;
+  hasFlashcardTools: boolean;
+  editableContentId: string | undefined;
+  isChatContent: boolean;
+  chatContentId: string | undefined;
+  autoPronounceDefault: boolean;
+  userContextSection: string;
+  mentionedContext: string;
+}
+
+export function buildSystemPrompt(ctx: SystemPromptContext): string {
+  const sections: string[] = [BASE_PROMPT];
+
+  if (ctx.hasImageTools) sections.push(IMAGE_SECTION);
+  if (ctx.hasFlashcardTools) sections.push(flashcardSection(ctx.autoPronounceDefault));
+  if (ctx.editableContentId) sections.push(editorSection(ctx.editableContentId));
+  if (ctx.isChatContent && ctx.chatContentId) sections.push(chatContentSection(ctx.chatContentId));
+  if (ctx.userContextSection) sections.push(ctx.userContextSection);
+  if (ctx.mentionedContext) sections.push(ctx.mentionedContext);
+
+  return sections.join("\n\n");
+}

--- a/lib/domain/ai/tools/editor-tools.ts
+++ b/lib/domain/ai/tools/editor-tools.ts
@@ -198,7 +198,7 @@ export function createEditorTools(ctx: ToolExecuteContext) {
     // editor.commands.setContent() with the converted TipTap JSON.
     replace_document: tool({
       description:
-        "Replace the entire document content with new markdown. Use for major rewrites or when apply_diff would require too many individual changes. Preserves the document title and metadata.",
+        "Replace the ENTIRE document content with new markdown. Use ONLY when the user explicitly asks to rewrite or replace the whole document. NEVER use this to add, append, insert, or make targeted changes — use apply_diff for all of those. Preserves the document title and metadata.",
       inputSchema: z.object({
         markdown: z
           .string()

--- a/lib/domain/ai/tools/flashcard-tools.ts
+++ b/lib/domain/ai/tools/flashcard-tools.ts
@@ -404,11 +404,15 @@ export function createFlashcardTools(ctx: ToolExecuteContext) {
               front: z
                 .string()
                 .min(1)
-                .describe("Question / prompt side of the card (plain text)."),
+                .describe(
+                  "The term or prompt being tested — keep it concise, bare term only. No definitions, examples, or context on the front.",
+                ),
               back: z
                 .string()
                 .min(1)
-                .describe("Answer side of the card (plain text)."),
+                .describe(
+                  "The answer, definition, or translation. For language cards, always include pronunciation here: romanization for non-Latin scripts (kana→romaji, →pinyin with tones, Arabic→transliteration), or IPA/phonetic respelling for Latin-script languages with non-obvious pronunciation.",
+                ),
               frontLabel: z
                 .string()
                 .max(80)

--- a/lib/domain/browser-extension/service.ts
+++ b/lib/domain/browser-extension/service.ts
@@ -15,6 +15,12 @@ function asIsoString(value: Date | null | undefined) {
   return value ? value.toISOString() : null;
 }
 
+function effectiveUpdatedAt(nodeUpdatedAt: Date, payloadUpdatedAt: Date | null | undefined) {
+  const nodeMs = nodeUpdatedAt.getTime();
+  const payloadMs = payloadUpdatedAt ? payloadUpdatedAt.getTime() : 0;
+  return new Date(Math.max(nodeMs, payloadMs)).toISOString();
+}
+
 function trimNullable(value: string | null | undefined, maxLength = 2048) {
   if (value === undefined) return undefined;
   if (value === null) return null;
@@ -408,6 +414,7 @@ type TreeNode = {
   slug: string;
   contentType: string;
   displayOrder: number;
+  updatedAt: string;
   customIcon: string | null;
   iconColor: string | null;
   folder: {
@@ -425,6 +432,20 @@ type TreeNode = {
   selectable: boolean;
   children: TreeNode[];
 };
+
+function getContentPickerTitle(node: {
+  title: string;
+  slug: string;
+  contentType: string;
+}) {
+  const title = node.title.trim();
+  if (title) return title;
+
+  const slug = node.slug.trim();
+  if (slug) return slug;
+
+  return `Untitled ${node.contentType}`;
+}
 
 export async function getExtensionContentPickerTree(
   userId: string,
@@ -480,6 +501,12 @@ export async function getExtensionContentPickerTree(
           engine: true,
         },
       },
+      notePayload: {
+        select: {
+          updatedAt: true,
+        },
+      },
+      updatedAt: true,
     },
   });
 
@@ -500,10 +527,11 @@ export async function getExtensionContentPickerTree(
       })
       .map((node) => ({
         id: node.id,
-        title: node.title,
+        title: getContentPickerTitle(node),
         slug: node.slug,
         contentType: node.contentType,
         displayOrder: node.displayOrder,
+        updatedAt: effectiveUpdatedAt(node.updatedAt, node.notePayload?.updatedAt),
         customIcon: node.customIcon,
         iconColor: node.iconColor,
         folder: node.folderPayload
@@ -543,10 +571,11 @@ export async function getExtensionContentPickerTree(
     if (!item) return null;
     return {
       id: item.id,
-      title: item.title,
+      title: getContentPickerTitle(item),
       slug: item.slug,
       contentType: item.contentType,
       displayOrder: item.displayOrder,
+      updatedAt: effectiveUpdatedAt(item.updatedAt, item.notePayload?.updatedAt),
       customIcon: item.customIcon,
       iconColor: item.iconColor,
       folder: item.folderPayload ? { viewMode: item.folderPayload.viewMode } : null,

--- a/lib/domain/content/outline-extractor.ts
+++ b/lib/domain/content/outline-extractor.ts
@@ -14,6 +14,7 @@ export interface OutlineHeading {
   level: number; // 1-6 (H1-H6)
   text: string; // Heading text content
   position: number; // Node position in document (for scroll-to)
+  kind?: "heading" | "accordion"; // source node type
 }
 
 /**
@@ -102,7 +103,18 @@ export function extractOutline(tiptapJson: JSONContent): OutlineHeading[] {
           level,
           text: text.trim(),
           position: pos,
+          kind: "heading",
         });
+      }
+    }
+
+    // Check if this node is an accordion block (title lives in attrs, not content)
+    if (node.type === "accordion" && node.attrs?.headerText) {
+      const text = (node.attrs.headerText as string).trim();
+      const level = parseInt((node.attrs.headerLevel as string) || "2", 10);
+      if (text) {
+        const id = generateAnchorId(text, existingIds);
+        headings.push({ id, level, text, position: pos, kind: "accordion" });
       }
     }
 

--- a/lib/domain/editor/ai/edit-orchestrator.ts
+++ b/lib/domain/editor/ai/edit-orchestrator.ts
@@ -22,6 +22,7 @@
  */
 
 import type { Editor } from "@tiptap/react";
+import type { JSONContent } from "@tiptap/core";
 import { TextSelection } from "@tiptap/pm/state";
 import { findTextInDoc } from "./text-search";
 import { markdownToTiptap } from "@/lib/domain/content/markdown";
@@ -35,6 +36,7 @@ export interface ApplyDiffPayload {
   after: string;
   documentTitle: string;
   action: string;
+  toolCallId?: string;
 }
 
 export interface ReplaceDocumentPayload {
@@ -43,6 +45,7 @@ export interface ReplaceDocumentPayload {
   markdown: string;
   documentTitle: string;
   action: string;
+  toolCallId?: string;
 }
 
 export interface InsertImagePayload {
@@ -52,6 +55,7 @@ export interface InsertImagePayload {
   alt: string;
   documentTitle: string;
   action: string;
+  toolCallId?: string;
 }
 
 export type EditPayload = ApplyDiffPayload | ReplaceDocumentPayload | InsertImagePayload;
@@ -60,6 +64,10 @@ export interface EditResult {
   success: boolean;
   action: string;
   error?: string;
+  /** Document state captured immediately before this edit was applied. Present only on success. */
+  snapshot?: JSONContent;
+  /** The tool call ID that triggered this edit, for associating the revert with the chat UI. */
+  toolCallId?: string;
 }
 
 // ─── Constants ───────────────────────────────────────────────
@@ -214,14 +222,25 @@ export class AiEditOrchestrator {
   // ─── Edit execution ────────────────────────────────────────
 
   private async executeEdit(payload: EditPayload): Promise<EditResult> {
+    // Capture document state before applying the edit so the UI can offer revert.
+    const snapshot = this.getEditor()?.getJSON();
+
+    let result: EditResult;
     if (payload.type === "apply_diff") {
-      return this.executeApplyDiff(payload);
+      result = await this.executeApplyDiff(payload);
     } else if (payload.type === "replace_document") {
-      return this.executeReplaceDocument(payload);
+      result = await this.executeReplaceDocument(payload);
     } else if (payload.type === "insert_image") {
-      return this.executeInsertImage(payload);
+      result = await this.executeInsertImage(payload);
+    } else {
+      return { success: false, action: "Unknown edit type", error: "Unknown payload type" };
     }
-    return { success: false, action: "Unknown edit type", error: "Unknown payload type" };
+
+    if (result.success && snapshot) {
+      result.snapshot = snapshot;
+      result.toolCallId = payload.toolCallId;
+    }
+    return result;
   }
 
   private async executeApplyDiff(payload: ApplyDiffPayload): Promise<EditResult> {

--- a/lib/domain/editor/extensions/blocks/accordion.ts
+++ b/lib/domain/editor/extensions/blocks/accordion.ts
@@ -336,15 +336,25 @@ export const Accordion = Node.create({
     return ({ node: initialNode, getPos, editor }) => {
       let currentNode = initialNode;
 
-      // Auto-assign blockId if missing
+      // Auto-assign blockId if missing. Deferred via queueMicrotask to avoid
+      // calling editor.view.dispatch() while ProseMirror's updateState is still
+      // running (addNodeView is called from within docView.update). A synchronous
+      // dispatch here triggers a re-entrant updateState, which can cause PM to
+      // register the wrong NodeView instance — leaving currentNode.attrs.blockId
+      // as null and breaking all subsequent blockId-keyed event dispatches.
       if (!currentNode.attrs.blockId && typeof getPos === "function") {
-        const pos = getPos();
-        if (pos !== undefined) {
-          const newId = crypto.randomUUID();
+        const newId = crypto.randomUUID();
+        queueMicrotask(() => {
+          const pos = getPos();
+          if (pos === undefined) return;
+          const existingNode = editor.state.doc.nodeAt(pos);
+          // Skip if another path already assigned a blockId
+          if (!existingNode || existingNode.attrs.blockId) return;
           const { tr } = editor.state;
-          tr.setNodeMarkup(pos, undefined, { ...currentNode.attrs, blockId: newId });
+          // Spread CURRENT node.attrs so any headerText already typed is preserved
+          tr.setNodeMarkup(pos, undefined, { ...existingNode.attrs, blockId: newId });
           editor.view.dispatch(tr);
-        }
+        });
       }
 
       const dom = document.createElement("div");
@@ -484,6 +494,16 @@ export const Accordion = Node.create({
               detail: { blockId, key: "headerText", value: text },
             })
           );
+        } else if (typeof getPos === "function") {
+          // blockId not yet assigned (microtask pending) — dispatch directly so
+          // PM attrs.headerText stays in sync with user typing even before the
+          // blockId queueMicrotask fires.
+          const pos = getPos();
+          if (pos !== undefined) {
+            const { tr } = editor.state;
+            tr.setNodeMarkup(pos, undefined, { ...currentNode.attrs, headerText: text });
+            editor.view.dispatch(tr);
+          }
         }
       });
 
@@ -543,6 +563,14 @@ export const Accordion = Node.create({
           window.dispatchEvent(new CustomEvent("block-attrs-change", {
             detail: { blockId, key: "headerText", value: text },
           }));
+        } else if (typeof getPos === "function") {
+          // blockId still unassigned — direct positional dispatch as fallback
+          const pos = getPos();
+          if (pos !== undefined) {
+            const { tr } = editor.state;
+            tr.setNodeMarkup(pos, undefined, { ...currentNode.attrs, headerText: text });
+            editor.view.dispatch(tr);
+          }
         }
       });
       // Stop beforeinput/input from reaching ProseMirror's input handler

--- a/public/digital-garden-tree.svg
+++ b/public/digital-garden-tree.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="uuid-4697f3b3-58d5-49b3-ac15-392af1934a89" data-name="starting-animation" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560.86 540.14">
+  <g id="uuid-434b8b2a-785a-4977-8aef-4ba4af96105c" data-name="rootSystem">
+    <polyline points="229.88 388.61 203.31 413.88 150.37 413.88 113.14 450.82" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="105.66" cy="457.22" r="7.79" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="216.32 458.72 198.3 477.05 198.3 505.06" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <polyline points="280.86 396.21 292.34 406.49 292.34 453.9 310.41 473.06 310.41 515.95" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="310.55" cy="524.21" r="6.53" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="329.33 390.21 355.95 413.88 411.84 413.88 448.78 450.82" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="453.73" cy="457.29" r="6.93" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="346.32 458.72 362.36 477.05 362.36 503.83" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <polyline points="258.77 400.8 258.77 434.44 240.95 452.36 240.95 460.98" style="fill: none; stroke: #e4c288; stroke-miterlimit: 10; stroke-width: 5px;"/>
+    <polyline points="209.53 503.71 209.53 489.28 240.95 458.72 240.95 473.99 234.07 481.22 234.07 502.5" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="209.22" cy="512.72" r="6.48" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="233.57" cy="509.24" r="4.78" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="280.11 454.35 280.01 460.98 292.34 471.9" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="296.58" cy="475.03" r="4.77" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <path d="M280.01,460.98s-11.13,10.73-11.13,14.31c0,7.74,18.23,18.53,20.91,26.3.61,1.77.41,8.21-1.72,10.66-2.56,2.94-7.21,2.02-7.21,5.77,0,8.41-.26,20.13-.75,20.12" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="317.88 458.72 317.88 472.47 327.73 482.25 327.73 503.71" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 3px;"/>
+    <circle cx="327.94" cy="509.55" r="4.48" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="351.92" cy="512.25" r="5.77" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="251.16" cy="524.47" r="5.27" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="351.92 506.49 352.01 490.35 320.09 458.43" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="301.94 398.84 301.94 435.01 318.88 452.51 318.88 456.09" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="220.42" cy="454.66" r="5.84" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="155.64" cy="435.76" r="5.27" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="405.32" cy="434.67" r="6.52" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="250.84 518.02 250.84 471.43 268.91 453.64 268.91 406.21 279.52 398.84" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <line x1="362.36" y1="434.44" x2="397.94" y2="434.44" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <line x1="196.15" y1="435.76" x2="160.76" y2="435.76" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <path d="M279.92,380l.19,74.35-.19-74.35Z" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <polyline points="320.39 394.44 380.15 452.36 412.18 452.36" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="238.69 394.44 182.6 450.82 147.21 450.82" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="391.95" cy="495.51" r="8.32" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="171.19" cy="494.23" r="8.27" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <line x1="388.91" y1="477.05" x2="388.91" y2="486.96" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <line x1="171.55" y1="477.05" x2="171.55" y2="484.96" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 6px;"/>
+    <circle cx="428.33" cy="476.23" r="5.27" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="129.8" cy="476.23" r="5.27" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="422.79 475.29 384.76 475.29 318.88 411.67" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="135.54 475.29 176.2 475.29 219.78 432.47 240.95 411.67" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="261.62 342.47 203.31 400.92 117.35 400.92" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="298.6 344.68 357.69 400.92 439.1 401.5 443.52 401.5" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="451.1" cy="402.23" r="7.79" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="280.11 364.04 310.41 391.52 310.41 422.4 336.39 448.37" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="279.54 364.61 248.63 390.86 248.63 425.26 224.13 448.37" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="341.34" cy="453.9" r="6.08" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="482.56" cy="401.45" r="7.79" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="109.56" cy="401.45" r="7.79" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <circle cx="77.75" cy="400.92" r="7.79" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <line x1="101.76" y1="401.45" x2="85.54" y2="400.92" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <line x1="458.89" y1="402.23" x2="474.77" y2="401.45" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <line x1="69.96" y1="400.92" x2="2" y2="401.5" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <line x1="490.35" y1="401.45" x2="558.86" y2="401.5" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="140.75 401.84 117.35 425.93 85.54 425.93" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="420.81 401.5 443.52 428.14 474.77 428.14" style="fill: none; stroke: #e4c288; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+  </g>
+  <g data-name="shootSystem">
+    <line x1="279.73" y1="378.91" x2="256.74" y2="400.8" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <polyline points="279.73 378.91 283.12 381.92 304.95 402.44" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <line x1="279.73" y1="378.91" x2="279.52" y2="356.88" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 7px;"/>
+    <polyline points="279.54 360.74 279.54 279.01 316.77 247.9" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 7px;"/>
+    <circle cx="324.9" cy="238.94" r="10.46" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <polyline points="279.54 323.57 279.73 272.56 253.56 246.77 227.96 268.98" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 7px;"/>
+    <circle cx="218.5" cy="276.42" r="10.46" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <line x1="280.86" y1="273.25" x2="210.08" y2="202.85" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 6px;"/>
+    <line x1="209.33" y1="203.23" x2="185.52" y2="203.38" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <polyline points="279.54 278.16 279.54 224.51 331.68 180.7 331.68 135.71" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 7px;"/>
+    <circle cx="331.68" cy="124.42" r="10.46" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <polyline points="279.54 228.02 279.54 169.74 243.69 134.02" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 7px;"/>
+    <circle cx="235.01" cy="125.25" r="10.46" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <polyline points="279.54 176.94 279.54 124.42 280.11 98.63" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 7px;"/>
+    <polyline points="277.28 122.73 280.11 124.42 284.81 121.78 333.36 85.87" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 6px;"/>
+    <line x1="280.29" y1="125.93" x2="217.32" y2="75.28" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 6px;"/>
+    <circle cx="175.2" cy="203.96" r="10.32" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="342.15" cy="79.25" r="10.46" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="208.04" cy="68.78" r="10.46" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="280.31" cy="79.49" r="15.68" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 7px;"/>
+    <circle cx="238.29" cy="382.99" r="4.22" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 3px;"/>
+    <circle cx="321.73" cy="382.99" r="4.22" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 3px;"/>
+    <polyline points="317.52 378.77 296.86 359.34 296.86 235.29 391.35 159.05 421.09 143.81 422.98 142.87" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="433.55" cy="136.59" r="12.47" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <polyline points="241.71 378.91 262.6 359.71 263.54 286.89 225.33 247.9 164.34 247.9" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="153.4" cy="247.28" r="9.94" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 4px;"/>
+    <polyline points="354.83 187.29 354.83 159.24 364.25 132.51 364.25 130.82" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <line x1="374.6" y1="194.5" x2="347.42" y2="194.5" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <line x1="231.73" y1="223.94" x2="232.73" y2="182.53" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 6px;"/>
+    <circle cx="384.24" cy="192.85" r="8.62" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="366.49" cy="120.53" r="9.13" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <line x1="373.09" y1="113.95" x2="400.2" y2="93.36" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="410.28" cy="86.05" r="10.79" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <polyline points="210.08 202.85 210.08 173.55 196.53 132.14" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 6px;"/>
+    <polyline points="209.33 203.23 179.21 171.48 133.47 148.89 131.59 147.95" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 6px;"/>
+    <circle cx="119.77" cy="142.56" r="12.82" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="193.99" cy="121.25" r="9.32" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <line x1="184.67" y1="115.54" x2="161.14" y2="104.47" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 6px;"/>
+    <circle cx="149.77" cy="99.58" r="11.76" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <line x1="279.92" y1="64.94" x2="279.92" y2="23.9" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+    <circle cx="279.98" cy="13.2" r="10.7" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 5px;"/>
+  </g>
+  <circle cx="253.15" cy="404.09" r="3.29" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 3px;"/>
+  <circle cx="308.25" cy="406.21" r="3.29" style="fill: none; stroke: #4FAE8A; stroke-linecap: round; stroke-linejoin: round; stroke-width: 3px;"/>
+</svg>


### PR DESCRIPTION
## Sprint 51 — Security Hardening

Tighten the attack surface across several independent vectors.

- Tighten SSRF blocklist on `validateExternalUrl` (private IP ranges, link-local, metadata endpoints)
- Block cross-user embed-token session fixation
- Sanitize Excalidraw `cachedSvg` before DOM injection
- Escape HTML in search excerpt highlights
- Scrub 5xx error detail from collab token responses
- Remove TLS-bypass instruction from OG preview error messages
- Sanitize Mammoth-converted docx HTML before client render
- Wire per-request nonce for inline scripts (CSP prep)

**Gate:** `pnpm typecheck && pnpm lint`

---

## Sprint 52 — Editor Fidelity

Fix three independent editor regressions: accordion state, image drag-and-drop, and wiki-link click precision.

- Accordion: prevent NodeView reuse across blocks; always persist toggle state to attrs
- Accordion: allow text selection drag; 3-Enter exit; prevent accordion-split on Enter
- Accordion: defer `blockId` auto-assign to avoid re-entrant ProseMirror dispatch
- Image: make wrapper `draggable` unconditionally for reliable D&D trigger
- Image: reposition via direct PM transaction (no `dispatchEvent` short-circuit)
- Wiki-link: use `posAtCoords.inside` to prevent adjacent-node click navigation

**Gate:** manual smoke test of accordion toggle, image drag, wiki-link click

---

## Sprint 53 — Stats-Table Publishing Block

New publishing block for case study key/value metrics tables.

- `extensions/publishing/blocks/stats-table.ts` — schema, client/server TipTap extension, `registerBlock()`
- Per-row `valueType` field: text, number, boolean, rating, or comma-separated pills
- Dark mode CSS (light defaults + `.dark` companions)
- Slash command registration
- Polish: wrap controls, pill accent themes, S/M compactness toggle

**Gate:** `pnpm publishing:schema:check && pnpm publishing:audit:defaults`

---

## Sprint 54 — People + External Link

Two small features that share no code.

- **People `@mention`** — add "Create contact" affordance at the bottom of the suggestion dropdown; `PeopleCreateDialog` improvements
- **External link** — auto-fetch OG metadata when the URL field changes in `ExternalLinkDialog`
- **External link** — dark mode visibility: `text-white` → `text-foreground` in `ExternalViewer`, `dark:` companions for all hardcoded gray text in `ExternalLinkViewer`

**Gate:** manual test of @mention create + OG auto-fetch in dark mode

---

## Sprint 55 — Browser Bookmarks: Phase 5 Iframe

Replace the lossy `contenteditable` capture path with a full app iframe embed.

- `service.ts` — URL validation hardening; domain allowlist for `localhost:3014` / `davidvalentine.org`
- `overlay/index.js` — full iframe embed rewrite (auth bridge wiring, message protocol)
- `background/index.js` — tab message routing for iframe sessions
- `popup/index.js` + `popup.html` — UI updates for iframe mode
- `page-bridge.js` — postMessage relay for cross-frame communication
- `styles.css` — overlay layout for iframe container
- `SendToTabButton.tsx` — React component for triggering tab send from the app

**Gate:** reload in `chrome://extensions`; open overlay on a page; verify iframe loads the app

---

## Sprint 56 — Session Resilience + UI Polish

Auth stability and accumulated UI cleanup across several surfaces.

- Auth: stop session polling immediately on sign-out decision
- Auth: harden against transient DB failures (retry with backoff before 401)
- Auth: remove duplicate `SESSION_RENEW_THRESHOLD_MS` from merge artifact
- Toolbar icon-only styling; sidebar header refinements
- Pane icons in wiki-link submenu; ⌥+Click hint; sub-row gap shading
- Chat error banner dismiss button; flashcard chat overflow; optional pronunciation
- People mention: blue → cyan for readability
- `OutlinePanel`, `MainPanelContent`, `MarkdownEditor`, `ContentToolbar`, `JsonArrayEditor` incremental polish
- Left sidebar reorganization; `PlatformHome` layout updates
- Public site stub pages: community, contact, docs, features, guides, help, notes-system, privacy, status, terms

**Gate:** `pnpm typecheck && pnpm lint`

---

## Sprint 57 — AI: Rate Limiting + Modular System Prompt

Fix the root cause of OpenAI TPM 429s and clean up the system prompt architecture.

- `lib/domain/ai/middleware/rate-limit-retry.ts` — cross-provider retry middleware: detects 429 by status code + message pattern (`rate_limit`, `resource_exhausted`, `too many requests`); parses `Retry-After` and inline `"try again in Xs"` messages; exponential backoff with jitter; wired into `applyMiddleware()` stack in the chat route
- `lib/domain/ai/system-prompt.ts` — `buildSystemPrompt(ctx)` replaces the ~1,500-token monolith; sections are conditional on active tools (`hasImageTools`, `hasFlashcardTools`, `editableContentId`, `isChatContent`); base-only chat costs ~30 tokens
- `replace_document` tool description: explicit "NEVER for adds/appends/inserts — use `apply_diff`"
- Flashcard path hierarchy: "domain-named root" rule restored; `general/` placeholder banned
- Flashcard `front`/`back` field descriptions tightened for cleaner card generation
- Dark mode contrast fixes on flashcard proposal cards (`gray-500→400`, `gray-400→300`)

**Gate:** trigger a 429; verify retry fires. Check `system` token count in network tab before/after.

---

## Sprint 58 — AI Editor: Per-Edit Undo

Document recovery affordance so the user can safely revert any AI edit from the chat.

- `AiEditOrchestrator.executeEdit()` captures `editor.getJSON()` immediately before each edit phase; attaches `snapshot` + `toolCallId` to `EditResult` on success only
- `EditPayload` union types gain `toolCallId?`; threaded from `ChatPanel.enqueue()` call through the orchestrator and back out via `onEditResult`
- `ChatPanel` maintains `revertSnapshotsRef` (map, always-current) + `revertableToolIds` state (Set, drives re-renders); `revertEdit(toolCallId)` calls `editor.commands.setContent(snapshot)` and shows a toast
- `ToolCallBubble` in `ChatMessage` renders a thin "Undo" row for any `__editPayload` result: disabled (greyed, "Applying edit…") while the animation runs, activates when `isRevertable` flips, shows "Reverted ✓" after use

**Gate:** apply_diff undo, replace_document undo, multi-edit per-card undo (see smoke test below)

---

## Pre-merge checklist

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new warnings above ratchet
- [x] `pnpm publishing:schema:check` — stats-table registered
- [x] Browser extension: reload in `chrome://extensions`, verify overlay
- [x] AI chat: Sprint 57 — check `system` token count in network tab; trigger 429 + confirm retry
- [x] AI chat: Sprint 58 — apply_diff undo; replace_document undo; two-edit turn with per-card undo
- [x] Dark mode: flashcard proposals legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)