### PR TITLE
feat: periodic notes overhaul, glide nav, collab resilience, UI polish

### DIFF
--- a/app/api/periodic-notes/neighbors/route.ts
+++ b/app/api/periodic-notes/neighbors/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/database/client";
+import { requireAuth } from "@/lib/infrastructure/auth/middleware";
+import { logger, withRouteTrace } from "@/lib/core/logger";
+
+const ROUTE_PATH = "/api/periodic-notes/neighbors";
+
+interface NeighborNote {
+  id: string;
+  title: string;
+  periodKey: string;
+}
+
+/**
+ * Sparse "glide" navigation between periodic notes.
+ *
+ * Given the currently-open note's contentId, returns the nearest EXISTING
+ * periodic note before and after it in its own sequence (daily or weekly).
+ * "Sparse" = it skips gaps: if you journaled July 3 then July 10, the
+ * neighbor of July 10 going back is July 3, not July 9.
+ *
+ * This leans entirely on PeriodicNoteIndex: `periodKey` (YYYY-MM-DD /
+ * GGGG-[W]WW) sorts lexicographically identically to chronologically, and the
+ * `@@unique([ownerId, kind, periodKey])` constraint is a B-tree index, so each
+ * neighbor lookup is an indexed range seek that stops at the first row.
+ */
+export async function GET(request: NextRequest) {
+  return withRouteTrace(request, { route: ROUTE_PATH }, async () => {
+    try {
+      const session = await requireAuth();
+      const contentId = request.nextUrl.searchParams.get("contentId");
+
+      if (!contentId) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "contentId is required.",
+            },
+          },
+          { status: 400 }
+        );
+      }
+
+      // Reverse-lookup the current note's place in the sequence (indexed via
+      // @@index([contentId])). If it isn't a periodic note, there's nothing to
+      // glide between — the client hides the controls on isPeriodic: false.
+      const current = await prisma.periodicNoteIndex.findFirst({
+        where: { ownerId: session.user.id, contentId },
+        select: { kind: true, periodKey: true },
+      });
+
+      if (!current) {
+        return NextResponse.json({
+          success: true,
+          data: { isPeriodic: false },
+        });
+      }
+
+      const [prev, next] = await Promise.all([
+        findNeighbor(session.user.id, current.kind, current.periodKey, "prev"),
+        findNeighbor(session.user.id, current.kind, current.periodKey, "next"),
+      ]);
+
+      return NextResponse.json({
+        success: true,
+        data: {
+          isPeriodic: true,
+          kind: current.kind,
+          periodKey: current.periodKey,
+          prev,
+          next,
+        },
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to resolve neighbors";
+      const isAuthError = message.toLowerCase().includes("auth");
+      const status = isAuthError ? 401 : 500;
+
+      // Only genuine failures are worth an error-level log; unauthenticated
+      // pokes are expected noise.
+      if (status === 500) {
+        logger.error({
+          layer: "periodic",
+          event: "neighbors:caught",
+          summary: "neighbors failed — 500",
+          error,
+        });
+      }
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: isAuthError ? "UNAUTHORIZED" : "INTERNAL_ERROR",
+            message,
+          },
+        },
+        { status }
+      );
+    }
+  });
+}
+
+async function findNeighbor(
+  ownerId: string,
+  kind: string,
+  periodKey: string,
+  direction: "prev" | "next"
+): Promise<NeighborNote | null> {
+  const row = await prisma.periodicNoteIndex.findFirst({
+    where: {
+      ownerId,
+      kind,
+      periodKey: direction === "prev" ? { lt: periodKey } : { gt: periodKey },
+      // Skip notes that have been trashed — the index row survives soft-delete.
+      content: { deletedAt: null },
+    },
+    orderBy: { periodKey: direction === "prev" ? "desc" : "asc" },
+    select: {
+      periodKey: true,
+      content: { select: { id: true, title: true } },
+    },
+  });
+
+  if (!row?.content) return null;
+  return {
+    id: row.content.id,
+    title: row.content.title,
+    periodKey: row.periodKey,
+  };
+}

--- a/app/api/periodic-notes/resolve/route.ts
+++ b/app/api/periodic-notes/resolve/route.ts
@@ -25,7 +25,13 @@ interface ResolvePeriodicNoteRequest {
 }
 
 function isPeriodicNoteKind(value: unknown): value is PeriodicNoteKind {
-  return value === "daily" || value === "weekly";
+  return (
+    value === "daily" ||
+    value === "weekly" ||
+    value === "monthly" ||
+    value === "quarterly" ||
+    value === "yearly"
+  );
 }
 
 export async function POST(request: NextRequest) {
@@ -41,7 +47,8 @@ export async function POST(request: NextRequest) {
           success: false,
           error: {
             code: "VALIDATION_ERROR",
-            message: "Periodic note kind must be daily or weekly.",
+            message:
+              "Periodic note kind must be daily, weekly, monthly, quarterly, or yearly.",
           },
         },
         { status: 400 }
@@ -57,7 +64,7 @@ export async function POST(request: NextRequest) {
           success: false,
           error: {
             code: "DISABLED",
-            message: `${kind === "daily" ? "Daily" : "Weekly"} notes are disabled.`,
+            message: `${kind.charAt(0).toUpperCase()}${kind.slice(1)} notes are disabled.`,
           },
         },
         { status: 400 }
@@ -68,9 +75,10 @@ export async function POST(request: NextRequest) {
     const period = getPeriodicNotePeriod(
       kind,
       noteSettings.filenameFormat,
-      body.localDateTime
+      body.localDateTime,
+      noteSettings.nightOwlHour
     );
-    const currentMoment = getMomentForPeriodicNote(body.localDateTime);
+    const currentMoment = getMomentForPeriodicNote(body.localDateTime, noteSettings.nightOwlHour);
     const templateJson = await resolveTemplateJson(
       session.user.id,
       noteSettings.templateId

--- a/components/client/nav/ProfileMenu.tsx
+++ b/components/client/nav/ProfileMenu.tsx
@@ -2,11 +2,34 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronDown, Shield, LogOut, MessageSquare, Bug, Settings } from "lucide-react";
+import {
+  ChevronDown,
+  Shield,
+  LogOut,
+  MessageSquare,
+  Bug,
+  Settings,
+  Sun,
+  Moon,
+  Monitor,
+  SunMoon,
+} from "lucide-react";
 import type { SessionData } from "@/lib/infrastructure/auth/types";
 import { getSurfaceStyles } from "@/lib/design/system";
 import { publishSignedOut } from "@/lib/infrastructure/auth/client-session-events";
 import { clientLogger } from "@/lib/core/logger/client";
+import { useThemePreference, type ThemePreference } from "@/lib/features/theme";
+import { useSettingsStore } from "@/state/settings-store";
+
+const THEME_OPTIONS: Array<{
+  value: ThemePreference;
+  label: string;
+  Icon: typeof Sun;
+}> = [
+  { value: "light", label: "Light", Icon: Sun },
+  { value: "dark", label: "Dark", Icon: Moon },
+  { value: "system", label: "Auto", Icon: Monitor },
+];
 
 export default function ProfileMenu() {
   const router = useRouter();
@@ -14,6 +37,9 @@ export default function ProfileMenu() {
   const [isLoading, setIsLoading] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+
+  const themePreference = useThemePreference();
+  const setUISettings = useSettingsStore((s) => s.setUISettings);
 
   const glass1 = getSurfaceStyles("glass-1");
 
@@ -155,6 +181,35 @@ export default function ProfileMenu() {
               <span className="text-sm">
                 Role: <span className="text-foreground font-medium">{session.user.role}</span>
               </span>
+            </div>
+
+            {/* Theme Mode */}
+            <div className="px-4 py-2 flex items-center gap-3 text-sm text-foreground">
+              <SunMoon className="h-4 w-4 text-gold-primary" />
+              <span className="flex-1">Theme</span>
+              <div
+                className="flex items-center gap-0.5 rounded-md border border-white/10 bg-white/5 p-0.5"
+                role="radiogroup"
+                aria-label="Theme mode"
+              >
+                {THEME_OPTIONS.map(({ value, label, Icon }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    role="radio"
+                    aria-checked={themePreference === value}
+                    title={`${label} mode`}
+                    onClick={() => void setUISettings({ theme: value })}
+                    className={`p-1.5 rounded transition-colors cursor-pointer ${
+                      themePreference === value
+                        ? "bg-gold-primary/20 text-gold-primary"
+                        : "text-muted-foreground hover:text-foreground hover:bg-white/5"
+                    }`}
+                  >
+                    <Icon className="h-3.5 w-3.5" />
+                  </button>
+                ))}
+              </div>
             </div>
 
             {/* Divider */}

--- a/components/content/ai/ChatContextPicker.tsx
+++ b/components/content/ai/ChatContextPicker.tsx
@@ -181,18 +181,18 @@ export function ChatContextPicker({
   return (
     <div ref={containerRef} className="relative">
       {isOpen && (
-        <div className="absolute bottom-full left-0 z-50 mb-1 w-72 overflow-hidden rounded-lg border border-white/10 bg-[#1a1a1a] shadow-xl">
+        <div className="absolute bottom-full left-0 z-50 mb-1 w-72 overflow-hidden rounded-lg border border-black/10 bg-white dark:border-white/10 dark:bg-[#1a1a1a] shadow-xl">
           {draft ? (
             // ── Form view (create / edit) ──
             <div className="p-2.5">
               <div className="mb-2 flex items-center justify-between">
-                <span className="text-[11px] font-medium uppercase tracking-wider text-gray-400">
+                <span className="text-[11px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
                   {draft.id ? "Edit context" : "New context"}
                 </span>
                 <button
                   type="button"
                   onClick={() => setDraft(null)}
-                  className="rounded p-0.5 text-gray-500 hover:bg-white/10 hover:text-gray-300"
+                  className="rounded p-0.5 text-gray-500 hover:bg-black/[0.06] hover:text-gray-700 dark:hover:bg-white/10 dark:hover:text-gray-300"
                   aria-label="Cancel"
                 >
                   <X className="h-3.5 w-3.5" />
@@ -212,7 +212,7 @@ export function ChatContextPicker({
                 placeholder="Name (e.g. Concise & technical)"
                 maxLength={CHAT_CONTEXT_NAME_MAX}
                 autoFocus
-                className="mb-2 w-full rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-1.5 text-xs text-white placeholder:text-gray-500 focus:border-white/25 focus:outline-none"
+                className="mb-2 w-full rounded-md border border-black/10 bg-black/[0.03] text-gray-900 focus:border-black/25 dark:border-white/10 dark:bg-white/[0.04] dark:text-white dark:focus:border-white/25 px-2.5 py-1.5 text-xs placeholder:text-gray-500 focus:outline-none"
               />
               <textarea
                 value={draft.body}
@@ -228,13 +228,13 @@ export function ChatContextPicker({
                 placeholder="How should the assistant respond? e.g. 'Be terse. Prefer code examples. Assume I'm a senior engineer.'"
                 maxLength={CHAT_CONTEXT_BODY_MAX}
                 rows={5}
-                className="scrollbar-hide w-full resize-none rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-1.5 text-xs leading-relaxed text-white placeholder:text-gray-500 focus:border-white/25 focus:outline-none"
+                className="scrollbar-hide w-full resize-none rounded-md border border-black/10 bg-black/[0.03] text-gray-900 focus:border-black/25 dark:border-white/10 dark:bg-white/[0.04] dark:text-white dark:focus:border-white/25 px-2.5 py-1.5 text-xs leading-relaxed placeholder:text-gray-500 focus:outline-none"
               />
               <div className="mt-2 flex items-center justify-end gap-1.5">
                 <button
                   type="button"
                   onClick={() => setDraft(null)}
-                  className="rounded-md px-2.5 py-1 text-[11px] text-gray-400 hover:bg-white/10 hover:text-gray-200"
+                  className="rounded-md px-2.5 py-1 text-[11px] text-gray-500 hover:bg-black/[0.06] hover:text-gray-800 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-gray-200"
                 >
                   Cancel
                 </button>
@@ -242,7 +242,7 @@ export function ChatContextPicker({
                   type="button"
                   onClick={handleSave}
                   disabled={saving}
-                  className="flex items-center gap-1 rounded-md bg-white/10 px-2.5 py-1 text-[11px] text-white hover:bg-white/20 disabled:opacity-50"
+                  className="flex items-center gap-1 rounded-md bg-gray-900 text-white hover:bg-gray-700 dark:bg-white/10 dark:hover:bg-white/20 px-2.5 py-1 text-[11px] disabled:opacity-50"
                 >
                   <Check className="h-3 w-3" />
                   {saving ? "Saving…" : "Save"}
@@ -259,8 +259,8 @@ export function ChatContextPicker({
                 className={cn(
                   "flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors",
                   value === null
-                    ? "bg-white/10 text-white"
-                    : "text-gray-400 hover:bg-white/5 hover:text-gray-200",
+                    ? "bg-black/[0.06] text-gray-900 dark:bg-white/10 dark:text-white"
+                    : "text-gray-500 hover:bg-black/[0.04] hover:text-gray-800 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-200",
                 )}
               >
                 <span>No context</span>
@@ -287,7 +287,7 @@ export function ChatContextPicker({
                     key={ctx.id}
                     className={cn(
                       "group flex items-center gap-1 px-1.5",
-                      isSelected && "bg-white/10",
+                      isSelected && "bg-black/[0.06] dark:bg-white/10",
                     )}
                   >
                     <button
@@ -296,8 +296,8 @@ export function ChatContextPicker({
                       className={cn(
                         "flex min-w-0 flex-1 items-center justify-between rounded px-1.5 py-2 text-left text-xs transition-colors",
                         isSelected
-                          ? "text-white"
-                          : "text-gray-400 hover:text-gray-200",
+                          ? "text-gray-900 dark:text-white"
+                          : "text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200",
                       )}
                     >
                       <span className="truncate">{ctx.name}</span>
@@ -314,7 +314,7 @@ export function ChatContextPicker({
                           body: ctx.body,
                         })
                       }
-                      className="rounded p-1 text-gray-500 opacity-0 transition-opacity hover:bg-white/10 hover:text-gray-300 group-hover:opacity-100"
+                      className="rounded p-1 text-gray-500 opacity-0 transition-opacity hover:bg-black/[0.06] hover:text-gray-700 dark:hover:bg-white/10 dark:hover:text-gray-300 group-hover:opacity-100"
                       aria-label={`Edit ${ctx.name}`}
                     >
                       <Pencil className="h-3 w-3" />
@@ -332,11 +332,11 @@ export function ChatContextPicker({
               })}
 
               {/* New context */}
-              <div className="mt-1 border-t border-white/5 pt-1">
+              <div className="mt-1 border-t border-black/5 dark:border-white/5 pt-1">
                 <button
                   type="button"
                   onClick={() => setDraft({ id: null, name: "", body: "" })}
-                  className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-xs text-gray-400 transition-colors hover:bg-white/5 hover:text-gray-200"
+                  className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-xs text-gray-500 hover:bg-black/[0.04] hover:text-gray-800 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-200 transition-colors"
                 >
                   <Plus className="h-3.5 w-3.5 shrink-0" />
                   New context
@@ -355,8 +355,8 @@ export function ChatContextPicker({
         className={cn(
           "flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] transition-colors",
           active
-            ? "text-emerald-300/90 hover:text-emerald-200"
-            : "text-gray-500 dark:text-gray-400 hover:text-gray-300",
+            ? "text-emerald-600 hover:text-emerald-700 dark:text-emerald-300/90 dark:hover:text-emerald-200"
+            : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300",
           "disabled:cursor-not-allowed disabled:opacity-50",
         )}
         title={

--- a/components/content/ai/ChatInput.tsx
+++ b/components/content/ai/ChatInput.tsx
@@ -453,15 +453,15 @@ export function ChatInput({
   return (
     <form
       onSubmit={handleSubmit}
-      className="border-t border-black/10 dark:border-white/10 bg-black/20 p-2"
+      className="border-t border-black/10 dark:border-white/10 bg-black/[0.03] dark:bg-black/20 p-2"
     >
       <div
         ref={treeDropRef as unknown as React.Ref<HTMLDivElement>}
         className={cn(
-          "relative rounded-xl border bg-white/[0.04] transition-colors",
+          "relative rounded-xl border bg-white/70 dark:bg-white/[0.04] transition-colors",
           isDragging || isOverTree
             ? "border-emerald-400/60 ring-1 ring-emerald-400/30"
-            : "border-white/10 focus-within:border-white/25 focus-within:ring-1 focus-within:ring-white/10",
+            : "border-black/10 focus-within:border-black/25 focus-within:ring-1 focus-within:ring-black/10 dark:border-white/10 dark:focus-within:border-white/25 dark:focus-within:ring-white/10",
         )}
         onDragOver={
           dropEnabled
@@ -516,7 +516,7 @@ export function ChatInput({
           className={cn(
             "scrollbar-hide block w-full max-h-[160px] min-h-[36px] overflow-y-auto whitespace-pre-wrap break-words",
             "bg-transparent px-3 pt-2.5 pb-1",
-            "text-sm text-white",
+            "text-sm text-gray-900 dark:text-white",
             "focus:outline-none",
             (disabled || isActive) && "opacity-50 cursor-not-allowed",
             isEmpty &&
@@ -549,7 +549,7 @@ export function ChatInput({
                     : "Attach text files (active model can't read images)"
                 }
                 aria-label="Attach files"
-                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-black/[0.06] dark:hover:bg-white/10 transition-colors"
               >
                 <Paperclip className="h-3.5 w-3.5" />
               </button>
@@ -559,7 +559,7 @@ export function ChatInput({
             type="button"
             disabled
             title="Speech input (coming soon)"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-gray-500 hover:text-gray-300 transition-colors cursor-not-allowed disabled:opacity-50"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors cursor-not-allowed disabled:opacity-50"
           >
             <Mic className="h-3.5 w-3.5" />
           </button>
@@ -580,8 +580,8 @@ export function ChatInput({
               className={cn(
                 "flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors",
                 canSend
-                  ? "bg-white/15 text-white hover:bg-white/25"
-                  : "bg-white/5 text-gray-600 cursor-not-allowed",
+                  ? "bg-gray-900 text-white hover:bg-gray-700 dark:bg-white/15 dark:hover:bg-white/25"
+                  : "bg-black/5 text-gray-400 dark:bg-white/5 dark:text-gray-600 cursor-not-allowed",
               )}
             >
               <ArrowUp className="h-3.5 w-3.5" />
@@ -741,8 +741,8 @@ function AttachmentChip({
       className={cn(
         "group/att relative flex items-center gap-1.5 rounded-lg border px-2 py-1 text-[11px] max-w-[180px]",
         status === "error"
-          ? "border-red-500/30 bg-red-500/10 text-red-300"
-          : "border-white/10 bg-white/[0.06] text-gray-300",
+          ? "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300"
+          : "border-black/10 bg-black/[0.04] text-gray-700 dark:border-white/10 dark:bg-white/[0.06] dark:text-gray-300",
       )}
       title={error || name}
     >

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -33,6 +33,7 @@ import {
   getProviderTheme,
   type ProviderTheme,
 } from "@/lib/design/system/ai-providers";
+import { useResolvedTheme } from "@/lib/features/theme/useResolvedTheme";
 import { PROVIDER_CATALOG } from "@/lib/domain/ai/providers/catalog";
 import { ReasoningRouter } from "./reasoning/ReasoningRouter";
 
@@ -409,7 +410,7 @@ export const ChatMessage = memo(function ChatMessage({
     >
       {/* Avatar */}
       {isUser ? (
-        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-500/20 text-blue-400">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-500/15 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400">
           <User className="h-4 w-4" />
         </div>
       ) : (
@@ -459,12 +460,12 @@ export const ChatMessage = memo(function ChatMessage({
               //     `w-full` which is still legible just wider;
               //   - `max-w-full` keeps it from overflowing the column.
               style={{ fieldSizing: "content" } as React.CSSProperties}
-              className="w-full max-w-full resize-y rounded-xl border border-blue-500/20 bg-blue-600/30 px-3.5 py-2.5 text-sm leading-relaxed text-blue-100 outline-none focus:border-blue-400/60 focus:ring-2 focus:ring-blue-400/30 align-top"
+              className="w-full max-w-full resize-y rounded-xl border border-blue-500/20 bg-blue-600/10 text-blue-950 dark:bg-blue-600/30 dark:text-blue-100 px-3.5 py-2.5 text-sm leading-relaxed outline-none focus:border-blue-400/60 focus:ring-2 focus:ring-blue-400/30 align-top"
             />
             <div className="flex items-center justify-end gap-1.5">
               <button
                 onClick={() => setEditing(false)}
-                className="rounded-md px-2 py-1 text-[11px] text-gray-400 hover:text-gray-200 hover:bg-white/5 transition-colors"
+                className="rounded-md px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-black/[0.04] dark:hover:bg-white/5 transition-colors"
               >
                 Cancel
               </button>
@@ -587,7 +588,7 @@ export const ChatMessage = memo(function ChatMessage({
               return (
                 <div
                   key={i}
-                  className="inline-block rounded-xl px-3.5 py-2.5 text-sm leading-relaxed bg-blue-600/30 text-blue-100 border border-blue-500/20"
+                  className="inline-block rounded-xl px-3.5 py-2.5 text-sm leading-relaxed bg-blue-600/10 text-blue-950 dark:bg-blue-600/30 dark:text-blue-100 border border-blue-500/20"
                 >
                   <UserMessageText text={part.text} />
                 </div>
@@ -775,7 +776,7 @@ function MessageActionButton({
       disabled={disabled}
       title={label}
       aria-label={label}
-      className="inline-flex items-center justify-center rounded-md p-1 hover:text-gray-200 hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/60"
+      className="inline-flex items-center justify-center rounded-md p-1 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-black/[0.04] dark:hover:bg-white/5 transition-colors disabled:opacity-40 disabled:cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/60"
     >
       {children}
     </button>
@@ -893,7 +894,7 @@ function buildMarkdownComponents(theme: ProviderTheme): Components {
     return (
       <code
         {...rest}
-        className="rounded bg-white/10 px-1 py-0.5 text-xs font-mono text-amber-300"
+        className="rounded bg-black/[0.06] text-amber-700 dark:bg-white/10 dark:text-amber-300 px-1 py-0.5 text-xs font-mono"
       >
         {children}
       </code>
@@ -910,32 +911,32 @@ function buildMarkdownComponents(theme: ProviderTheme): Components {
 const themeNeutralMarkdownComponents: Components = {
   // ── Headings ──
   h1: ({ children }) => (
-    <h1 className="text-xl font-bold mt-4 mb-2 text-white/90 first:mt-0">
+    <h1 className="text-xl font-bold mt-4 mb-2 text-gray-900 dark:text-white/90 first:mt-0">
       {children}
     </h1>
   ),
   h2: ({ children }) => (
-    <h2 className="text-lg font-bold mt-3.5 mb-2 text-white/90 first:mt-0">
+    <h2 className="text-lg font-bold mt-3.5 mb-2 text-gray-900 dark:text-white/90 first:mt-0">
       {children}
     </h2>
   ),
   h3: ({ children }) => (
-    <h3 className="text-base font-semibold mt-3 mb-1.5 text-white/85 first:mt-0">
+    <h3 className="text-base font-semibold mt-3 mb-1.5 text-gray-900/90 dark:text-white/85 first:mt-0">
       {children}
     </h3>
   ),
   h4: ({ children }) => (
-    <h4 className="text-sm font-semibold mt-2.5 mb-1 text-white/80 first:mt-0">
+    <h4 className="text-sm font-semibold mt-2.5 mb-1 text-gray-900/85 dark:text-white/80 first:mt-0">
       {children}
     </h4>
   ),
   h5: ({ children }) => (
-    <h5 className="text-sm font-medium mt-2 mb-1 text-white/75 first:mt-0">
+    <h5 className="text-sm font-medium mt-2 mb-1 text-gray-800/85 dark:text-white/75 first:mt-0">
       {children}
     </h5>
   ),
   h6: ({ children }) => (
-    <h6 className="text-xs font-medium mt-2 mb-1 text-white/70 uppercase tracking-wide first:mt-0">
+    <h6 className="text-xs font-medium mt-2 mb-1 text-gray-700 dark:text-white/70 uppercase tracking-wide first:mt-0">
       {children}
     </h6>
   ),
@@ -965,7 +966,7 @@ const themeNeutralMarkdownComponents: Components = {
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-blue-400 hover:text-blue-300 underline underline-offset-2 transition-colors"
+        className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline underline-offset-2 transition-colors"
       >
         {children}
       </a>
@@ -994,7 +995,7 @@ const themeNeutralMarkdownComponents: Components = {
 
   // ── Inline formatting ──
   strong: ({ children }) => (
-    <strong className="font-semibold text-[#FFD700]">{children}</strong>
+    <strong className="font-semibold text-[#8A6A00] dark:text-[#FFD700]">{children}</strong>
   ),
   em: ({ children }) => <em className="italic">{children}</em>,
   del: ({ children }) => (
@@ -1013,7 +1014,7 @@ const themeNeutralMarkdownComponents: Components = {
   ),
   tbody: ({ children }) => <tbody>{children}</tbody>,
   tr: ({ children }) => (
-    <tr className="border-b border-white/5 last:border-0">{children}</tr>
+    <tr className="border-b border-black/5 dark:border-white/5 last:border-0">{children}</tr>
   ),
   th: ({ children }) => (
     <th className="px-3 py-1.5 text-left font-medium text-gray-700 dark:text-gray-300">
@@ -1090,13 +1091,13 @@ function CodeBlock({
         {theme.codeBlock.showCopyButton && (
           <button
             onClick={handleCopy}
-            className="flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-300 transition-colors"
+            className="flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
             title="Copy code"
           >
             {copied ? (
               <>
-                <Check className="h-3 w-3 text-green-400" />
-                <span className="text-green-400">Copied</span>
+                <Check className="h-3 w-3 text-green-600 dark:text-green-400" />
+                <span className="text-green-600 dark:text-green-400">Copied</span>
               </>
             ) : (
               <>
@@ -1205,7 +1206,7 @@ function AssistantAvatar({
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [portalReady, setPortalReady] = useState(false);
 
-  const theme = getProviderTheme(providerId);
+  const theme = getProviderTheme(providerId, useResolvedTheme());
   const provider = PROVIDER_CATALOG.find((p) => p.id === providerId);
   const model = provider?.models.find((m) => m.id === modelId);
   const providerName = provider?.name ?? "AI assistant";
@@ -1276,7 +1277,7 @@ function AssistantAvatar({
               transform: "translateY(-50%)",
               zIndex: 9999,
             }}
-            className="pointer-events-none whitespace-nowrap rounded-md border border-white/10 bg-[#1a1a1a] px-2.5 py-1.5 text-[10px] text-gray-200 shadow-xl"
+            className="pointer-events-none whitespace-nowrap rounded-md border border-black/10 bg-white text-gray-700 dark:border-white/10 dark:bg-[#1a1a1a] dark:text-gray-200 px-2.5 py-1.5 text-[10px] shadow-xl"
           >
             <div className="flex items-center gap-1.5">
               <span
@@ -1291,11 +1292,11 @@ function AssistantAvatar({
               </div>
             )}
             {usage && (usage.inputTokens != null || usage.outputTokens != null) && (
-              <div className="mt-1 flex items-center gap-2 border-t border-white/10 pt-1 text-gray-400 dark:text-gray-500">
+              <div className="mt-1 flex items-center gap-2 border-t border-black/10 dark:border-white/10 pt-1 text-gray-500">
                 {usage.inputTokens != null && (
                   <span>
                     <span className="text-gray-500">in</span>{" "}
-                    <span className="tabular-nums text-gray-300">
+                    <span className="tabular-nums text-gray-700 dark:text-gray-300">
                       {usage.inputTokens.toLocaleString()}
                     </span>
                   </span>
@@ -1303,7 +1304,7 @@ function AssistantAvatar({
                 {usage.outputTokens != null && (
                   <span>
                     <span className="text-gray-500">out</span>{" "}
-                    <span className="tabular-nums text-gray-300">
+                    <span className="tabular-nums text-gray-700 dark:text-gray-300">
                       {usage.outputTokens.toLocaleString()}
                     </span>
                   </span>
@@ -1325,7 +1326,7 @@ function MentionPill({ title, contentId }: { title: string; contentId: string })
       onClick={() => {
         useContentStore.getState().setSelectedContentId(contentId);
       }}
-      className="inline-flex items-center gap-0.5 rounded bg-blue-500/20 text-blue-300 px-1.5 py-0.5 text-xs font-medium hover:bg-blue-500/30 transition-colors cursor-pointer"
+      className="inline-flex items-center gap-0.5 rounded bg-blue-500/15 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300 px-1.5 py-0.5 text-xs font-medium hover:bg-blue-500/25 dark:hover:bg-blue-500/30 transition-colors cursor-pointer"
     >
       @{title}
     </button>
@@ -1568,7 +1569,7 @@ function ToolCallBubble({
             <button
               type="button"
               onClick={handleCopy}
-              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-white/5 transition-colors"
+              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 hover:bg-black/[0.04] dark:hover:bg-white/5 transition-colors"
               title="Copy result"
             >
               {copied ? (
@@ -1823,7 +1824,7 @@ function GeneratedImageCard({ payload }: { payload: ImagePayload }) {
             inserted
               ? "bg-green-500/20 text-green-300 border border-green-500/20"
               : canInsert
-                ? "bg-blue-500/20 text-blue-300 border border-blue-500/20 hover:bg-blue-500/30"
+                ? "bg-blue-500/15 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300 border border-blue-500/20 hover:bg-blue-500/25 dark:hover:bg-blue-500/30"
                 : "bg-black/[0.03] dark:bg-white/5 text-gray-500 dark:text-gray-400 border border-white/5 cursor-not-allowed"
           )}
         >
@@ -1974,7 +1975,7 @@ function GeneratedAudioCard({ payload }: { payload: AudioPayload }) {
             inserted
               ? "bg-green-500/20 text-green-300 border border-green-500/20"
               : canInsert
-                ? "bg-blue-500/20 text-blue-300 border border-blue-500/20 hover:bg-blue-500/30"
+                ? "bg-blue-500/15 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300 border border-blue-500/20 hover:bg-blue-500/25 dark:hover:bg-blue-500/30"
                 : "bg-black/[0.03] dark:bg-white/5 text-gray-500 dark:text-gray-400 border border-white/5 cursor-not-allowed"
           )}
         >

--- a/components/content/ai/ChatPanel.tsx
+++ b/components/content/ai/ChatPanel.tsx
@@ -17,6 +17,7 @@ import { useRef, useEffect, useCallback, useState, useMemo } from "react";
 import { Trash2, Bot, Pencil, Maximize2, ChevronDown } from "lucide-react";
 import { PROVIDER_CATALOG } from "@/lib/domain/ai/providers/catalog";
 import { getProviderTheme } from "@/lib/design/system/ai-providers";
+import { useResolvedTheme } from "@/lib/features/theme/useResolvedTheme";
 import { ProviderIcon } from "./ProviderIcon";
 import { toast } from "sonner";
 import { useEditorInstanceStore } from "@/state/editor-instance-store";
@@ -531,7 +532,7 @@ export function ChatPanel({
             <button
               onClick={() => void handleOpenInPage()}
               title="Open in full view"
-              className="rounded p-1.5 text-gray-600 dark:text-gray-400 hover:bg-black/[0.05] dark:hover:bg-white/10 hover:text-gray-200 transition-colors"
+              className="rounded p-1.5 text-gray-600 dark:text-gray-400 hover:bg-black/[0.05] dark:hover:bg-white/10 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
             >
               <Maximize2 className="h-3.5 w-3.5" />
             </button>
@@ -600,7 +601,7 @@ export function ChatPanel({
         <button
           type="button"
           onClick={scrollToBottom}
-          className="absolute bottom-2 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-white/15 bg-[#1a1a1a]/90 px-2.5 py-1 text-[11px] text-gray-200 shadow-lg backdrop-blur transition-colors hover:bg-white/10"
+          className="absolute bottom-2 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-black/15 bg-white/90 text-gray-700 hover:bg-black/[0.06] dark:border-white/15 dark:bg-[#1a1a1a]/90 dark:text-gray-200 dark:hover:bg-white/10 px-2.5 py-1 text-[11px] shadow-lg backdrop-blur transition-colors"
         >
           <ChevronDown className="h-3 w-3" /> Jump to latest
         </button>
@@ -669,7 +670,7 @@ function HeaderTitle({
   providerId: string;
   modelId: string;
 }) {
-  const theme = getProviderTheme(providerId);
+  const theme = getProviderTheme(providerId, useResolvedTheme());
   const provider = useMemo(
     () => PROVIDER_CATALOG.find((p) => p.id === providerId),
     [providerId],
@@ -679,7 +680,7 @@ function HeaderTitle({
     [provider, modelId],
   );
   return (
-    <div className="flex items-center gap-2 text-sm text-gray-300 min-w-0">
+    <div className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 min-w-0">
       <span
         className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
         style={{
@@ -742,7 +743,7 @@ function DeleteWithConfirm({
           ? "Confirm delete (click again, auto-cancels in 3s)"
           : "Confirm clear (click again, auto-cancels in 3s)"
       }
-      className="inline-flex items-center gap-1 rounded px-1.5 py-1 text-[10px] font-medium bg-red-500/20 text-red-300 border border-red-500/30 hover:bg-red-500/30 transition-colors"
+      className="inline-flex items-center gap-1 rounded px-1.5 py-1 text-[10px] font-medium bg-red-500/15 text-red-700 dark:bg-red-500/20 dark:text-red-300 border border-red-500/30 hover:bg-red-500/25 dark:hover:bg-red-500/30 transition-colors"
     >
       <Trash2 className="h-3 w-3" />
       {destructive ? "Delete" : "Confirm"}
@@ -761,7 +762,7 @@ function LoadingMessages() {
     <div className="flex h-full flex-col items-center justify-center gap-3 px-4">
       <div className="flex w-full max-w-[280px] flex-col gap-2 opacity-50 animate-pulse">
         <div className="ml-auto h-7 w-2/3 rounded-xl bg-blue-500/20" />
-        <div className="h-8 w-3/4 rounded-xl bg-white/10" />
+        <div className="h-8 w-3/4 rounded-xl bg-black/10 dark:bg-white/10" />
         <div className="ml-auto h-7 w-1/2 rounded-xl bg-blue-500/20" />
       </div>
       <p className="text-[10px] uppercase tracking-wider text-gray-500">

--- a/components/content/ai/ChatSnippetMenu.tsx
+++ b/components/content/ai/ChatSnippetMenu.tsx
@@ -88,10 +88,10 @@ export function ChatSnippetMenu({ onSelect, selectedIds }: ChatSnippetMenuProps)
 
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center pb-20 bg-black/20">
-      <div className="w-full max-w-sm rounded-xl border border-black/10 dark:border-white/10 bg-gray-900/95 shadow-2xl backdrop-blur-sm">
+      <div className="w-full max-w-sm rounded-xl border border-black/10 dark:border-white/10 bg-white/95 dark:bg-gray-900/95 shadow-2xl backdrop-blur-sm">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-black/10 dark:border-white/10">
-          <h3 className="text-xs font-medium flex items-center gap-2 text-gray-300">
+          <h3 className="text-xs font-medium flex items-center gap-2 text-gray-700 dark:text-gray-300">
             <Scissors className="h-3.5 w-3.5" />
             Attach Snippets
             {selectedIds.length > 0 && (
@@ -118,7 +118,7 @@ export function ChatSnippetMenu({ onSelect, selectedIds }: ChatSnippetMenuProps)
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search snippets..."
-              className="w-full pl-7 pr-3 py-1.5 text-xs rounded-md bg-white/5 border border-black/10 dark:border-white/10 focus:border-white/30 focus:outline-none"
+              className="w-full pl-7 pr-3 py-1.5 text-xs rounded-md bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 focus:border-black/30 dark:focus:border-white/30 focus:outline-none"
             />
           </div>
         </div>
@@ -173,7 +173,7 @@ export function ChatSnippetMenu({ onSelect, selectedIds }: ChatSnippetMenuProps)
           <div className="px-3 py-2 border-t border-black/10 dark:border-white/10">
             <button
               onClick={handleClose}
-              className="w-full text-xs py-1.5 rounded-md bg-blue-600/30 text-blue-400 hover:bg-blue-600/40 transition-colors"
+              className="w-full text-xs py-1.5 rounded-md bg-blue-600/15 text-blue-700 hover:bg-blue-600/25 dark:bg-blue-600/30 dark:text-blue-400 dark:hover:bg-blue-600/40 transition-colors"
             >
               Done ({selectedIds.length} attached)
             </button>

--- a/components/content/ai/ChatSuggestionMenu.tsx
+++ b/components/content/ai/ChatSuggestionMenu.tsx
@@ -70,11 +70,11 @@ export function ChatSuggestionMenu({
       className={cn(
         "absolute bottom-full left-0 right-0 mb-1 z-50",
         "max-h-48 overflow-y-auto rounded-lg",
-        "border border-black/10 dark:border-white/10 bg-[#1a1a1a] shadow-xl",
+        "border border-black/10 dark:border-white/10 bg-white dark:bg-[#1a1a1a] shadow-xl",
         "backdrop-blur-sm"
       )}
     >
-      <div className="px-2 py-1.5 text-[10px] uppercase tracking-wider text-gray-500 font-medium border-b border-white/5">
+      <div className="px-2 py-1.5 text-[10px] uppercase tracking-wider text-gray-500 font-medium border-b border-black/5 dark:border-white/5">
         {mode === "mention" ? "Mention a file" : "Commands"}
       </div>
       {items.map((item, i) => (
@@ -88,7 +88,7 @@ export function ChatSuggestionMenu({
           className={cn(
             "flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors",
             i === selectedIndex
-              ? "bg-white/10 text-white"
+              ? "bg-black/[0.06] text-gray-900 dark:bg-white/10 dark:text-white"
               : "text-gray-600 dark:text-gray-400 hover:bg-black/[0.04] hover:text-gray-800 dark:hover:bg-white/5 dark:hover:text-gray-200"
           )}
         >

--- a/components/content/ai/ConversationPicker.tsx
+++ b/components/content/ai/ConversationPicker.tsx
@@ -240,10 +240,10 @@ export function ConversationPicker({
   return (
     <div
       ref={containerRef}
-      className="absolute top-full left-2 right-2 mt-1 rounded-xl border border-white/10 bg-[#1a1a1a] shadow-2xl z-50 overflow-hidden flex flex-col"
+      className="absolute top-full left-2 right-2 mt-1 rounded-xl border border-black/10 bg-white dark:border-white/10 dark:bg-[#1a1a1a] shadow-2xl z-50 overflow-hidden flex flex-col"
       style={{ maxHeight: "60vh", maxWidth: "calc(100% - 1rem)" }}
     >
-      <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+      <div className="flex items-center gap-2 border-b border-black/10 dark:border-white/10 px-3 py-2">
         <Search className="h-3.5 w-3.5 text-gray-500" />
         <input
           autoFocus
@@ -251,11 +251,11 @@ export function ConversationPicker({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search chats…"
-          className="flex-1 bg-transparent text-xs text-white placeholder-gray-500 focus:outline-none"
+          className="flex-1 bg-transparent text-xs text-gray-900 dark:text-white placeholder-gray-500 focus:outline-none"
         />
         <button
           onClick={onClose}
-          className="text-gray-500 hover:text-gray-300"
+          className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
         >
           <X className="h-3.5 w-3.5" />
         </button>
@@ -283,13 +283,13 @@ export function ConversationPicker({
                     disabled={isBusy}
                     className={cn(
                       "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors",
-                      "hover:bg-white/[0.04]",
+                      "hover:bg-black/[0.03] dark:hover:bg-white/[0.04]",
                       alreadyPinned && "opacity-50",
                     )}
                   >
                     <MessageSquare className="h-3.5 w-3.5 shrink-0 text-gray-500" />
                     <div className="min-w-0 flex-1">
-                      <div className="text-xs text-white truncate">
+                      <div className="text-xs text-gray-900 dark:text-white truncate">
                         {item.title || "Untitled chat"}
                       </div>
                       <div className="text-[10px] text-gray-500">

--- a/components/content/ai/FollowUpsStrip.tsx
+++ b/components/content/ai/FollowUpsStrip.tsx
@@ -35,14 +35,14 @@ export function FollowUpsStrip({
       aria-label="Suggested follow-up prompts"
     >
       <div className="flex items-center gap-1.5">
-        <Sparkles className="h-3 w-3 shrink-0 text-amber-300/70" aria-hidden />
+        <Sparkles className="h-3 w-3 shrink-0 text-amber-600/70 dark:text-amber-300/70" aria-hidden />
         <div className="flex flex-wrap gap-1.5 flex-1 min-w-0">
           {followUps.map((text, i) => (
             <button
               key={`${i}:${text.slice(0, 24)}`}
               type="button"
               onClick={() => onPick(text)}
-              className="text-left text-[11px] leading-snug rounded-md border border-white/10 bg-white/[0.04] hover:bg-white/10 hover:border-white/20 px-2 py-1 text-gray-300 transition-colors max-w-[280px] truncate"
+              className="text-left text-[11px] leading-snug rounded-md border border-black/10 bg-black/[0.03] hover:bg-black/[0.06] hover:border-black/20 text-gray-700 dark:border-white/10 dark:bg-white/[0.04] dark:hover:bg-white/10 dark:hover:border-white/20 dark:text-gray-300 px-2 py-1 transition-colors max-w-[280px] truncate"
               title={text}
             >
               {text}
@@ -54,7 +54,7 @@ export function FollowUpsStrip({
             type="button"
             onClick={onDismiss}
             aria-label="Dismiss follow-up suggestions"
-            className="shrink-0 text-gray-500 hover:text-gray-300 transition-colors"
+            className="shrink-0 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
           >
             <X className="h-3 w-3" />
           </button>

--- a/components/content/ai/MakeAndModelPicker.tsx
+++ b/components/content/ai/MakeAndModelPicker.tsx
@@ -29,6 +29,7 @@ import {
   BIG_THREE_PROVIDER_IDS,
   getProviderTheme,
 } from "@/lib/design/system/ai-providers";
+import { useResolvedTheme } from "@/lib/features/theme/useResolvedTheme";
 import type { AIProviderId } from "@/lib/domain/ai/types";
 import { MixedProviderChip } from "./MixedProviderChip";
 import { ProviderIcon } from "./ProviderIcon";
@@ -126,6 +127,7 @@ export function MakeAndModelPicker({
 }: MakeAndModelPickerProps) {
   const [moreOpen, setMoreOpen] = useState(false);
   const [modelOpen, setModelOpen] = useState(false);
+  const resolvedTheme = useResolvedTheme();
   const moreRef = useRef<HTMLDivElement>(null);
   const modelRef = useRef<HTMLDivElement>(null);
 
@@ -405,7 +407,7 @@ export function MakeAndModelPicker({
         />
 
         {moreOpen && (
-          <div className="absolute bottom-full left-0 mb-1 min-w-[220px] rounded-lg border border-white/10 bg-[#1a1a1a] shadow-xl z-50 overflow-hidden">
+          <div className="absolute bottom-full left-0 mb-1 min-w-[220px] rounded-lg border border-black/10 bg-white dark:border-white/10 dark:bg-[#1a1a1a] shadow-xl z-50 overflow-hidden">
             {overflowProviders.map((p) => {
               const isActive = p.id === providerId;
               // Count this provider's models that a Connection can
@@ -431,10 +433,10 @@ export function MakeAndModelPicker({
                   className={cn(
                     "flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-xs transition-colors",
                     isActive
-                      ? "bg-white/10 text-white"
+                      ? "bg-black/[0.06] text-gray-900 dark:bg-white/10 dark:text-white"
                       : noneAvailable
                         ? "text-gray-500/70 hover:bg-amber-500/[0.05]"
-                        : "text-gray-600 dark:text-gray-400 hover:bg-white/5 hover:text-gray-200",
+                        : "text-gray-600 dark:text-gray-400 hover:bg-black/[0.04] dark:hover:bg-white/5 hover:text-gray-800 dark:hover:text-gray-200",
                   )}
                 >
                   <span className="flex items-center gap-2">
@@ -447,7 +449,7 @@ export function MakeAndModelPicker({
                         "h-3.5 w-3.5 shrink-0",
                         noneAvailable && "opacity-50",
                       )}
-                      color={getProviderTheme(p.id).brandColor}
+                      color={getProviderTheme(p.id, resolvedTheme).brandColor}
                     />
                     <span>{p.name}</span>
                   </span>
@@ -464,7 +466,7 @@ export function MakeAndModelPicker({
       </div>
 
       {/* Vertical divider */}
-      <div className="h-3 w-px bg-white/10 mx-0.5" />
+      <div className="h-3 w-px bg-black/10 dark:bg-white/10 mx-0.5" />
 
       {/* Model picker for the active make */}
       <div ref={modelRef} className="relative">
@@ -480,7 +482,7 @@ export function MakeAndModelPicker({
           aria-expanded={modelOpen}
           aria-label={`Active model: ${activeModelName}. Click to change.`}
           className={cn(
-            "flex h-7 items-center gap-1 rounded-full px-2 border border-white/10 text-gray-300 hover:text-white hover:border-white/20 transition-colors",
+            "flex h-7 items-center gap-1 rounded-full px-2 border border-black/10 text-gray-600 hover:text-gray-900 hover:border-black/20 dark:border-white/10 dark:text-gray-300 dark:hover:text-white dark:hover:border-white/20 transition-colors",
             disabled && "opacity-50 cursor-not-allowed",
           )}
         >
@@ -488,7 +490,7 @@ export function MakeAndModelPicker({
           <span className="max-w-[120px] truncate">{activeModelName}</span>
           {!compact && activeRouting?.via === "gateway" && (
             <span
-              className="hidden sm:inline-flex items-center rounded-md bg-amber-500/10 border border-amber-500/30 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-amber-300/90"
+              className="hidden sm:inline-flex items-center rounded-md bg-amber-500/10 border border-amber-500/30 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-300/90"
               title={`Routed through ${activeRouting.conn.name}`}
             >
               via {activeRouting.conn.name}
@@ -506,9 +508,9 @@ export function MakeAndModelPicker({
           <div
             role="listbox"
             aria-label={`${activeProvider.name} models`}
-            className="absolute bottom-full left-0 mb-1 min-w-[260px] rounded-lg border border-white/10 bg-[#1a1a1a] shadow-xl z-50 overflow-hidden"
+            className="absolute bottom-full left-0 mb-1 min-w-[260px] rounded-lg border border-black/10 bg-white dark:border-white/10 dark:bg-[#1a1a1a] shadow-xl z-50 overflow-hidden"
           >
-            <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-gray-500 dark:text-gray-400 font-medium border-b border-white/5">
+            <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-gray-500 dark:text-gray-400 font-medium border-b border-black/5 dark:border-white/5">
               {activeProvider.name}
             </div>
             {activeProvider.models.map((m) => {
@@ -540,9 +542,9 @@ export function MakeAndModelPicker({
                     "flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors",
                     !available && "opacity-40 cursor-help",
                     isSelected
-                      ? "bg-white/10 text-white"
+                      ? "bg-black/[0.06] text-gray-900 dark:bg-white/10 dark:text-white"
                       : available
-                        ? "text-gray-600 dark:text-gray-400 hover:bg-white/5 hover:text-gray-200"
+                        ? "text-gray-600 dark:text-gray-400 hover:bg-black/[0.04] dark:hover:bg-white/5 hover:text-gray-800 dark:hover:text-gray-200"
                         : "text-gray-500 hover:bg-amber-500/[0.04]",
                   )}
                   title={
@@ -568,8 +570,8 @@ export function MakeAndModelPicker({
               );
             })}
             {notice && (
-              <div className="border-t border-white/5 bg-amber-500/[0.06] px-3 py-2.5 space-y-1.5">
-                <p className="text-[11px] text-amber-200 leading-snug">
+              <div className="border-t border-black/5 dark:border-white/5 bg-amber-500/[0.06] px-3 py-2.5 space-y-1.5">
+                <p className="text-[11px] text-amber-800 dark:text-amber-200 leading-snug">
                   <span className="font-medium">{notice.modelName}</span>{" "}
                   isn&apos;t set up. Add a {notice.providerName} Connection (or
                   a gateway Connection that routes to it) in Settings &rarr; AI.
@@ -580,7 +582,7 @@ export function MakeAndModelPicker({
                     setNotice(null);
                     setModelOpen(false);
                   }}
-                  className="inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[11px] font-medium text-amber-200 hover:bg-amber-500/20 hover:border-amber-500/60 transition-colors"
+                  className="inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[11px] font-medium text-amber-800 dark:text-amber-200 hover:bg-amber-500/20 hover:border-amber-500/60 transition-colors"
                 >
                   <ExternalLink className="h-3 w-3" />
                   Open AI Settings
@@ -594,7 +596,7 @@ export function MakeAndModelPicker({
       {/* Mixed-provider chip — only when conversation has used 2+ providers */}
       {isMixed && (
         <>
-          <div className="h-3 w-px bg-white/10 mx-0.5" />
+          <div className="h-3 w-px bg-black/10 dark:bg-white/10 mx-0.5" />
           <MixedProviderChip contributors={contributors} />
         </>
       )}
@@ -620,9 +622,10 @@ function MoreChip({
   activeOverflowProviderId: AIProviderId | null;
   onClick: () => void;
 }) {
+  const resolvedTheme = useResolvedTheme();
   const isActive = activeOverflowProviderId !== null;
   const theme = isActive
-    ? getProviderTheme(activeOverflowProviderId)
+    ? getProviderTheme(activeOverflowProviderId, resolvedTheme)
     : null;
   const providerName = isActive
     ? PROVIDER_CATALOG.find((p) => p.id === activeOverflowProviderId)?.name
@@ -639,7 +642,7 @@ function MoreChip({
       className={cn(
         "flex h-7 items-center gap-0.5 rounded-full px-1.5 border transition-colors",
         !isActive &&
-          "border-white/10 text-gray-500 dark:text-gray-400 hover:text-gray-300 hover:border-white/20",
+          "border-black/10 dark:border-white/10 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-black/20 dark:hover:border-white/20",
         disabled && "opacity-50 cursor-not-allowed",
       )}
       style={
@@ -689,7 +692,7 @@ function MakeChip({
   disabled: boolean;
   onClick: () => void;
 }) {
-  const theme = getProviderTheme(providerId);
+  const theme = getProviderTheme(providerId, useResolvedTheme());
 
   return (
     <button
@@ -702,7 +705,7 @@ function MakeChip({
       className={cn(
         "flex h-7 w-7 items-center justify-center rounded-full border transition-colors",
         !isActive &&
-          "border-white/10 text-gray-500 dark:text-gray-400 hover:border-white/25 hover:text-gray-300",
+          "border-black/10 dark:border-white/10 text-gray-500 dark:text-gray-400 hover:border-black/25 dark:hover:border-white/25 hover:text-gray-700 dark:hover:text-gray-300",
         disabled && "opacity-50 cursor-not-allowed",
       )}
       style={

--- a/components/content/ai/MixedProviderChip.tsx
+++ b/components/content/ai/MixedProviderChip.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import { Info } from "lucide-react";
 import { cn } from "@/lib/core/utils";
 import { getProviderTheme } from "@/lib/design/system/ai-providers";
+import { useResolvedTheme } from "@/lib/features/theme/useResolvedTheme";
 import { PROVIDER_CATALOG } from "@/lib/domain/ai/providers/catalog";
 import type { AIProviderId } from "@/lib/domain/ai/types";
 
@@ -22,6 +23,7 @@ export interface MixedProviderChipProps {
 
 export function MixedProviderChip({ contributors }: MixedProviderChipProps) {
   const [hover, setHover] = useState(false);
+  const resolvedTheme = useResolvedTheme();
 
   if (contributors.length < 2) return null;
 
@@ -31,7 +33,7 @@ export function MixedProviderChip({ contributors }: MixedProviderChipProps) {
   // border.
   const stops = contributors
     .map((id, i) => {
-      const c = getProviderTheme(id).brandColor;
+      const c = getProviderTheme(id, resolvedTheme).brandColor;
       const pct = Math.round((i / Math.max(1, contributors.length - 1)) * 100);
       return `${c}33 ${pct}%`;
     })
@@ -46,7 +48,7 @@ export function MixedProviderChip({ contributors }: MixedProviderChipProps) {
       <span
         className={cn(
           "inline-flex items-center gap-1 rounded-full px-2.5 py-1 border text-[11px]",
-          "border-white/15 text-gray-300",
+          "border-black/15 text-gray-700 dark:border-white/15 dark:text-gray-300",
         )}
         style={{
           background: `linear-gradient(135deg, ${stops})`,
@@ -57,14 +59,14 @@ export function MixedProviderChip({ contributors }: MixedProviderChipProps) {
       </span>
 
       {hover && (
-        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 whitespace-nowrap rounded-md border border-white/10 bg-[#1a1a1a] px-2.5 py-1.5 text-[10px] text-gray-300 shadow-xl z-50">
+        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 whitespace-nowrap rounded-md border border-black/10 bg-white text-gray-700 dark:border-white/10 dark:bg-[#1a1a1a] dark:text-gray-300 px-2.5 py-1.5 text-[10px] shadow-xl z-50">
           <div className="text-gray-500 dark:text-gray-400 mb-0.5">
             Providers in this conversation
           </div>
           {contributors.map((id) => {
             const name =
               PROVIDER_CATALOG.find((p) => p.id === id)?.name ?? id;
-            const color = getProviderTheme(id).brandColor;
+            const color = getProviderTheme(id, resolvedTheme).brandColor;
             return (
               <div key={id} className="flex items-center gap-1.5">
                 <span

--- a/components/content/ai/MultiConversationSidebar.tsx
+++ b/components/content/ai/MultiConversationSidebar.tsx
@@ -28,6 +28,7 @@ import { useAIChatStore } from "@/state/ai-chat-store";
 import { useContentStore } from "@/state/content-store";
 import { useConversationCacheStore } from "@/state/conversation-cache-store";
 import { buildSurfaceBackground } from "@/lib/design/system/ai-providers";
+import { useResolvedTheme } from "@/lib/features/theme/useResolvedTheme";
 import type { AIProviderId } from "@/lib/domain/ai/types";
 
 interface Props {
@@ -50,6 +51,7 @@ export function MultiConversationSidebar({ contentId }: Props) {
     (s) => s.setActiveModelSelection,
   );
   const activeProviderId = sessionProviderId ?? defaultProviderId;
+  const resolvedTheme = useResolvedTheme();
 
   // ─── Cache store: tabs come from the shared store, kept in sync via
   // the SSE event bus (no more prop-drilled `onTitleChanged` reloads). ──
@@ -335,6 +337,7 @@ export function MultiConversationSidebar({ contentId }: Props) {
   const surfaceBackground = buildSurfaceBackground(
     activeProviderId ?? null,
     [(activeProviderId ?? "anthropic") as AIProviderId],
+    resolvedTheme,
   );
 
   // Tabs not yet known for this content → show a skeleton, NOT the empty
@@ -352,18 +355,18 @@ export function MultiConversationSidebar({ contentId }: Props) {
         aria-busy="true"
         aria-label="Loading conversations"
       >
-        <div className="flex h-10 shrink-0 items-center gap-2 border-b border-white/10 px-3">
-          <div className="h-5 w-24 animate-pulse rounded bg-white/10" />
-          <div className="h-5 w-16 animate-pulse rounded bg-white/5" />
+        <div className="flex h-10 shrink-0 items-center gap-2 border-b border-black/10 dark:border-white/10 px-3">
+          <div className="h-5 w-24 animate-pulse rounded bg-black/10 dark:bg-white/10" />
+          <div className="h-5 w-16 animate-pulse rounded bg-black/5 dark:bg-white/5" />
         </div>
         <div className="min-h-0 flex-1 space-y-3 p-4">
-          <div className="h-4 w-1/2 animate-pulse rounded bg-white/5" />
-          <div className="ml-auto h-16 w-3/4 animate-pulse rounded-lg bg-white/10" />
-          <div className="h-20 w-4/5 animate-pulse rounded-lg bg-white/5" />
-          <div className="ml-auto h-12 w-2/3 animate-pulse rounded-lg bg-white/10" />
+          <div className="h-4 w-1/2 animate-pulse rounded bg-black/5 dark:bg-white/5" />
+          <div className="ml-auto h-16 w-3/4 animate-pulse rounded-lg bg-black/10 dark:bg-white/10" />
+          <div className="h-20 w-4/5 animate-pulse rounded-lg bg-black/5 dark:bg-white/5" />
+          <div className="ml-auto h-12 w-2/3 animate-pulse rounded-lg bg-black/10 dark:bg-white/10" />
         </div>
-        <div className="h-12 shrink-0 border-t border-white/10 p-2">
-          <div className="h-8 w-full animate-pulse rounded-lg bg-white/5" />
+        <div className="h-12 shrink-0 border-t border-black/10 dark:border-white/10 p-2">
+          <div className="h-8 w-full animate-pulse rounded-lg bg-black/5 dark:bg-white/5" />
         </div>
       </div>
     );
@@ -432,7 +435,9 @@ export function MultiConversationSidebar({ contentId }: Props) {
 
       {creatingNew && (
         <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
-          <div className="text-xs text-gray-300">Creating chat…</div>
+          <div className="rounded-md bg-black/60 px-2.5 py-1 text-xs text-gray-100">
+            Creating chat…
+          </div>
         </div>
       )}
     </div>

--- a/components/content/ai/SidebarChatTabs.tsx
+++ b/components/content/ai/SidebarChatTabs.tsx
@@ -22,6 +22,7 @@ import { Plus, Sparkles, X, Pin } from "lucide-react";
 import { cn } from "@/lib/core/utils";
 import { toast } from "sonner";
 import { getProviderTheme } from "@/lib/design/system/ai-providers";
+import { useResolvedTheme } from "@/lib/features/theme/useResolvedTheme";
 
 export interface SidebarTabEntry {
   conversationId: string;
@@ -130,13 +131,13 @@ export function SidebarChatTabs({
           <div className="relative shrink-0">
             <button
               onClick={() => setOverflowOpen((v) => !v)}
-              className="rounded-full px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400 hover:text-gray-300 hover:bg-white/10 transition-colors"
+              className="rounded-full px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-black/[0.06] dark:hover:bg-white/10 transition-colors"
               title={`${overflow.length} more`}
             >
               …
             </button>
             {overflowOpen && (
-              <div className="absolute top-full right-0 mt-1 min-w-[180px] rounded-lg border border-white/10 bg-[#1a1a1a] shadow-xl z-50 overflow-hidden">
+              <div className="absolute top-full right-0 mt-1 min-w-[180px] rounded-lg border border-black/10 dark:border-white/10 bg-white dark:bg-[#1a1a1a] shadow-xl z-50 overflow-hidden">
                 {overflow.map((t) => (
                   <button
                     key={t.conversationId}
@@ -147,8 +148,8 @@ export function SidebarChatTabs({
                     className={cn(
                       "flex w-full items-center justify-between px-3 py-1.5 text-left text-xs transition-colors",
                       t.conversationId === activeConversationId
-                        ? "bg-white/10 text-white"
-                        : "text-gray-600 dark:text-gray-400 hover:bg-white/5 hover:text-gray-200",
+                        ? "bg-black/[0.06] text-gray-900 dark:bg-white/10 dark:text-white"
+                        : "text-gray-600 dark:text-gray-400 hover:bg-black/[0.04] dark:hover:bg-white/5 hover:text-gray-800 dark:hover:text-gray-200",
                     )}
                   >
                     <span className="truncate">
@@ -209,8 +210,8 @@ function AddMenu({ onNew, onPick }: { onNew: () => void; onPick: () => void }) {
         aria-haspopup="menu"
         aria-expanded={open}
         className={cn(
-          "rounded-md p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-300 hover:bg-white/10 transition-colors",
-          open && "bg-white/10 text-gray-200",
+          "rounded-md p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-black/[0.06] dark:hover:bg-white/10 transition-colors",
+          open && "bg-black/[0.06] text-gray-700 dark:bg-white/10 dark:text-gray-200",
         )}
       >
         <Plus className="h-3.5 w-3.5" />
@@ -218,7 +219,7 @@ function AddMenu({ onNew, onPick }: { onNew: () => void; onPick: () => void }) {
       {open && (
         <div
           role="menu"
-          className="absolute top-full right-0 mt-1 min-w-[160px] rounded-lg border border-white/10 bg-[#1a1a1a] shadow-xl z-50 overflow-hidden py-1"
+          className="absolute top-full right-0 mt-1 min-w-[160px] rounded-lg border border-black/10 dark:border-white/10 bg-white dark:bg-[#1a1a1a] shadow-xl z-50 overflow-hidden py-1"
         >
           <button
             role="menuitem"
@@ -226,7 +227,7 @@ function AddMenu({ onNew, onPick }: { onNew: () => void; onPick: () => void }) {
               setOpen(false);
               onNew();
             }}
-            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-emerald-400 hover:bg-emerald-500/10 hover:text-emerald-300 transition-colors"
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10 hover:text-emerald-700 dark:hover:text-emerald-300 transition-colors"
           >
             <Sparkles className="h-3.5 w-3.5" />
             New chat
@@ -237,7 +238,7 @@ function AddMenu({ onNew, onPick }: { onNew: () => void; onPick: () => void }) {
               setOpen(false);
               onPick();
             }}
-            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-gray-400 hover:bg-white/5 hover:text-gray-200 transition-colors"
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-gray-500 dark:text-gray-400 hover:bg-black/[0.04] dark:hover:bg-white/5 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
           >
             <Pin className="h-3.5 w-3.5" />
             Pin existing chat
@@ -261,7 +262,7 @@ function TabButton({
   onUnpin?: (conversationId: string) => void;
   onRename?: (conversationId: string, newTitle: string) => Promise<void> | void;
 }) {
-  const theme = getProviderTheme(tab.providerId);
+  const theme = getProviderTheme(tab.providerId, useResolvedTheme());
   const label = tabLabel(tab);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(label);
@@ -306,7 +307,7 @@ function TabButton({
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/60",
         active
           ? "z-10"
-          : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-300 hover:bg-white/[0.04]",
+          : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-black/[0.04] dark:hover:bg-white/[0.04]",
         editing ? "cursor-text" : "cursor-pointer",
       )}
       style={

--- a/components/content/ai/reasoning/ReasoningBlockChatGPT.tsx
+++ b/components/content/ai/reasoning/ReasoningBlockChatGPT.tsx
@@ -29,7 +29,7 @@ export function ReasoningBlockChatGPT({ text, streaming }: ReasoningBlockProps) 
       <button
         type="button"
         onClick={() => setUserPref(!open)}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-[#10A37F] hover:bg-[#10A37F]/[0.08] transition-colors rounded-lg"
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-[#0B7A5E] dark:text-[#10A37F] hover:bg-[#10A37F]/[0.08] transition-colors rounded-lg"
       >
         {open ? (
           <ChevronDown className="h-3 w-3 opacity-70" />
@@ -49,18 +49,18 @@ export function ReasoningBlockChatGPT({ text, streaming }: ReasoningBlockProps) 
           {steps.map((step, i) => (
             <li
               key={i}
-              className="flex gap-2.5 rounded-md border border-[#10A37F]/15 bg-black/20 px-2.5 py-1.5"
+              className="flex gap-2.5 rounded-md border border-[#10A37F]/15 bg-black/[0.03] dark:bg-black/20 px-2.5 py-1.5"
             >
-              <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-[#10A37F]/25 text-[10px] font-bold text-[#10A37F]">
+              <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-[#10A37F]/25 text-[10px] font-bold text-[#0B7A5E] dark:text-[#10A37F]">
                 {i + 1}
               </span>
-              <span className="text-xs leading-relaxed text-gray-300 whitespace-pre-wrap">
+              <span className="text-xs leading-relaxed text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
                 {step}
               </span>
             </li>
           ))}
           {streaming && (
-            <li className="flex items-center gap-2 px-2.5 py-1 text-[11px] text-[#10A37F]/70">
+            <li className="flex items-center gap-2 px-2.5 py-1 text-[11px] text-[#0B7A5E]/80 dark:text-[#10A37F]/70">
               <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[#10A37F]" />
               <span>working through next step</span>
             </li>

--- a/components/content/ai/reasoning/ReasoningBlockGemini.tsx
+++ b/components/content/ai/reasoning/ReasoningBlockGemini.tsx
@@ -70,7 +70,7 @@ export function ReasoningBlockGemini({ text, streaming }: ReasoningBlockProps) {
       <button
         type="button"
         onClick={() => setUserPref(!open)}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[#4285F4] hover:bg-white/[0.04] transition-colors rounded-lg"
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[#1967D2] dark:text-[#4285F4] hover:bg-black/[0.03] dark:hover:bg-white/[0.04] transition-colors rounded-lg"
       >
         {open ? (
           <ChevronDown className="h-3 w-3 opacity-70" />
@@ -81,11 +81,11 @@ export function ReasoningBlockGemini({ text, streaming }: ReasoningBlockProps) {
         <span>{streaming ? "Thinking process…" : "Thinking process"}</span>
       </button>
       {open && (
-        <div className="space-y-2.5 px-3.5 pb-3 pt-1 text-xs leading-relaxed text-gray-300">
+        <div className="space-y-2.5 px-3.5 pb-3 pt-1 text-xs leading-relaxed text-gray-700 dark:text-gray-300">
           {sections.map((s, i) => (
             <div key={i}>
               {s.heading && (
-                <div className="mb-1 text-[11px] font-semibold text-[#4285F4]/90">
+                <div className="mb-1 text-[11px] font-semibold text-[#1967D2]/90 dark:text-[#4285F4]/90">
                   {s.heading}
                 </div>
               )}
@@ -101,7 +101,7 @@ export function ReasoningBlockGemini({ text, streaming }: ReasoningBlockProps) {
             </div>
           ))}
           {streaming && (
-            <div className="flex items-center gap-1.5 text-[11px] text-[#4285F4]/70">
+            <div className="flex items-center gap-1.5 text-[11px] text-[#1967D2]/80 dark:text-[#4285F4]/70">
               <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[#4285F4]" />
               <span>continuing</span>
             </div>

--- a/components/content/ai/reasoning/ReasoningBlockGeneric.tsx
+++ b/components/content/ai/reasoning/ReasoningBlockGeneric.tsx
@@ -16,11 +16,11 @@ export function ReasoningBlockGeneric({ text, streaming }: ReasoningBlockProps) 
   const open = userPref ?? Boolean(streaming);
 
   return (
-    <div className="my-2 rounded-lg border border-white/10 bg-white/[0.03]">
+    <div className="my-2 rounded-lg border border-black/10 bg-black/[0.02] dark:border-white/10 dark:bg-white/[0.03]">
       <button
         type="button"
         onClick={() => setUserPref(!open)}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-400 hover:bg-white/[0.04] transition-colors rounded-lg"
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 hover:bg-black/[0.03] dark:hover:bg-white/[0.04] transition-colors rounded-lg"
       >
         {open ? (
           <ChevronDown className="h-3 w-3 opacity-70" />
@@ -31,7 +31,7 @@ export function ReasoningBlockGeneric({ text, streaming }: ReasoningBlockProps) 
         <span>{streaming ? "Thinking…" : "Reasoning"}</span>
       </button>
       {open && (
-        <div className="px-3.5 pb-2.5 pt-1 text-xs leading-relaxed text-gray-400 whitespace-pre-wrap">
+        <div className="px-3.5 pb-2.5 pt-1 text-xs leading-relaxed text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
           {text}
           {streaming && <span className="ml-0.5 inline-block animate-pulse">▍</span>}
         </div>

--- a/components/content/editor/MarkdownEditor.tsx
+++ b/components/content/editor/MarkdownEditor.tsx
@@ -41,6 +41,10 @@ import type {
   CollaborationUser,
 } from "@/lib/domain/collaboration/runtime";
 import { sanitizeTipTapJsonWithExtensions } from "@/lib/domain/editor/unsupported-content";
+import {
+  hasMeaningfulTipTapContent,
+  ydocHasMeaningfulDefaultContent,
+} from "@/lib/domain/collaboration/content-safety";
 import { dropPoint } from "@tiptap/pm/transform";
 import type { NodeSelection } from "@tiptap/pm/state";
 import type { Slice } from "@tiptap/pm/model";
@@ -290,6 +294,57 @@ export function MarkdownEditor({
     () => sanitizeTipTapJsonWithExtensions(content, viewerExtensions).json,
     [content, viewerExtensions]
   );
+  // Does the durable REST payload prove this note has real content? This is the
+  // authoritative "content exists" signal — the NotePayload is persisted and
+  // survives regardless of collaboration state. When it is true we must NEVER
+  // show a blank document: the collaboration Y.Doc has to actually carry that
+  // content before the editor is allowed to bind to it.
+  const restContentIsMeaningful = useMemo(
+    () => hasMeaningfulTipTapContent(safeContent),
+    [safeContent]
+  );
+  // Reactively track whether the collaboration Y.Doc's "default" field carries
+  // meaningful content yet. The Y.Doc mutates in place (bootstrap seeding,
+  // canonical apply, provider sync), so we observe it rather than reading once.
+  // We stop observing as soon as it reports ready — subsequent user typing does
+  // not need this (potentially heavy) fromYdoc transform on every keystroke.
+  const [ydocContentReady, setYdocContentReady] = useState(false);
+  useEffect(() => {
+    if (!runtimeYdoc) {
+      setYdocContentReady(false);
+      return;
+    }
+    // Reset for this (possibly new) document, then read the current state.
+    if (ydocHasMeaningfulDefaultContent(runtimeYdoc)) {
+      setYdocContentReady(true);
+      return;
+    }
+    setYdocContentReady(false);
+    const fragment = runtimeYdoc.getXmlFragment("default");
+    const evaluate = () => {
+      if (ydocHasMeaningfulDefaultContent(runtimeYdoc)) {
+        setYdocContentReady(true);
+        // Once content is present it stays present for binding purposes; stop
+        // paying for the transform on every structural mutation.
+        fragment.unobserveDeep(evaluate);
+      }
+    };
+    fragment.observeDeep(evaluate);
+    return () => {
+      fragment.unobserveDeep(evaluate);
+    };
+  }, [runtimeYdoc]);
+  // Anti-blank-document guard (the whole point of this component's care around
+  // collaboration): the editor may bind to the collaborative Y.Doc only when
+  // either the note is genuinely empty (nothing to protect) or the Y.Doc has
+  // actually materialized the content the REST payload promises. Otherwise the
+  // "plain" branch keeps the REST content on screen — a document that exists
+  // never renders blank. The gate is sticky: once we have entered collaboration
+  // for this instance we never fall back out of it (a later transient empty
+  // read must not unbind a live collaborative session).
+  const hasEnteredCollaborationRef = useRef(false);
+  const collaborationBindingSafe =
+    hasEnteredCollaborationRef.current || !restContentIsMeaningful || ydocContentReady;
   // Tracks the content reference the editor currently holds, seeded with the
   // value the editor is created with (see useEditor `content` below). The
   // content-sync effect compares against this to skip the redundant initial
@@ -304,7 +359,8 @@ export function MarkdownEditor({
       !isPlainEditorFallback &&
       runtimeYdoc &&
       runtimePersistenceState === "localReady" &&
-      runtimeBootstrapState === "ready"
+      runtimeBootstrapState === "ready" &&
+      collaborationBindingSafe
         ? {
             document: runtimeYdoc,
             provider: runtimeProvider,
@@ -325,8 +381,21 @@ export function MarkdownEditor({
       runtimeReadOnly,
       runtimeUser,
       runtimeYdoc,
+      collaborationBindingSafe,
     ]
   );
+  // Latch the sticky guard the moment we successfully enter collaboration, so a
+  // later transient "Y.Doc looks empty" read can never tear down a live session.
+  useEffect(() => {
+    if (collaborationState) hasEnteredCollaborationRef.current = true;
+  }, [collaborationState]);
+  // This editor instance is reused across documents (see contentIdRef), so the
+  // sticky collaboration latch must be released on navigation — otherwise a new
+  // note would inherit the previous note's "already bound" state and skip the
+  // anti-blank guard.
+  useEffect(() => {
+    hasEnteredCollaborationRef.current = false;
+  }, [contentId]);
   const collaborationWarning = collaborationRuntime?.state.warning ?? null;
   const collaborationNotice = runtimeEditPolicy?.warning ?? collaborationWarning;
   const isCollaborationEditBlocked =

--- a/components/content/viewer/ChatViewer.tsx
+++ b/components/content/viewer/ChatViewer.tsx
@@ -30,6 +30,7 @@ import {
   buildSurfaceBackground,
   detectMixedProvider,
 } from "@/lib/design/system/ai-providers";
+import { useResolvedTheme } from "@/lib/features/theme/useResolvedTheme";
 import type { AIProviderId } from "@/lib/domain/ai/types";
 import { extractChatOutline } from "@/lib/domain/ai/chat-outline";
 import { useOutlineStore } from "@/state/outline-store";
@@ -510,6 +511,7 @@ function ChatViewerInner({
   const [renamingTitle, setRenamingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState("");
   const titleInputRef = useRef<HTMLInputElement>(null);
+  const resolvedTheme = useResolvedTheme();
   const displayTitle = titleOverride ?? conversationTitle ?? title;
 
   const beginRenameTitle = useCallback(() => {
@@ -576,9 +578,11 @@ function ChatViewerInner({
       providerId: getMessageStamp(m.id, { providerId, modelId }).providerId,
     })),
   );
-  const surfaceBackground = buildSurfaceBackground(providerId, [
-    providerId as AIProviderId,
-  ]);
+  const surfaceBackground = buildSurfaceBackground(
+    providerId,
+    [providerId as AIProviderId],
+    resolvedTheme,
+  );
 
   return (
     <div
@@ -586,9 +590,9 @@ function ChatViewerInner({
       style={{ background: surfaceBackground }}
     >
       {/* Header */}
-      <div className="flex shrink-0 flex-col gap-2 border-b border-white/10 px-6 py-4">
+      <div className="flex shrink-0 flex-col gap-2 border-b border-black/10 dark:border-white/10 px-6 py-4">
         <div className="flex items-center gap-3">
-          <Bot className="h-5 w-5 text-green-400" />
+          <Bot className="h-5 w-5 text-green-600 dark:text-green-400" />
           <div className="min-w-0 flex-1">
             {renamingTitle ? (
               <input
@@ -606,11 +610,11 @@ function ChatViewerInner({
                   }
                 }}
                 onBlur={() => void commitRenameTitle()}
-                className="w-full bg-transparent text-lg font-semibold text-white outline-none border-b border-white/30 focus:border-white/60"
+                className="w-full bg-transparent text-lg font-semibold text-gray-900 dark:text-white outline-none border-b border-black/30 dark:border-white/30 focus:border-black/60 dark:focus:border-white/60"
               />
             ) : (
               <h1
-                className="text-lg font-semibold text-white truncate cursor-text"
+                className="text-lg font-semibold text-gray-900 dark:text-white truncate cursor-text"
                 onDoubleClick={beginRenameTitle}
                 title="Double-click to rename"
               >
@@ -678,7 +682,7 @@ function ChatViewerInner({
         <button
           type="button"
           onClick={scrollToBottom}
-          className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-white/15 bg-[#1a1a1a]/90 px-3 py-1 text-xs text-gray-200 shadow-lg backdrop-blur transition-colors hover:bg-white/10"
+          className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-black/15 bg-white/90 text-gray-700 hover:bg-black/[0.06] dark:border-white/15 dark:bg-[#1a1a1a]/90 dark:text-gray-200 dark:hover:bg-white/10 px-3 py-1 text-xs shadow-lg backdrop-blur transition-colors"
         >
           <ChevronDown className="h-3.5 w-3.5" /> Jump to latest
         </button>
@@ -735,9 +739,9 @@ function ChatViewerInner({
 function ChatViewerLoading({ title }: { title: string }) {
   return (
     <div className="flex h-full flex-col">
-      <div className="flex shrink-0 items-center gap-3 border-b border-white/10 px-6 py-4">
-        <Bot className="h-5 w-5 text-green-400" />
-        <h1 className="text-lg font-semibold text-white truncate">{title}</h1>
+      <div className="flex shrink-0 items-center gap-3 border-b border-black/10 dark:border-white/10 px-6 py-4">
+        <Bot className="h-5 w-5 text-green-600 dark:text-green-400" />
+        <h1 className="text-lg font-semibold text-gray-900 dark:text-white truncate">{title}</h1>
       </div>
       <ChatLoadingBody />
     </div>
@@ -750,7 +754,7 @@ function ChatLoadingBody() {
     <div className="flex h-full flex-col items-center justify-center gap-3 px-4">
       <div className="flex w-full max-w-[420px] flex-col gap-2 opacity-50 animate-pulse">
         <div className="ml-auto h-8 w-2/3 rounded-xl bg-blue-500/20" />
-        <div className="h-10 w-3/4 rounded-xl bg-white/10" />
+        <div className="h-10 w-3/4 rounded-xl bg-black/10 dark:bg-white/10" />
         <div className="ml-auto h-8 w-1/2 rounded-xl bg-blue-500/20" />
       </div>
       <p className="text-[10px] uppercase tracking-wider text-gray-500">
@@ -764,10 +768,10 @@ function ChatLoadingBody() {
 function EmptyState({ title }: { title: string }) {
   return (
     <div className="flex h-full flex-col items-center justify-center p-8 text-center">
-      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/5 border border-white/10 mb-4">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 mb-4">
         <Bot className="h-8 w-8 text-gray-500" />
       </div>
-      <h2 className="text-lg font-medium text-gray-300">{title}</h2>
+      <h2 className="text-lg font-medium text-gray-700 dark:text-gray-300">{title}</h2>
       <p className="mt-2 text-sm text-gray-500 max-w-sm">
         Start a conversation. Messages are automatically saved.
       </p>

--- a/docs/notes-feature/core/CONTENT-LOAD-CASCADE.md
+++ b/docs/notes-feature/core/CONTENT-LOAD-CASCADE.md
@@ -1,7 +1,9 @@
 # Content Page Load Cascade — Spec & Remediation Plan
 
-> Status: **DRAFT for approval** (2026-06-07). Authoritative contract for how
-> the authenticated `/content` page loads. New features and refactors that
+> Status: **DRAFT for approval** (2026-06-07; §4 data-safety invariant + §9
+> offline & non-standard contexts added 2026-07-02; §9.6 levers implemented
+> 2026-07-02). Authoritative contract for
+> how the authenticated `/content` page loads. New features and refactors that
 > touch the content surface MUST conform to the cascade and rules below.
 
 ## 1. Why this exists
@@ -137,6 +139,19 @@ the top-level order, but each must honor §3 rules).
   promotes `editorMode` `"collaboration-local"` → `"collaboration"`
   (`canonical`). It must never gate first contentful paint of the editor.
   Only for collaborative types (notes).
+- **Promotion must never regress content → blank (data-safety invariant).**
+  The plain/fallback editor paints the durable REST `NotePayload`. Promotion to
+  `"collaboration"` **recreates** the editor bound to the Y.Doc (the `useEditor`
+  deps change), which is only safe once that Y.Doc actually carries the content
+  the payload proves exists. The editor MUST NOT bind to an empty/partial Y.Doc
+  while the REST payload is non-empty; until the Y.Doc materializes that content
+  the editor keeps showing the payload — **never a blank document, and never a
+  skeleton painted over content we already hold.** "A document that exists only
+  ever loads content." Enforced in `MarkdownEditor` via `collaborationBindingSafe`
+  (`!restContentIsMeaningful || ydocContentReady`, latched sticky per instance).
+  This invariant is what makes the cascade safe in the harsher persistence
+  environments of §9. Do **not** attempt to satisfy it by re-tuning the
+  `runtime.ts` bootstrap state machine — enforce it at the binding layer.
 - **Teardown on navigation** (rule §3.6): switching a pane's active content —
   or hiding a pane via a layout change — tears down that pane's provider
   before the next content's provider mounts.
@@ -225,3 +240,138 @@ the top-level order, but each must honor §3 rules).
   tears the provider down.
 - Gates: `pnpm typecheck` → `pnpm lint` (≤175) → `pnpm build`; browser
   smoke on `:3017`. Consider a Playwright timing assertion for the cascade.
+
+## 9. Offline capabilities & non-standard browser contexts
+
+This section exists because the recurring "existing note opens blank / flashes
+then disappears" incidents all trace to the same seam: a note has **two content
+representations** that can disagree, and the cascade can bind the editor to the
+wrong one. Anything touching content load, save, or collaboration MUST hold the
+rules here.
+
+### 9.1 The two representations (know which is authoritative)
+
+| | `NotePayload.tiptapJson` (REST) | `CollaborationDocument` Y.Doc (CRDT) |
+|---|---|---|
+| Role | **Durable source of truth.** Survives every collab state. | Live-editing / real-time surface + offline local buffer. |
+| Written by | REST `PATCH /content/[id]`, extension writes, importers, AI. | Hocuspocus (`storeCollaborationYDocState`) on collab edits. |
+| Client cache | Server-inlined `initialContent` + fetch. | Per-content `IndexeddbPersistence` (`dg:content:<id>`). |
+| Emptiness meaning | Empty ⇒ note genuinely has no content. | Empty ⇒ **unknown** — may just not be bootstrapped/synced yet. |
+
+**Rule:** REST `NotePayload` is the authority on *"does content exist?"*. The
+Y.Doc is authoritative on *"what is the latest collaborative state"* only once it
+has actually synced. Never treat an empty/unbootstrapped Y.Doc as proof the note
+is empty. (This is the basis of the §4 promotion invariant.)
+
+### 9.2 Offline capability — current state & requirements
+
+**Requirement (target):** a user can edit a note (a) while starting offline,
+(b) after being disconnected mid-session, (c) across a reload or a killed tab —
+and those edits are durable locally and sync losslessly on reconnect, with the
+document **never** rendering blank at any point.
+
+**Current implementation:** offline editing is real **only when
+`NEXT_PUBLIC_COLLABORATION_ENABLED=true`.** The per-content `IndexeddbPersistence`
++ Y.Doc buffers edits locally; `runtime.ts` models this with
+`connectionState` `localOnly` / `disconnectedButDirty` and `editPolicy` reason
+`offline-local-durable` ("Changes are saved locally and will sync when
+collaboration reconnects"), reconnecting via `reconnect-after-offline`.
+- With collaboration **disabled**, notes use plain REST autosave, which has **no
+  durable offline story** beyond the in-memory `save-conflict-store` draft. Do
+  not describe the product as offline-capable in that mode.
+- The plain-mode editor stays editable during a bootstrap wait (§4 invariant),
+  so REST autosave keeps working; when collab later materializes, the Y.Doc
+  seeds from the now-current `NotePayload`.
+
+### 9.3 Non-standard browser contexts (mobile webview, extension iframe)
+
+The browser-extension embed (`app/embed/content/[id]` → `MainPanelWorkspace`) and
+the app opened in a **mobile webview** run the **identical** cascade and editor
+pipeline as desktop. They differ only in environment, and those differences are
+exactly what surface the binding bug:
+- **Aggressive IndexedDB eviction / partitioned storage** → the local Y.Doc is
+  frequently **absent, empty, or stale** at bind time.
+- **Lifecycle suspension** (backgrounded webview/iframe killed) → providers drop
+  mid-sync; local persistence may be half-written.
+- **Flakier networks** → Hocuspocus promotion races harder against first paint.
+
+**Rules:**
+1. Never assume the local Y.Doc exists, is populated, or is current in these
+   contexts. The §4 invariant + REST-as-truth (§9.1) is what keeps them safe.
+2. Any new load/persistence path must be validated in an **iframe and a
+   throttled/evicted-storage** profile, not just desktop.
+3. The "mobile app" (native) is a separate, currently-unstable track — **not**
+   this pipeline. "Mobile" in this doc means mobile **webview** of the web app.
+
+**Design decision — no REST-only mode (do not re-propose).** It is tempting to
+"fix" iframe/webview fragility by running those surfaces collaboration-disabled
+(plain REST). **We do not do this.** Running the *same* collaborative pipeline
+everywhere is a deliberate product value — the compatibility and uniform
+behavior (real-time sync + offline durability on every surface) outweigh the
+convenience of a REST-only escape hatch. Harden the Y.js path instead (§9.6),
+never bypass it. (Per-document `plainFallback` — the emergency last resort when a
+single doc genuinely cannot load into a Y.Doc — is a safety net, not a mode
+choice, and is fine.)
+
+### 9.4 Freshness contract — writes that bypass the Y.Doc
+
+Any server path that updates `NotePayload` **without** going through the
+collaborative Y.Doc MUST realign the `CollaborationDocument` afterward, or a
+stale-but-non-empty Y.Doc will win at bootstrap and mask the write (stale/blank
+note on next open). Use `reseedCollaborationDocumentFromNote(prisma, contentId)`.
+- **Known bypassing writers:** browser extension `updateExtensionNoteContent`
+  (wired 2026-07-02). **Any** future out-of-band note writer (bulk import, AI
+  edits, a REST mobile client) must do the same — this is a checklist item for
+  new note-write endpoints.
+- The reseed is **non-fatal**: `NotePayload` is the durable truth, so a reseed
+  failure logs and does not fail the write.
+- **Known residual (out of scope):** an out-of-band REST write racing a *live*
+  Hocuspocus session on the same note is the inherent two-writers conflict;
+  reseed does not resolve it (the live session re-persists its own state).
+  Proper reconciliation (revision vectors / last-writer-by-timestamp across the
+  two representations) is future work. Related: the destructive-PATCH guard
+  history in `storeCollaborationYDocState`.
+
+### 9.5 Verification (offline & context matrix)
+
+- **Extension write → app open:** edit a note via the extension, open it in the
+  app with collaboration enabled → shows the extension's content, never stale,
+  never blank.
+- **Cold webview/iframe open:** open a content-bearing note in the extension
+  iframe (and a mobile webview) with empty/evicted IndexedDB → content paints
+  and stays; only a "Connecting collaborative editor…" notice may appear — never
+  a blank editor.
+- **Offline round-trip:** go offline, edit, reload (edits persist), reconnect →
+  edits sync with no loss and no blank frame.
+
+### 9.6 Hardening levers (keep collaboration, reduce breakage)
+
+Per §9.3 we keep Y.js on every surface; these strengthen it in hostile contexts
+without abandoning it. All three are **implemented** (2026-07-02):
+
+- **`navigator.storage.persist()` on module load** ✅ — Added to
+  `lib/domain/collaboration/runtime.ts` (fires once when the module first loads,
+  client-side). Marks origin storage *persistent* so the browser stops
+  auto-evicting the Y.Doc's IndexedDB buffer under pressure/inactivity.
+  Best-effort and browser-discretionary; often **denied** in partitioned
+  third-party iframes — it mainly helps the standalone app + mobile webview (as
+  a top-level origin). Fire-and-forget; no behavior gated on the result.
+
+- **Third-party-safe collab token auth** ✅ — Already implemented. The embed
+  layout's inline `EMBED_BRIDGE_SCRIPT` patches `window.fetch` to inject
+  `X-Embed-Session` on all `/api/*` calls before any React code runs. Server-side
+  `validateSession` accepts `X-Embed-Session` as a fallback when the cookie is
+  blocked (see `lib/infrastructure/auth/session.ts:79`). The Hocuspocus WebSocket
+  uses a fetched JWT token (not cookies), so the full auth chain already works in
+  partitioned-cookie contexts.
+
+- **Faster hostile-context detection** ✅ — Added `INDEXEDDB_INIT_TIMEOUT_MS =
+  4_000` watchdog and new `routeToPlainFallback()` method in
+  `lib/domain/collaboration/runtime.ts`. If IndexedDB doesn't respond within 4s
+  (blocked or frozen by the browser), the editor routes to `plainFallback`
+  (editable via REST auto-save) instead of hanging in read-only "booting" state
+  for 25s. The `whenSynced.catch()` path now also routes to `plainFallback` via
+  the same method rather than `markBootstrapFailed` (read-only). Recovery: if
+  IndexedDB later resolves, `bootstrapInitialContent` re-runs and upgrades to
+  canonical automatically. `PersistenceState` type extended with `"unavailable"`
+  to represent blocked-storage state.

--- a/extensions/browser-bookmarks/browser-extension/src/background/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/background/index.js
@@ -1221,13 +1221,19 @@ async function plantEmbedCookie(appBaseUrl, { token, expiresAt, cookieName }) {
   const url = appBaseUrl.replace(/\/$/, "");
   const isSecure = url.startsWith("https://");
   const base = {
-    url,
+    url: `${url}/embed`,
     name: cookieName,
     value: token,
     httpOnly: true,
     secure: isSecure,
     expirationDate: new Date(expiresAt).getTime() / 1000,
-    path: "/",
+    // MUST stay scoped to /embed. Cookies are keyed by (name, domain, path) —
+    // at path "/" this short-lived token REPLACES the user's 7-day session
+    // cookie set by sign-in, logging them out of the app when it expires.
+    // Server-side embed cookie writers (proxy.ts, /embed/auth) enforce the
+    // same scoping; /api/* calls from the iframe use the X-Embed-Session
+    // header instead, so nothing outside /embed needs this cookie.
+    path: "/embed",
   };
 
   // Attempt 1: SameSite=None (required for cross-site iframe delivery).
@@ -1269,15 +1275,18 @@ async function plantEmbedCookie(appBaseUrl, { token, expiresAt, cookieName }) {
  * Uses chrome.storage.session to cache the session across service worker restarts
  * (MV3 workers wake frequently — this avoids a DB round-trip on each wake).
  */
-async function exchangeEmbedSession() {
+async function exchangeEmbedSession({ force = false } = {}) {
   const config = await getConfig();
   if (!config.appBaseUrl || !config.token) return null;
 
   try {
-    // Check session cache first
+    // Check session cache first. `force` skips it — the 20-min alarm must
+    // always mint a fresh session, because at that point the cached token has
+    // ~10 min left (> the 2-min buffer) and the NEXT alarm at 40 min lands
+    // after its 30-min expiry, leaving a dead-cookie window from minute 30-40.
     const cached = await chrome.storage.session.get(EMBED_SESSION_CACHE_KEY);
     const cachedSession = cached[EMBED_SESSION_CACHE_KEY];
-    if (cachedSession?.token && cachedSession?.expiresAt) {
+    if (!force && cachedSession?.token && cachedSession?.expiresAt) {
       const msRemaining = new Date(cachedSession.expiresAt).getTime() - Date.now();
       if (msRemaining > EMBED_SESSION_REFRESH_BUFFER_MS) {
         // Still valid — just re-plant the cookie (cheap: no DB, no API call)
@@ -1468,7 +1477,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
     });
   }
   if (alarm.name === "dg-embed-session-refresh") {
-    await exchangeEmbedSession().catch((error) => {
+    await exchangeEmbedSession({ force: true }).catch((error) => {
       console.error("[DG Bookmarks] Embed session refresh failed", error);
     });
   }

--- a/extensions/daily-notes/client.tsx
+++ b/extensions/daily-notes/client.tsx
@@ -1,6 +1,7 @@
 import { DAILY_NOTES_ACTION_ID, DAILY_NOTES_EXTENSION_ID } from "./manifest";
 import { PeriodicNotesHeaderAction } from "./components/PeriodicNotesHeaderAction";
 import { PeriodicNotesShellController } from "./components/PeriodicNotesShellController";
+import { PeriodicNotesGlideController } from "./components/PeriodicNotesGlideController";
 import PeriodicNotesSettingsDialog from "./settings/PeriodicNotesSettingsDialog";
 import type { ExtensionRuntime } from "@/lib/extensions/types";
 
@@ -9,6 +10,6 @@ export const dailyNotesExtensionRuntime: ExtensionRuntime = {
   headerNavActions: {
     [DAILY_NOTES_ACTION_ID]: PeriodicNotesHeaderAction,
   },
-  shellControllers: [PeriodicNotesShellController],
+  shellControllers: [PeriodicNotesShellController, PeriodicNotesGlideController],
   settingsDialog: PeriodicNotesSettingsDialog,
 };

--- a/extensions/daily-notes/components/PeriodicNotesGlideController.tsx
+++ b/extensions/daily-notes/components/PeriodicNotesGlideController.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import moment from "moment";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useContentStore } from "@/state/content-store";
+
+interface NeighborNote {
+  id: string;
+  title: string;
+  periodKey: string;
+}
+
+interface NeighborsState {
+  // The note these neighbors belong to. Guards against a slow fetch resolving
+  // after the user has already glided/switched to a different note.
+  contentId: string;
+  kind: string;
+  prev: NeighborNote | null;
+  next: NeighborNote | null;
+}
+
+function formatNeighborLabel(kind: string, periodKey: string): string {
+  if (kind === "weekly") {
+    const parsed = moment(periodKey, "GGGG-[W]WW");
+    return parsed.isValid() ? parsed.format("[Wk] WW") : periodKey;
+  }
+  if (kind === "monthly") {
+    const parsed = moment(periodKey, "YYYY-MM");
+    return parsed.isValid() ? parsed.format("MMM YYYY") : periodKey;
+  }
+  if (kind === "quarterly") {
+    // periodKey is "YYYY-Q#" — surface it as "Q# YYYY".
+    const parsed = moment(periodKey, "YYYY-[Q]Q");
+    return parsed.isValid() ? parsed.format("[Q]Q YYYY") : periodKey;
+  }
+  if (kind === "yearly") {
+    // periodKey is already "YYYY" — nothing to reformat.
+    return periodKey;
+  }
+  const parsed = moment(periodKey, "YYYY-MM-DD");
+  return parsed.isValid() ? parsed.format("ddd, MMM D") : periodKey;
+}
+
+/**
+ * Sparse "glide" navigation between periodic notes. Renders a floating pill
+ * over the workspace when the focused pane is showing a daily/weekly note,
+ * letting the user step to the nearest existing note before/after it in its
+ * sequence. Backed by GET /api/periodic-notes/neighbors — no client-side
+ * sequencing logic, the DB index does the ordering.
+ */
+export function PeriodicNotesGlideController() {
+  const selectedContentId = useContentStore((state) => state.selectedContentId);
+  const selectedContentType = useContentStore(
+    (state) => state.selectedContentType
+  );
+  const setSelectedContentId = useContentStore(
+    (state) => state.setSelectedContentId
+  );
+  const [neighbors, setNeighbors] = useState<NeighborsState | null>(null);
+
+  useEffect(() => {
+    // Only notes can be periodic — skip the round-trip for folders/files.
+    // Stale state (from a previously-open note) is filtered at render time by
+    // matching contentId, so there's no need to synchronously clear here.
+    if (!selectedContentId || selectedContentType !== "note") return;
+
+    const contentId = selectedContentId;
+    const controller = new AbortController();
+    const load = async () => {
+      try {
+        const response = await fetch(
+          `/api/periodic-notes/neighbors?contentId=${encodeURIComponent(contentId)}`,
+          { credentials: "include", signal: controller.signal }
+        );
+        const result = await response.json();
+        if (controller.signal.aborted) return;
+
+        if (response.ok && result.success && result.data?.isPeriodic) {
+          setNeighbors({
+            contentId,
+            kind: result.data.kind,
+            prev: result.data.prev,
+            next: result.data.next,
+          });
+        } else {
+          setNeighbors(null);
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          console.warn("[PeriodicNotesGlideController] neighbors fetch failed:", error);
+        }
+      }
+    };
+
+    void load();
+    return () => controller.abort();
+  }, [selectedContentId, selectedContentType]);
+
+  const glideTo = useCallback(
+    (target: NeighborNote | null) => {
+      if (!target) return;
+      setSelectedContentId(target.id, {
+        title: target.title,
+        contentType: "note",
+      });
+    },
+    [setSelectedContentId]
+  );
+
+  // Render only when the resolved neighbors belong to the currently-focused
+  // note (guards the async race) and there's somewhere to glide to.
+  if (
+    !neighbors ||
+    neighbors.contentId !== selectedContentId ||
+    (!neighbors.prev && !neighbors.next)
+  ) {
+    return null;
+  }
+
+  const buttonBase =
+    "flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium transition-colors";
+  const enabled =
+    "text-gray-900 hover:bg-primary/10 hover:text-primary dark:text-gray-200 dark:hover:bg-white/10 dark:hover:text-white";
+  const disabled = "cursor-default text-gray-400 dark:text-gray-600";
+
+  return (
+    <div className="pointer-events-none fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
+      <div className="pointer-events-auto flex items-center gap-1 rounded-full border border-black/10 bg-white/95 px-1.5 py-1 shadow-lg backdrop-blur-sm dark:border-white/10 dark:bg-gray-900/95">
+        <button
+          type="button"
+          className={`${buttonBase} ${neighbors.prev ? enabled : disabled}`}
+          onClick={() => glideTo(neighbors.prev)}
+          disabled={!neighbors.prev}
+          title={
+            neighbors.prev
+              ? `Previous note · ${neighbors.prev.title}`
+              : "No earlier note"
+          }
+          aria-label="Previous periodic note"
+        >
+          <ChevronLeft className="h-3.5 w-3.5 shrink-0" />
+          {neighbors.prev
+            ? formatNeighborLabel(neighbors.kind, neighbors.prev.periodKey)
+            : "Start"}
+        </button>
+
+        <div className="h-4 w-px bg-black/10 dark:bg-white/10" />
+
+        <button
+          type="button"
+          className={`${buttonBase} ${neighbors.next ? enabled : disabled}`}
+          onClick={() => glideTo(neighbors.next)}
+          disabled={!neighbors.next}
+          title={
+            neighbors.next
+              ? `Next note · ${neighbors.next.title}`
+              : "No later note"
+          }
+          aria-label="Next periodic note"
+        >
+          {neighbors.next
+            ? formatNeighborLabel(neighbors.kind, neighbors.next.periodKey)
+            : "Latest"}
+          <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/extensions/daily-notes/components/PeriodicNotesHeaderAction.tsx
+++ b/extensions/daily-notes/components/PeriodicNotesHeaderAction.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import moment from "moment";
 import { toast } from "sonner";
 import { renderExtensionIcon } from "@/lib/extensions/icons";
@@ -19,6 +20,57 @@ import { useSettingsStore } from "@/state/settings-store";
 import { DAILY_NOTES_EXTENSION_ID } from "../manifest";
 
 const HOLD_TO_OPEN_MS = 550;
+
+// One "period" ahead resolves per kind: +1 day / week / month / year. Months
+// and years are variable-length, so we advance by the calendar unit rather than
+// a fixed day count.
+const PERIOD_UNIT: Record<PeriodicNoteKind, moment.unitOfTime.DurationConstructor> = {
+  daily: "days",
+  weekly: "weeks",
+  monthly: "months",
+  quarterly: "quarters",
+  yearly: "years",
+};
+
+const NEXT_PERIOD_NOUN: Record<PeriodicNoteKind, string> = {
+  daily: "tomorrow's note",
+  weekly: "next week's note",
+  monthly: "next month's note",
+  quarterly: "next quarter's note",
+  yearly: "next year's note",
+};
+
+const CURRENT_PERIOD_NOUN: Record<PeriodicNoteKind, string> = {
+  daily: "daily note",
+  weekly: "weekly note",
+  monthly: "monthly note",
+  quarterly: "quarterly note",
+  yearly: "yearly note",
+};
+
+const PREV_PERIOD_NOUN: Record<PeriodicNoteKind, string> = {
+  daily: "yesterday's note",
+  weekly: "last week's note",
+  monthly: "last month's note",
+  quarterly: "last quarter's note",
+  yearly: "last year's note",
+};
+
+// Per-interval affordance: previous / current / next, only rendered for
+// enabled kinds. Each label maps to an offsetPeriods (-1 / 0 / +1).
+const PERIOD_NAV: Array<{
+  kind: PeriodicNoteKind;
+  label: string;
+  prev: string;
+  current: string;
+  next: string;
+}> = [
+  { kind: "daily", label: "Daily", prev: "Yesterday", current: "Today", next: "Tomorrow" },
+  { kind: "weekly", label: "Weekly", prev: "Last Week", current: "To Week", next: "Next Week" },
+  { kind: "monthly", label: "Monthly", prev: "Last Month", current: "To Month", next: "Next Month" },
+  { kind: "quarterly", label: "Quarterly", prev: "Last Quarter", current: "To Quarter", next: "Next Quarter" },
+  { kind: "yearly", label: "Yearly", prev: "Last Year", current: "To Year", next: "Next Year" },
+];
 
 interface MenuPosition {
   top: number;
@@ -45,18 +97,16 @@ export function PeriodicNotesHeaderAction({
     (state) => state.openExtensionDialog
   );
   const settings = getPeriodicNotesSettings({ periodicNotes });
-  const dailyEnabled = settings.daily.enabled;
-  const weeklyEnabled = settings.weekly.enabled;
 
   const openMenu = useCallback(() => {
     const rect = buttonRef.current?.getBoundingClientRect();
     if (!rect) return;
-    const menuWidth = 176;
+    const menuWidth = 248;
     const left = collapsed
       ? rect.right + 8
       : rect.left + rect.width / 2 - menuWidth / 2;
     setMenuPosition({
-      top: rect.bottom + 6,
+      top: rect.bottom + 2,
       left: Math.max(8, Math.min(left, window.innerWidth - menuWidth - 8)),
     });
     setMenuOpen(true);
@@ -87,13 +137,22 @@ export function PeriodicNotesHeaderAction({
   }, [menuOpen]);
 
   const openPeriodicNote = useCallback(
-    async (kind: PeriodicNoteKind) => {
+    async (kind: PeriodicNoteKind, offsetPeriods = 0) => {
       closeMenu();
 
       if (!settings[kind].enabled) {
-        toast.error(`${kind === "daily" ? "Daily" : "Weekly"} notes are disabled`);
+        const label = kind.charAt(0).toUpperCase() + kind.slice(1);
+        toast.error(`${label} notes are disabled`);
         return;
       }
+
+      // Advance by whole periods. The server subtracts nightOwlHour from this
+      // timestamp, so a whole-period offset always lands cleanly in the next
+      // period — the shared periodKey + unique DB index dedupes against any
+      // auto-generated note.
+      const localDateTime = moment()
+        .add(offsetPeriods, PERIOD_UNIT[kind])
+        .format("YYYY-MM-DDTHH:mm:ss");
 
       try {
         const response = await fetch("/api/periodic-notes/resolve", {
@@ -102,10 +161,7 @@ export function PeriodicNotesHeaderAction({
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({
-            kind,
-            localDateTime: moment().format("YYYY-MM-DDTHH:mm:ss"),
-          }),
+          body: JSON.stringify({ kind, localDateTime }),
         });
         const result = await response.json();
 
@@ -122,10 +178,14 @@ export function PeriodicNotesHeaderAction({
           contentType: "note",
         });
         window.dispatchEvent(new CustomEvent("dg:tree-refresh"));
+        const noteNoun =
+          offsetPeriods > 0
+            ? NEXT_PERIOD_NOUN[kind]
+            : offsetPeriods < 0
+              ? PREV_PERIOD_NOUN[kind]
+              : CURRENT_PERIOD_NOUN[kind];
         toast.success(
-          result.data.created
-            ? `Created ${kind === "daily" ? "daily" : "weekly"} note`
-            : `Opened ${kind === "daily" ? "daily" : "weekly"} note`
+          result.data.created ? `Created ${noteNoun}` : `Opened ${noteNoun}`
         );
       } catch (error) {
         toast.error(
@@ -146,16 +206,16 @@ export function PeriodicNotesHeaderAction({
   );
 
   const openPrimaryNote = useCallback(() => {
-    if (dailyEnabled) {
-      void openPeriodicNote("daily");
+    // Single click opens the highest-cadence enabled note (daily first).
+    const primary = (["daily", "weekly", "monthly", "yearly"] as const).find(
+      (kind) => settings[kind].enabled
+    );
+    if (primary) {
+      void openPeriodicNote(primary);
       return;
     }
-    if (weeklyEnabled) {
-      void openPeriodicNote("weekly");
-      return;
-    }
-    toast.error("Enable daily or weekly notes in extension settings first");
-  }, [dailyEnabled, openPeriodicNote, weeklyEnabled]);
+    toast.error("Enable a periodic note kind in extension settings first");
+  }, [openPeriodicNote, settings]);
 
   const openSettings = useCallback(() => {
     closeMenu();
@@ -217,43 +277,59 @@ export function PeriodicNotesHeaderAction({
         {renderExtensionIcon(item.iconName, iconClassName)}
       </button>
 
-      {menuOpen && menuPosition ? (
-        <div
-          ref={menuRef}
-          role="menu"
-          className="fixed z-50 min-w-40 rounded-md border border-white/10 bg-[#111318] p-1 text-sm text-gray-200 shadow-xl"
-          style={{ top: menuPosition.top, left: menuPosition.left }}
-        >
-          {dailyEnabled ? (
-            <button
-              type="button"
-              role="menuitem"
-              className="flex w-full items-center rounded px-3 py-2 text-left transition-colors hover:bg-white/10"
-              onClick={() => void openPeriodicNote("daily")}
+      {menuOpen && menuPosition
+        ? createPortal(
+            <div
+              ref={menuRef}
+              role="menu"
+              className="fixed z-50 w-[248px] rounded-md border border-black/10 bg-white/95 p-1 text-sm text-gray-900 shadow-lg backdrop-blur-sm dark:border-white/10 dark:bg-gray-900/95 dark:text-gray-200"
+              style={{ top: menuPosition.top, left: menuPosition.left }}
             >
-              Today
-            </button>
-          ) : null}
-          {weeklyEnabled ? (
-            <button
-              type="button"
-              role="menuitem"
-              className="flex w-full items-center rounded px-3 py-2 text-left transition-colors hover:bg-white/10"
-              onClick={() => void openPeriodicNote("weekly")}
-            >
-              This Week
-            </button>
-          ) : null}
-          <button
-            type="button"
-            role="menuitem"
-            className="flex w-full items-center rounded px-3 py-2 text-left transition-colors hover:bg-white/10"
-            onClick={openSettings}
-          >
-            Settings
-          </button>
-        </div>
-      ) : null}
+              {PERIOD_NAV.filter((nav) => settings[nav.kind].enabled).map(
+                (nav) => (
+                  <div key={nav.kind} className="px-0.5 pb-0.5">
+                    <div className="px-1 pb-0.5 text-[10px] font-semibold uppercase tracking-wider text-gray-700 dark:text-gray-100">
+                      {nav.label}
+                    </div>
+                    <div className="grid grid-cols-3 gap-0.5">
+                      {[
+                        { rel: nav.prev, offset: -1 },
+                        { rel: nav.current, offset: 0 },
+                        { rel: nav.next, offset: 1 },
+                      ].map((seg) => (
+                        <button
+                          key={seg.offset}
+                          type="button"
+                          role="menuitem"
+                          className={`rounded px-1 py-1 text-center text-[11px] leading-tight transition-colors hover:bg-primary/10 hover:text-primary dark:hover:bg-white/10 dark:hover:text-gray-100 ${
+                            seg.offset === 0
+                              ? "bg-primary/5 font-semibold dark:bg-white/[0.06]"
+                              : "text-gray-600 dark:text-gray-400"
+                          }`}
+                          onClick={() => void openPeriodicNote(nav.kind, seg.offset)}
+                        >
+                          {seg.rel}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )
+              )}
+              {PERIOD_NAV.some((nav) => settings[nav.kind].enabled) ? (
+                <div className="my-0.5 border-t border-black/10 dark:border-white/10" />
+              ) : null}
+              <button
+                type="button"
+                role="menuitem"
+                className="flex w-full items-center rounded px-2 py-1.5 text-left transition-colors hover:bg-primary/10 hover:text-primary dark:hover:bg-white/10 dark:hover:text-gray-100"
+                onClick={openSettings}
+              >
+                Settings
+              </button>
+            </div>,
+            document.body
+          )
+        : null}
     </>
   );
 }

--- a/extensions/daily-notes/components/PeriodicNotesShellController.tsx
+++ b/extensions/daily-notes/components/PeriodicNotesShellController.tsx
@@ -3,10 +3,21 @@
 import { useEffect, useMemo, useRef } from "react";
 import moment from "moment";
 import { toast } from "sonner";
-import { getNextPeriodicRolloverDelay } from "@/lib/domain/periodic-notes";
+import {
+  formatPeriodKey,
+  getNextPeriodicRolloverDelay,
+} from "@/lib/domain/periodic-notes";
 import { getPeriodicNotesSettings } from "@/lib/domain/periodic-notes/settings";
 import type { PeriodicNoteKind } from "@/lib/domain/periodic-notes/types";
 import { useSettingsStore } from "@/state/settings-store";
+
+const PERIODIC_KINDS: PeriodicNoteKind[] = [
+  "daily",
+  "weekly",
+  "monthly",
+  "quarterly",
+  "yearly",
+];
 
 export function PeriodicNotesShellController() {
   const periodicNotes = useSettingsStore((state) => state.periodicNotes);
@@ -28,28 +39,29 @@ export function PeriodicNotesShellController() {
     let retryTimeoutId: number | null = null;
     const runAutoCreate = async () => {
       const localDateTime = moment().format("YYYY-MM-DDTHH:mm:ss");
-      const dailyKey = moment(localDateTime).format("YYYY-MM-DD");
-      const weeklyKey = moment(localDateTime)
-        .clone()
-        .startOf("isoWeek")
-        .format("GGGG-[W]WW");
-      const runKey = [
-        settings.daily.enabled && settings.daily.autoCreateOnOpen
-          ? `daily:${dailyKey}`
-          : null,
-        settings.weekly.enabled && settings.weekly.autoCreateOnOpen
-          ? `weekly:${weeklyKey}`
-          : null,
-      ]
-        .filter(Boolean)
+
+      // Every enabled kind with auto-create on. The runKey (kind:periodKey per
+      // active kind) dedupes so we don't re-hit the API within the same period.
+      const activeKinds = PERIODIC_KINDS.filter(
+        (kind) => settings[kind].enabled && settings[kind].autoCreateOnOpen
+      );
+      const runKey = activeKinds
+        .map((kind) => {
+          const adjusted = moment(localDateTime).subtract(
+            settings[kind].nightOwlHour,
+            "hours"
+          );
+          return `${kind}:${formatPeriodKey(kind, adjusted)}`;
+        })
         .join("|");
 
       if (!runKey || lastAutoCreateKeyRef.current === runKey) return;
 
-      const results = await Promise.all([
-        maybeResolvePeriodicNote("daily", localDateTime, settings.daily.enabled && settings.daily.autoCreateOnOpen),
-        maybeResolvePeriodicNote("weekly", localDateTime, settings.weekly.enabled && settings.weekly.autoCreateOnOpen),
-      ]);
+      const results = await Promise.all(
+        activeKinds.map((kind) =>
+          maybeResolvePeriodicNote(kind, localDateTime, true)
+        )
+      );
       const requestedResults = results.filter((result) => result.requested);
       const failedResult = requestedResults.find((result) => !result.ok);
 
@@ -78,7 +90,7 @@ export function PeriodicNotesShellController() {
     const scheduleNextRun = () => {
       timeoutId = window.setTimeout(() => {
         void runAutoCreate().finally(scheduleNextRun);
-      }, getNextPeriodicRolloverDelay());
+      }, getNextPeriodicRolloverDelay(new Date(), settings.daily.nightOwlHour));
     };
 
     void runAutoCreate();

--- a/extensions/daily-notes/settings/PeriodicNotesSettingsDialog.tsx
+++ b/extensions/daily-notes/settings/PeriodicNotesSettingsDialog.tsx
@@ -2,10 +2,22 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import { CalendarCheck, Folder, Search } from "lucide-react";
+import { CalendarCheck, Folder, Info, Search } from "lucide-react";
 import { Input } from "@/components/client/ui/input";
 import { Label } from "@/components/client/ui/label";
 import { Switch } from "@/components/client/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/client/ui/tooltip";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/client/ui/tabs";
 import { getSurfaceStyles } from "@/lib/design/system";
 import type { TreeNode } from "@/lib/domain/content/types";
 import {
@@ -147,9 +159,7 @@ export default function PeriodicNotesSettingsDialog() {
       ...settings[kind],
       ...updates,
     };
-    void setPeriodicNotesSettings(
-      kind === "daily" ? { daily: next } : { weekly: next }
-    );
+    void setPeriodicNotesSettings({ [kind]: next });
   };
 
   return (
@@ -157,37 +167,78 @@ export default function PeriodicNotesSettingsDialog() {
       <div>
         <div className="flex items-center gap-3">
           <CalendarCheck className="h-7 w-7 text-gold-primary" />
-          <h1 className="text-3xl font-bold">Daily Notes</h1>
+          <h1 className="text-3xl font-bold">Periodic Notes</h1>
         </div>
         <p className="mt-2 text-sm text-gray-400">
-          Create a note for today or this ISO week from the left-panel header.
+          Open or auto-create daily, weekly, monthly, and yearly notes from the
+          left-panel header.
         </p>
       </div>
 
-      <PeriodicNoteSection
-        title="Daily Notes"
-        description="Use today as the note period."
-        kind="daily"
-        values={settings.daily}
-        folders={folders}
-        templates={templates}
-        onChange={updateKind}
-        surfaceStyle={glass0}
-      />
-
-      <PeriodicNoteSection
-        title="Weekly Notes"
-        description="Use the current ISO week as the note period."
-        kind="weekly"
-        values={settings.weekly}
-        folders={folders}
-        templates={templates}
-        onChange={updateKind}
-        surfaceStyle={glass0}
-      />
+      <Tabs defaultValue="daily" className="w-full">
+        <TabsList className="grid w-full grid-cols-5">
+          {PERIODIC_SECTIONS.map((section) => (
+            <TabsTrigger key={section.kind} value={section.kind}>
+              {section.tab}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {PERIODIC_SECTIONS.map((section) => (
+          <TabsContent key={section.kind} value={section.kind} className="mt-6">
+            <PeriodicNoteSection
+              title={section.title}
+              description={section.description}
+              kind={section.kind}
+              values={settings[section.kind]}
+              folders={folders}
+              templates={templates}
+              onChange={updateKind}
+              surfaceStyle={glass0}
+            />
+          </TabsContent>
+        ))}
+      </Tabs>
     </div>
   );
 }
+
+const PERIODIC_SECTIONS: Array<{
+  kind: PeriodicNoteKind;
+  tab: string;
+  title: string;
+  description: string;
+}> = [
+  {
+    kind: "daily",
+    tab: "Daily",
+    title: "Daily Notes",
+    description: "Use today as the note period.",
+  },
+  {
+    kind: "weekly",
+    tab: "Weekly",
+    title: "Weekly Notes",
+    description: "Use the current ISO week as the note period.",
+  },
+  {
+    kind: "monthly",
+    tab: "Monthly",
+    title: "Monthly Notes",
+    description: "Use the current month as the note period.",
+  },
+  {
+    kind: "quarterly",
+    tab: "Quarterly",
+    title: "Quarterly Notes",
+    description: "Use the current calendar quarter as the note period.",
+  },
+  {
+    kind: "yearly",
+    tab: "Yearly",
+    title: "Yearly Notes",
+    description: "Use the current year as the note period.",
+  },
+];
 
 function PeriodicNoteSection({
   title,
@@ -322,9 +373,11 @@ function PeriodicNoteSection({
 
         <div className="flex items-center justify-between gap-4 rounded-lg border border-white/10 px-4 py-3">
           <div>
-            <p className="text-sm font-medium">Auto-create on app open</p>
+            <p className="text-sm font-medium">
+              Auto-create {kind} note on app open
+            </p>
             <p className="text-xs text-gray-500">
-              Create missing note content without opening the note.
+              Create missing {kind} note content without opening the note.
             </p>
           </div>
           <Switch
@@ -335,9 +388,41 @@ function PeriodicNoteSection({
                 enabled: autoCreateOnOpen ? true : values.enabled,
               })
             }
-            aria-label={`Auto-create ${title.toLowerCase()} on app open`}
+            aria-label={`Auto-create ${kind} note on app open`}
           />
         </div>
+
+        {kind === "daily" || kind === "weekly" ? (
+          <div className="space-y-2 md:col-span-2">
+            <div className="flex items-center gap-1.5">
+              <Label htmlFor={`${kind}-night-owl-hour`}>Night Owl Protection</Label>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="h-3.5 w-3.5 cursor-help text-gray-500" />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-64">
+                    If you journal late at night, this shifts when your &ldquo;day&rdquo; begins.
+                    Set to 2 AM and notes created at 1:30 AM will still open the
+                    previous {kind === "weekly" ? "week" : "day"}&apos;s entry — not a blank one for the next period.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+            <select
+              id={`${kind}-night-owl-hour`}
+              value={String(values.nightOwlHour ?? 0)}
+              onChange={(e) => onChange(kind, { nightOwlHour: Number(e.target.value) })}
+              className="flex h-10 w-full rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm"
+            >
+              <option value="0">Off — day starts at midnight</option>
+              <option value="1">1 AM — day starts at 1 AM</option>
+              <option value="2">2 AM — day starts at 2 AM</option>
+              <option value="3">3 AM — day starts at 3 AM</option>
+              <option value="4">4 AM — day starts at 4 AM</option>
+            </select>
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/lib/design/system/ai-providers.ts
+++ b/lib/design/system/ai-providers.ts
@@ -31,6 +31,25 @@ import type { AIProviderId } from "@/lib/domain/ai/types";
 export type ProviderBubbleShape = "minimal" | "no-bubble" | "rounded-soft";
 export type ProviderCodeChrome = "tight" | "structured" | "soft";
 export type ProviderStreamingIndicator = "cursor" | "smooth" | "shimmer" | "dots";
+export type ProviderThemeMode = "light" | "dark";
+
+/**
+ * Light-mode counterparts for the raw-CSS color values on ProviderTheme.
+ * These exist because surface backgrounds and brand accents are applied
+ * via inline `style={}` (they're gradients / computed colors), so they
+ * can't ride Tailwind's `dark:` variant like the className fields do.
+ *
+ * Contrast rule: `brandColor` here is used as TEXT on the light surface
+ * (header model name, tab labels, chips) and must clear WCAG AA 4.5:1
+ * against the light surface base — the dark-mode brand colors are all
+ * mid-tone pastels that fail badly on white (e.g. #D4A574 ≈ 1.9:1).
+ */
+export interface ProviderThemeLightColors {
+  brandColor: string;
+  bubbleTint: string;
+  surfaceBackground: string;
+  gradientStop: string;
+}
 
 export interface ProviderTheme {
   id: AIProviderId | "generic";
@@ -40,7 +59,7 @@ export interface ProviderTheme {
   isBigThree: boolean;
 
   // ─── color ───
-  /** Hex accent color used for chips, tab tints, message tints. */
+  /** Hex accent color used for chips, tab tints, message tints (dark-surface tuned). */
   brandColor: string;
   /** CSS color for the message bubble tint (low alpha derivative of brandColor). */
   bubbleTint: string;
@@ -51,6 +70,12 @@ export interface ProviderTheme {
   surfaceBackground: string;
   /** Single-color stop (rgba) used when composing the mixed-provider gradient. */
   gradientStop: string;
+  /**
+   * Light-mode counterparts for the four raw-CSS values above.
+   * Resolved by `getProviderTheme(id, "light")` — consumers never read
+   * this block directly.
+   */
+  light: ProviderThemeLightColors;
 
   // ─── bubble ───
   bubble: {
@@ -118,10 +143,19 @@ const ANTHROPIC: ProviderTheme = {
   surfaceBackground:
     "linear-gradient(180deg, rgba(212, 165, 116, 0.14) 0%, rgba(212, 165, 116, 0.05) 60%, rgba(28, 22, 18, 0.65) 100%), #1c1612",
   gradientStop: "rgba(212, 165, 116, 0.18)",
+  light: {
+    // Rust accent (vs the dark-mode tan): 5.0:1 on the ivory base.
+    brandColor: "#AE5630",
+    bubbleTint: "rgba(174, 86, 48, 0.10)",
+    // Same warm-parchment identity, ivory base instead of espresso.
+    surfaceBackground:
+      "linear-gradient(180deg, rgba(212, 165, 116, 0.16) 0%, rgba(212, 165, 116, 0.06) 60%, rgba(250, 246, 240, 0.65) 100%), #faf6f0",
+    gradientStop: "rgba(212, 165, 116, 0.22)",
+  },
   bubble: {
     shape: "rounded-soft",
     assistantClassName:
-      "rounded-2xl bg-[rgba(212,165,116,0.06)] border border-[rgba(212,165,116,0.18)] text-[#E5D4B0]",
+      "rounded-2xl bg-[rgba(212,165,116,0.06)] border border-[rgba(174,86,48,0.22)] dark:border-[rgba(212,165,116,0.18)] text-[#4A3A28] dark:text-[#E5D4B0]",
     columnClassName: "max-w-[95%]",
     paddingClassName: "px-4 py-3",
     proseClassName: "leading-relaxed",
@@ -129,9 +163,9 @@ const ANTHROPIC: ProviderTheme = {
   codeBlock: {
     chrome: "tight",
     wrapperClassName:
-      "rounded-lg border border-[rgba(212,165,116,0.18)] bg-black/40 overflow-hidden",
+      "rounded-lg border border-[rgba(174,86,48,0.22)] dark:border-[rgba(212,165,116,0.18)] bg-black/[0.04] dark:bg-black/40 overflow-hidden",
     headerClassName:
-      "flex items-center justify-between px-3 py-1.5 bg-[rgba(212,165,116,0.05)] border-b border-[rgba(212,165,116,0.12)] text-[10px]",
+      "flex items-center justify-between px-3 py-1.5 bg-[rgba(212,165,116,0.10)] dark:bg-[rgba(212,165,116,0.05)] border-b border-[rgba(174,86,48,0.15)] dark:border-[rgba(212,165,116,0.12)] text-[10px]",
     showLanguagePill: true,
     showCopyButton: true,
   },
@@ -169,10 +203,20 @@ const OPENAI: ProviderTheme = {
   surfaceBackground:
     "linear-gradient(180deg, rgba(16, 163, 127, 0.06) 0%, rgba(16, 163, 127, 0.02) 40%, rgba(13, 13, 13, 0.85) 100%), #0d0d0d",
   gradientStop: "rgba(16, 163, 127, 0.12)",
+  light: {
+    // Deep teal (vs #10A37F which is only ~3.0:1 on white): 5.3:1.
+    brandColor: "#0B7A5E",
+    bubbleTint: "rgba(11, 122, 94, 0.08)",
+    // Mirror of the dark identity: near-pure-white canvas, the faintest
+    // green wash at the top — distinction stays "absence of color".
+    surfaceBackground:
+      "linear-gradient(180deg, rgba(16, 163, 127, 0.05) 0%, rgba(16, 163, 127, 0.015) 40%, rgba(255, 255, 255, 0.85) 100%), #fdfdfd",
+    gradientStop: "rgba(16, 163, 127, 0.10)",
+  },
   bubble: {
     shape: "no-bubble",
     assistantClassName:
-      "rounded-none border-0 bg-transparent text-gray-100 dark:text-gray-100",
+      "rounded-none border-0 bg-transparent text-gray-800 dark:text-gray-100",
     columnClassName: "max-w-[95%]",
     paddingClassName: "px-2 py-2",
     proseClassName: "leading-[1.65]",
@@ -180,9 +224,9 @@ const OPENAI: ProviderTheme = {
   codeBlock: {
     chrome: "structured",
     wrapperClassName:
-      "rounded-xl border border-white/10 bg-[#0d0d0d] overflow-hidden shadow-sm",
+      "rounded-xl border border-black/10 dark:border-white/10 bg-[#f7f7f8] dark:bg-[#0d0d0d] overflow-hidden shadow-sm",
     headerClassName:
-      "flex items-center justify-between px-4 py-2 bg-white/[0.04] border-b border-white/10 text-[11px]",
+      "flex items-center justify-between px-4 py-2 bg-black/[0.03] dark:bg-white/[0.04] border-b border-black/10 dark:border-white/10 text-[11px]",
     showLanguagePill: true,
     showCopyButton: true,
   },
@@ -219,10 +263,19 @@ const GOOGLE: ProviderTheme = {
   surfaceBackground:
     "linear-gradient(135deg, rgba(66, 133, 244, 0.16) 0%, rgba(155, 114, 203, 0.12) 50%, rgba(14, 19, 32, 0.85) 100%), #0e1320",
   gradientStop: "rgba(66, 133, 244, 0.20)",
+  light: {
+    // Google blue-700 — their own accent for light surfaces: 5.2:1.
+    brandColor: "#1967D2",
+    bubbleTint: "rgba(25, 103, 210, 0.09)",
+    // Same blue → purple diagonal, landing on a cool near-white.
+    surfaceBackground:
+      "linear-gradient(135deg, rgba(66, 133, 244, 0.14) 0%, rgba(155, 114, 203, 0.10) 50%, rgba(245, 248, 253, 0.85) 100%), #f5f8fd",
+    gradientStop: "rgba(66, 133, 244, 0.16)",
+  },
   bubble: {
     shape: "rounded-soft",
     assistantClassName:
-      "rounded-3xl bg-[rgba(66,133,244,0.05)] border border-[rgba(66,133,244,0.16)] text-gray-100",
+      "rounded-3xl bg-[rgba(66,133,244,0.05)] border border-[rgba(25,103,210,0.20)] dark:border-[rgba(66,133,244,0.16)] text-gray-800 dark:text-gray-100",
     columnClassName: "max-w-[95%]",
     paddingClassName: "px-4 py-3.5",
     proseClassName: "leading-[1.7]",
@@ -230,9 +283,9 @@ const GOOGLE: ProviderTheme = {
   codeBlock: {
     chrome: "soft",
     wrapperClassName:
-      "rounded-2xl border border-[rgba(66,133,244,0.16)] bg-black/30 overflow-hidden",
+      "rounded-2xl border border-[rgba(25,103,210,0.20)] dark:border-[rgba(66,133,244,0.16)] bg-white/60 dark:bg-black/30 overflow-hidden",
     headerClassName:
-      "flex items-center justify-between px-3.5 py-2 bg-[rgba(66,133,244,0.04)] border-b border-[rgba(66,133,244,0.10)] text-[10px]",
+      "flex items-center justify-between px-3.5 py-2 bg-[rgba(66,133,244,0.08)] dark:bg-[rgba(66,133,244,0.04)] border-b border-[rgba(25,103,210,0.12)] dark:border-[rgba(66,133,244,0.10)] text-[10px]",
     showLanguagePill: true,
     showCopyButton: true,
   },
@@ -262,10 +315,16 @@ const GENERIC: ProviderTheme = {
   bubbleTint: "rgba(156, 163, 175, 0.08)",
   surfaceBackground: "transparent",
   gradientStop: "rgba(156, 163, 175, 0.06)",
+  light: {
+    brandColor: "#6B7280", // gray-500 — 4.8:1 on white
+    bubbleTint: "rgba(107, 114, 128, 0.08)",
+    surfaceBackground: "transparent",
+    gradientStop: "rgba(107, 114, 128, 0.06)",
+  },
   bubble: {
     shape: "minimal",
     assistantClassName:
-      "rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 text-[#E5D4B0]",
+      "rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 text-gray-800 dark:text-[#E5D4B0]",
     columnClassName: "max-w-[95%]",
     paddingClassName: "px-3.5 py-2.5",
     proseClassName: "leading-relaxed",
@@ -273,9 +332,9 @@ const GENERIC: ProviderTheme = {
   codeBlock: {
     chrome: "tight",
     wrapperClassName:
-      "rounded-lg border border-black/10 dark:border-white/10 bg-black/40 overflow-hidden",
+      "rounded-lg border border-black/10 dark:border-white/10 bg-black/[0.04] dark:bg-black/40 overflow-hidden",
     headerClassName:
-      "flex items-center justify-between px-3 py-1.5 bg-black/[0.03] dark:bg-white/5 border-b border-white/5 text-[10px]",
+      "flex items-center justify-between px-3 py-1.5 bg-black/[0.03] dark:bg-white/5 border-b border-black/5 dark:border-white/5 text-[10px]",
     showLanguagePill: true,
     showCopyButton: true,
   },
@@ -294,10 +353,13 @@ const GENERIC: ProviderTheme = {
 // Provider-specific minimal themes — same shape as GENERIC with their
 // own brand accent for the make-and-model picker chip color. Bubble +
 // code-block chrome inherit GENERIC; only color tokens differ.
+// `lightBrandColor` is a darker same-hue accent that clears 4.5:1 on
+// white — the dark-surface brand colors are all too pale for light text.
 function deriveMinimalTheme(
   id: AIProviderId,
   name: string,
   brandColor: string,
+  lightBrandColor: string,
 ): ProviderTheme {
   return {
     ...GENERIC,
@@ -307,12 +369,18 @@ function deriveMinimalTheme(
     bubbleTint: hexToRgba(brandColor, 0.08),
     gradientStop: hexToRgba(brandColor, 0.08),
     surfaceBackground: "transparent",
+    light: {
+      brandColor: lightBrandColor,
+      bubbleTint: hexToRgba(lightBrandColor, 0.08),
+      gradientStop: hexToRgba(lightBrandColor, 0.08),
+      surfaceBackground: "transparent",
+    },
   };
 }
 
-const XAI = deriveMinimalTheme("xai", "xAI", "#FF4D4D");
-const MISTRAL = deriveMinimalTheme("mistral", "Mistral", "#FF6B35");
-const GROQ = deriveMinimalTheme("groq", "Groq", "#F55036");
+const XAI = deriveMinimalTheme("xai", "xAI", "#FF4D4D", "#B93838");
+const MISTRAL = deriveMinimalTheme("mistral", "Mistral", "#FF6B35", "#B94A14");
+const GROQ = deriveMinimalTheme("groq", "Groq", "#F55036", "#BC3A20");
 
 // ────────────────────────────────────────────────────────────────────────────
 // Registry + lookup
@@ -334,17 +402,43 @@ export const BIG_THREE_PROVIDER_IDS: AIProviderId[] = [
   "google",
 ];
 
+// Flattened light-mode themes, built lazily and cached — same object
+// identity per (provider, mode) so React memo/deps stay stable.
+const LIGHT_THEME_CACHE = new Map<string, ProviderTheme>();
+
+function toLightTheme(theme: ProviderTheme): ProviderTheme {
+  const cached = LIGHT_THEME_CACHE.get(theme.id);
+  if (cached) return cached;
+  const flattened: ProviderTheme = {
+    ...theme,
+    brandColor: theme.light.brandColor,
+    bubbleTint: theme.light.bubbleTint,
+    surfaceBackground: theme.light.surfaceBackground,
+    gradientStop: theme.light.gradientStop,
+  };
+  LIGHT_THEME_CACHE.set(theme.id, flattened);
+  return flattened;
+}
+
 /**
  * Get a provider theme by id, falling back to GENERIC for any unknown
  * id (defensive against future schema drift or stored user keys for
  * providers we don't actively style).
+ *
+ * `mode` selects the raw-CSS color set (`surfaceBackground`, `brandColor`,
+ * `bubbleTint`, `gradientStop`). It defaults to "dark" — the historical
+ * behavior — so only surface-painting consumers need to opt in with
+ * `useResolvedTheme()`. The Tailwind className fields carry their own
+ * `dark:` variants and are identical across modes.
  */
 export function getProviderTheme(
   providerId: AIProviderId | string | null | undefined,
+  mode: ProviderThemeMode = "dark",
 ): ProviderTheme {
-  if (!providerId) return GENERIC;
-  const known = THEME_BY_ID[providerId as AIProviderId];
-  return known ?? GENERIC;
+  const known = providerId
+    ? (THEME_BY_ID[providerId as AIProviderId] ?? GENERIC)
+    : GENERIC;
+  return mode === "light" ? toLightTheme(known) : known;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -389,14 +483,15 @@ export function detectMixedProvider<
 export function buildSurfaceBackground(
   activeProviderId: AIProviderId | string | null,
   contributors: AIProviderId[],
+  mode: ProviderThemeMode = "dark",
 ): string {
   if (contributors.length <= 1) {
-    return getProviderTheme(activeProviderId).surfaceBackground;
+    return getProviderTheme(activeProviderId, mode).surfaceBackground;
   }
 
   const stops = contributors
     .map((id, i) => {
-      const stop = getProviderTheme(id).gradientStop;
+      const stop = getProviderTheme(id, mode).gradientStop;
       const pct = Math.round((i / Math.max(1, contributors.length - 1)) * 100);
       return `${stop} ${pct}%`;
     })

--- a/lib/domain/browser-extension/service.ts
+++ b/lib/domain/browser-extension/service.ts
@@ -9,6 +9,8 @@ import { syncImageReferences } from "@/lib/domain/content/image-refs";
 import { syncPersonMentions } from "@/lib/domain/content/person-mention-sync";
 import { getServerExtensions } from "@/lib/domain/editor/extensions-server";
 import { sanitizeTipTapJsonWithExtensions } from "@/lib/domain/editor/unsupported-content";
+import { reseedCollaborationDocumentFromNote } from "@/lib/domain/collaboration/documents";
+import { logger } from "@/lib/core/logger";
 import { generateJSON, type JSONContent } from "@tiptap/core";
 
 function asIsoString(value: Date | null | undefined) {
@@ -1074,6 +1076,23 @@ export async function updateExtensionNoteContent(
   await syncContentTags(contentId, json, userId);
   await syncImageReferences(contentId, json, userId);
   await syncPersonMentions(contentId, json, userId);
+
+  // Realign the collaborative Y.Doc with the payload we just wrote. This write
+  // path bypasses collaboration, so without a reseed a stale-but-non-empty
+  // CollaborationDocument would win at bootstrap and mask this edit (stale/blank
+  // note when later opened in the app). Non-fatal: the NotePayload above is the
+  // durable source of truth, so a reseed failure must not fail the note write.
+  try {
+    await reseedCollaborationDocumentFromNote(prisma, contentId);
+  } catch (error) {
+    logger.error({
+      layer: "browser_ext",
+      event: "note_content_update:reseed_failed",
+      summary: "failed to reseed collaboration doc after extension note write",
+      attrs: { content_id: contentId },
+      error,
+    });
+  }
 
   return getExtensionNoteContent(userId, contentId);
 }

--- a/lib/domain/collaboration/documents.ts
+++ b/lib/domain/collaboration/documents.ts
@@ -83,6 +83,76 @@ export async function loadCollaborationYDocState(
   return update;
 }
 
+/**
+ * Rebuild the CollaborationDocument Y.Doc from the note's CURRENT NotePayload.
+ *
+ * Use this after any write path that updates `NotePayload` WITHOUT going through
+ * the collaborative Y.Doc — the browser extension being the canonical example
+ * (`updateExtensionNoteContent` writes only NotePayload). Without this, a
+ * previously-stored, now-stale-but-non-empty `CollaborationDocument` wins during
+ * bootstrap (see `loadCollaborationYDocState`: a meaningful stored state is
+ * trusted over the payload), so the collaborative layer serves STALE content and
+ * masks the extension's edit. Re-seeding realigns the collaborative snapshot with
+ * the authoritative payload the user just wrote.
+ *
+ * Safety: this only rewrites the durable DB snapshot. It does not reach into a
+ * live Hocuspocus in-memory session — if one is connected it remains
+ * authoritative and re-persists on its next store. The dominant case (an
+ * extension-authored note that is NOT currently open in a live collab session)
+ * is fully corrected; the concurrent-live-session case is the inherent
+ * two-writers conflict and is out of scope here.
+ */
+export async function reseedCollaborationDocumentFromNote(
+  prisma: PrismaClient,
+  contentId: string
+): Promise<void> {
+  const documentName = getCollaborationDocumentName(contentId);
+  const content = await prisma.contentNode.findFirst({
+    where: {
+      id: contentId,
+      contentType: "note",
+      deletedAt: null,
+    },
+    include: {
+      notePayload: true,
+    },
+  });
+
+  if (!content?.notePayload) {
+    return;
+  }
+
+  const sanitizedContent = sanitizeTipTapJsonWithExtensions(
+    content.notePayload.tiptapJson as JSONContent,
+    getCollaborationServerExtensions()
+  ).json;
+
+  const ydoc = TiptapTransformer.toYdoc(
+    sanitizedContent,
+    "default",
+    getCollaborationServerExtensions()
+  );
+  const update = Y.encodeStateAsUpdate(ydoc);
+  ydoc.destroy();
+
+  await prisma.collaborationDocument.upsert({
+    where: { contentId },
+    update: {
+      documentName,
+      ownerId: content.ownerId,
+      ydocState: Buffer.from(update),
+      snapshotJson: sanitizedContent,
+    },
+    create: {
+      contentId,
+      ownerId: content.ownerId,
+      documentName,
+      ydocState: Buffer.from(update),
+      snapshotJson: sanitizedContent,
+    },
+  });
+}
+
 export async function storeCollaborationYDocState(
   prisma: PrismaClient,
   documentName: string,

--- a/lib/domain/collaboration/runtime.ts
+++ b/lib/domain/collaboration/runtime.ts
@@ -69,7 +69,7 @@ function schedulePostPaint(callback: () => void): { cancel: () => void } {
 export type LocalSurfaceTopology = "singleSurface" | "multiSurface";
 export type BrowserSessionTopology = "singleSession" | "multiSession";
 export type RemoteCollaborationTopology = "solo" | "remotePresent";
-export type PersistenceState = "booting" | "localReady";
+export type PersistenceState = "booting" | "localReady" | "unavailable";
 export type BootstrapState = "pending" | "ready" | "failed";
 export type CollaborationAvailabilityState = "canonical" | "localFallback" | "plainFallback";
 export type LocalFallbackReason =
@@ -328,6 +328,7 @@ const PROVIDER_RECONNECT_BASE_MS = 1000;
 const PROVIDER_RECONNECT_MAX_MS = 30_000;
 const BOOTSTRAP_SLOW_WARNING_MS = 10_000;
 const BOOTSTRAP_LOCAL_FALLBACK_MS = 25_000;
+const INDEXEDDB_INIT_TIMEOUT_MS = 4_000;
 const COOLDOWN_MS = 120_000;
 const IDLE_EVICTION_MS = 300_000;
 const LOCAL_CACHE_MANIFEST_KEY = "dg-collab-local-cache-manifest";
@@ -723,16 +724,40 @@ class CollaborationRuntimeManager {
     };
     entry.ydoc.on("update", entry.ydocUpdateHandler);
 
+    // Watchdog: if IndexedDB doesn't respond within INDEXEDDB_INIT_TIMEOUT_MS
+    // (common in mobile webviews with partitioned storage or background suspension),
+    // treat storage as unavailable and route to plainFallback so the user can edit
+    // via REST auto-save rather than being blocked in read-only "booting" state.
+    let indexedDbWatchdog: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+      indexedDbWatchdog = null;
+      if (entry.state.persistenceState !== "booting") return;
+      this.routeToPlainFallback(
+        entry,
+        "Local storage is unavailable. Editing from the last saved state — changes are saved to the server.",
+        "canonical-unavailable"
+      );
+    }, INDEXEDDB_INIT_TIMEOUT_MS);
+
     indexedDbProvider.whenSynced
       .then(() => {
+        if (indexedDbWatchdog !== null) {
+          clearTimeout(indexedDbWatchdog);
+          indexedDbWatchdog = null;
+        }
         entry.state.persistenceState = "localReady";
         void this.bootstrapInitialContent(entry);
         this.emit(entry);
       })
       .catch((error) => {
-        this.markBootstrapFailed(
+        if (indexedDbWatchdog !== null) {
+          clearTimeout(indexedDbWatchdog);
+          indexedDbWatchdog = null;
+        }
+        entry.state.persistenceState = "unavailable";
+        this.routeToPlainFallback(
           entry,
-          "Local collaborative storage could not be initialized. Editing is blocked to avoid data loss."
+          "Local collaborative storage could not be initialized. Editing from the last saved state — changes are saved to the server.",
+          "canonical-unavailable"
         );
         if (process.env.NODE_ENV === "development") {
           console.error(
@@ -938,6 +963,31 @@ class CollaborationRuntimeManager {
     entry.hasSeededInitialContent = false;
     entry.isBootstrappingInitialContent = false;
     this.emit(entry);
+  }
+
+  // Routes to plainFallback when IndexedDB is blocked or unavailable.
+  // plainFallback = editor uses REST content directly with REST auto-save,
+  // so edits are durable to the server even without local IndexedDB storage.
+  // Falls back to markBootstrapFailed if the pending content can't be used
+  // as a plain-editor fallback (e.g. not yet seeded or malformed).
+  private routeToPlainFallback(
+    entry: DocumentRuntimeEntry,
+    warning: string,
+    fallbackReason: LocalFallbackReason
+  ) {
+    const pendingContent = entry.pendingInitialContent;
+    if (pendingContent && canUsePlainEditorFallback(pendingContent)) {
+      this.clearBootstrapWatch(entry);
+      entry.state.bootstrapState = "failed";
+      entry.state.availabilityState = "plainFallback";
+      entry.state.localFallbackReason = fallbackReason;
+      entry.state.warning = warning;
+      entry.hasSeededInitialContent = false;
+      entry.isBootstrappingInitialContent = false;
+      this.emit(entry);
+    } else {
+      this.markBootstrapFailed(entry, warning);
+    }
   }
 
   private bootstrapFromSavedContent(
@@ -2048,6 +2098,16 @@ class CollaborationRuntimeManager {
 }
 
 export const collaborationRuntimeManager = new CollaborationRuntimeManager();
+
+// Request persistent IndexedDB storage on startup. Mobile browsers and some
+// desktop contexts (e.g. private browsing) apply aggressive eviction to
+// "best-effort" storage. Persistent storage is less likely to be cleared
+// mid-session — directly reduces Y.Doc buffer loss in webview/iframe contexts.
+// This is a hint to the browser; it may be denied (partitioned iframes, user
+// choice), so we fire-and-forget rather than gating any behavior on the result.
+if (typeof navigator !== "undefined" && "storage" in navigator && "persist" in navigator.storage) {
+  void navigator.storage.persist();
+}
 
 export function useCollaborationRuntime({
   contentId,

--- a/lib/domain/periodic-notes/period.ts
+++ b/lib/domain/periodic-notes/period.ts
@@ -2,29 +2,50 @@ import moment, { type Moment } from "moment";
 import type { PeriodicNoteKind, PeriodicNotePeriod } from "./types";
 import { PERIODIC_NOTES_DEFAULTS } from "./settings";
 
-export function getMomentForPeriodicNote(value?: string | null): Moment {
-  if (!value) return moment();
-
-  const parsed = moment(value);
-  return parsed.isValid() ? parsed : moment();
+export function getMomentForPeriodicNote(value?: string | null, nightOwlHour = 0): Moment {
+  const base = (() => {
+    if (!value) return moment();
+    const parsed = moment(value);
+    return parsed.isValid() ? parsed : moment();
+  })();
+  const clampedHour = Math.min(4, Math.max(0, Math.trunc(nightOwlHour)));
+  return clampedHour > 0 ? base.clone().subtract(clampedHour, "hours") : base;
 }
 
 export function getPeriodicNotePeriod(
   kind: PeriodicNoteKind,
   filenameFormat: string,
-  value?: string | null
+  value?: string | null,
+  nightOwlHour = 0
 ): PeriodicNotePeriod {
-  const current = getMomentForPeriodicNote(value);
+  const current = getMomentForPeriodicNote(value, nightOwlHour);
   const format = filenameFormat.trim() || PERIODIC_NOTES_DEFAULTS[kind].filenameFormat;
 
   return {
     kind,
-    periodKey:
-      kind === "weekly"
-        ? current.clone().startOf("isoWeek").format("GGGG-[W]WW")
-        : current.format("YYYY-MM-DD"),
+    periodKey: formatPeriodKey(kind, current),
     title: formatPeriodicNoteTitle(current, format, kind),
   };
+}
+
+/**
+ * Canonical period key per kind. All four formats sort lexicographically
+ * identically to chronologically, which is what lets the neighbor/glide range
+ * queries and the auto-create dedup index work without date parsing.
+ */
+export function formatPeriodKey(kind: PeriodicNoteKind, current: Moment): string {
+  switch (kind) {
+    case "weekly":
+      return current.clone().startOf("isoWeek").format("GGGG-[W]WW");
+    case "monthly":
+      return current.format("YYYY-MM");
+    case "quarterly":
+      return current.format("YYYY-[Q]Q");
+    case "yearly":
+      return current.format("YYYY");
+    default:
+      return current.format("YYYY-MM-DD");
+  }
 }
 
 export function formatPeriodicNoteTitle(
@@ -40,8 +61,10 @@ export function formatPeriodicNoteTitle(
   return current.format(fallbackFormat);
 }
 
-export function getNextPeriodicRolloverDelay(now = new Date()) {
+export function getNextPeriodicRolloverDelay(now = new Date(), nightOwlHour = 0) {
+  const clampedHour = Math.min(4, Math.max(0, Math.trunc(nightOwlHour)));
+  // The "day" flips at midnight + nightOwlHour real-clock hours, not at midnight.
   const current = moment(now);
-  const nextMidnight = current.clone().add(1, "day").startOf("day");
-  return Math.max(1_000, nextMidnight.diff(current) + 1_000);
+  const nextRollover = current.clone().add(1, "day").startOf("day").add(clampedHour, "hours");
+  return Math.max(1_000, nextRollover.diff(current) + 1_000);
 }

--- a/lib/domain/periodic-notes/settings.ts
+++ b/lib/domain/periodic-notes/settings.ts
@@ -15,6 +15,12 @@ export function getPeriodicNotesSettings(
   return {
     daily: normalizeKindSettings(settings?.periodicNotes?.daily, "daily"),
     weekly: normalizeKindSettings(settings?.periodicNotes?.weekly, "weekly"),
+    monthly: normalizeKindSettings(settings?.periodicNotes?.monthly, "monthly"),
+    quarterly: normalizeKindSettings(
+      settings?.periodicNotes?.quarterly,
+      "quarterly"
+    ),
+    yearly: normalizeKindSettings(settings?.periodicNotes?.yearly, "yearly"),
   };
 }
 
@@ -37,7 +43,7 @@ function normalizeKindSettings(
     folderId: value?.folderId ?? defaults.folderId,
     filenameFormat,
     templateId: value?.templateId ?? defaults.templateId,
-    autoCreateOnOpen:
-      value?.autoCreateOnOpen ?? defaults.autoCreateOnOpen,
+    autoCreateOnOpen: value?.autoCreateOnOpen ?? defaults.autoCreateOnOpen,
+    nightOwlHour: Math.min(4, Math.max(0, Math.trunc(value?.nightOwlHour ?? defaults.nightOwlHour ?? 0))),
   };
 }

--- a/lib/domain/periodic-notes/types.ts
+++ b/lib/domain/periodic-notes/types.ts
@@ -1,6 +1,11 @@
 import type { JSONContent } from "@tiptap/core";
 
-export type PeriodicNoteKind = "daily" | "weekly";
+export type PeriodicNoteKind =
+  | "daily"
+  | "weekly"
+  | "monthly"
+  | "quarterly"
+  | "yearly";
 
 export interface PeriodicNoteKindSettings {
   enabled: boolean;
@@ -8,11 +13,16 @@ export interface PeriodicNoteKindSettings {
   filenameFormat: string;
   templateId: string | null;
   autoCreateOnOpen: boolean;
+  /** Hours to subtract from "now" before resolving today's date (0–4). */
+  nightOwlHour: number;
 }
 
 export interface PeriodicNotesSettings {
   daily: PeriodicNoteKindSettings;
   weekly: PeriodicNoteKindSettings;
+  monthly: PeriodicNoteKindSettings;
+  quarterly: PeriodicNoteKindSettings;
+  yearly: PeriodicNoteKindSettings;
 }
 
 export interface PeriodicNotePeriod {

--- a/lib/features/settings/validation.ts
+++ b/lib/features/settings/validation.ts
@@ -252,12 +252,16 @@ const periodicNoteKindSettingsSchema = z.object({
   filenameFormat: z.string().min(1).max(120).optional(),
   templateId: z.string().uuid().nullable().optional(),
   autoCreateOnOpen: z.boolean().optional(),
+  nightOwlHour: z.number().int().min(0).max(4).optional(),
 });
 
 const periodicNotesSettingsSchema = z
   .object({
     daily: periodicNoteKindSettingsSchema.optional(),
     weekly: periodicNoteKindSettingsSchema.optional(),
+    monthly: periodicNoteKindSettingsSchema.optional(),
+    quarterly: periodicNoteKindSettingsSchema.optional(),
+    yearly: periodicNoteKindSettingsSchema.optional(),
   })
   .optional();
 
@@ -536,6 +540,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
       filenameFormat: "YYYY-MM-DD",
       templateId: null,
       autoCreateOnOpen: false,
+      nightOwlHour: 0,
     },
     weekly: {
       enabled: false,
@@ -543,6 +548,31 @@ export const DEFAULT_SETTINGS: UserSettings = {
       filenameFormat: "GGGG-[W]WW",
       templateId: null,
       autoCreateOnOpen: false,
+      nightOwlHour: 0,
+    },
+    monthly: {
+      enabled: false,
+      folderId: null,
+      filenameFormat: "YYYY-MM",
+      templateId: null,
+      autoCreateOnOpen: false,
+      nightOwlHour: 0,
+    },
+    quarterly: {
+      enabled: false,
+      folderId: null,
+      filenameFormat: "YYYY-[Q]Q",
+      templateId: null,
+      autoCreateOnOpen: false,
+      nightOwlHour: 0,
+    },
+    yearly: {
+      enabled: false,
+      folderId: null,
+      filenameFormat: "YYYY",
+      templateId: null,
+      autoCreateOnOpen: false,
+      nightOwlHour: 0,
     },
   },
   flashcards: {

--- a/state/settings-store.ts
+++ b/state/settings-store.ts
@@ -232,6 +232,18 @@ export const useSettingsStore = create<SettingsStore>()(
               ...state.periodicNotes?.weekly,
               ...periodicNotes.weekly,
             },
+            monthly: {
+              ...state.periodicNotes?.monthly,
+              ...periodicNotes.monthly,
+            },
+            quarterly: {
+              ...state.periodicNotes?.quarterly,
+              ...periodicNotes.quarterly,
+            },
+            yearly: {
+              ...state.periodicNotes?.yearly,
+              ...periodicNotes.yearly,
+            },
           },
           hasPendingChanges: true,
         }));


### PR DESCRIPTION
## Sprint 59 — Periodic Notes Overhaul

- Extend `PeriodicNoteKind` to 5 cadences: `daily | weekly | monthly | quarterly | yearly` — schema-zero change, all new kinds use the existing `PeriodicNoteIndex` unique key + lexicographic periodKey invariant
- **Night Owl Protection** (`nightOwlHour` 0–4): shifts "now" back N hours before resolving so late-night journaling lands on the correct period; shown only for daily/weekly (irrelevant at month/year scale)
- `formatPeriodKey(kind, moment)` — single source of truth for all period key strings (`YYYY-MM-DD`, `GGGG-[W]WW`, `YYYY-MM`, `YYYY-[Q]Q`, `YYYY`)
- **Glide navigation**: new `GET /api/periodic-notes/neighbors` endpoint (sparse B-tree range seeks on `periodKey`) + `PeriodicNotesGlideController` floating pill — prev/next between *existing* notes, skips gaps
- **Context menu redesign**: portaled to `document.body` (fixes transformed-ancestor gap), compact `w-[248px]`, segmented `prev · current · next` rows per enabled kind, brighter section headers
- Yesterday / Last Week / Last Month / Last Quarter / Last Year navigation items (negative `offsetPeriods`)
- Tomorrow / Next Week / Next Month / Next Quarter / Next Year items (positive offsets)
- **Tabbed settings dialog** (5 tabs, `grid-cols-5`), kind-specific auto-create wording, Night Owl UI on daily/weekly only
- Auto-create loop in `PeriodicNotesShellController` covers all 5 cadences; rollover timer accounts for `nightOwlHour`
- **Gate:** `pnpm typecheck` clean, lint 155 warnings (under 159 ratchet), 0 errors

## Sprint 60 — Theme Toggle in Profile Menu

- Quick-access light / dark / auto segmented control in the profile dropdown (Sun / Moon / Monitor icons), wired to `setUISettings({ theme })` for instant theme switching without navigating to settings
- **Gate:** visual smoke test in browser

## Sprint 61 — Collaboration Resilience

- **Anti-blank-document guard**: `MarkdownEditor` now tracks Y.Doc content readiness via `observeDeep` before allowing the editor to bind; prevents a blank note flash when Hocuspocus delivers content slightly after mount
- **`reseedCollaborationDocumentFromNote`**: after any write path that bypasses collaboration (browser extension), realigns the durable `CollaborationDocument` Y.Doc snapshot with the fresh `NotePayload` — prevents stale collab snapshot masking the extension's edit on next open
- **IndexedDB watchdog** (4 s): if IndexedDB stalls (mobile webview, partitioned storage, background suspension), routes to `plainFallback` so the user can edit via REST auto-save rather than being blocked in a read-only booting state; adds `"unavailable"` to `PersistenceState`
- **Gate:** existing collab smoke test + confirmed no CONTENT-LOAD-CASCADE regression

## Sprint 62 — Browser Extension + AI Chat

- `fix(browser-extension)`: stop embed iframe cookie from replacing the 7-day session cookie — auth cookie lifetime regression when extension was open
- `feat(ai-chat)`: light-mode color variants for all AI provider surfaces (Anthropic, OpenAI, Gemini, etc.)
- **Gate:** extension reload test, AI chat in light mode

---

## Pre-merge checklist

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — ≤ 159 warnings, 0 errors
- [x] `pnpm build` — production build passes
- [x] Periodic notes smoke: enable Monthly + Quarterly in settings → create monthly note → glide pill appears → glide prev/next
- [x] Context menu: hold icon → all enabled rows render, portal gap is gone, Yesterday/Today/Tomorrow work for daily
- [x] Night Owl Protection: set to 2h, confirm note resolves to yesterday after midnight
- [x] Theme toggle: profile menu → switch light/dark/auto → instant change, persists on reload
- [x] Browser extension: import note → reopen in app → content not blank (collab reseed verified)
- [x] AI chat: open in light mode → provider surfaces readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)