### PR TITLE
feat(collab): sleep-mode — reduce Cloud Run cost for idle sessions

### DIFF
--- a/components/content/editor/MarkdownEditor.tsx
+++ b/components/content/editor/MarkdownEditor.tsx
@@ -1234,8 +1234,8 @@ export function MarkdownEditor({
         <div
           className={
             isCollaborationEditBlocked
-              ? "border-b border-red-500/20 bg-red-500/10 px-4 py-2 text-sm text-red-700"
-              : "border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm text-amber-800"
+              ? "border-b border-red-500/20 bg-red-500/10 px-4 py-2 text-sm text-red-700 dark:text-red-400"
+              : "border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm text-amber-700 dark:text-amber-300"
           }
         >
           {isCollaborationEditBlocked ? "Editing blocked" : "Collaboration notice"}:{" "}

--- a/components/content/headers/MainPanelHeader.tsx
+++ b/components/content/headers/MainPanelHeader.tsx
@@ -36,6 +36,14 @@ interface TabPresenceSession {
   lastSeenAt: number;
 }
 
+// Transport states that represent an actively-synced collaboration connection.
+// Anything else (localOnly, coolingDown, disconnectedButDirty) renders as dormant/grey.
+const ACTIVE_TRANSPORT_STATES = new Set(["synced", "connected", "connecting", "promoting"]);
+
+function isActiveTransport(transportState: string | undefined): boolean {
+  return ACTIVE_TRANSPORT_STATES.has(transportState ?? "");
+}
+
 interface PresenceDisplayGroup {
   key: string;
   displayName: string;
@@ -45,6 +53,8 @@ interface PresenceDisplayGroup {
   sessionCount: number;
   firstSeenAt: number;
   colorSeed: string;
+  /** true if at least one session in this group has an active WebSocket to Hocuspocus */
+  hasActiveTransport: boolean;
 }
 
 interface PresenceSnapshotResponse {
@@ -130,6 +140,10 @@ function groupPresenceSessions(sessions: TabPresenceSession[]): PresenceDisplayG
       if (!existing.avatarUrl && session.avatarUrl) {
         existing.avatarUrl = session.avatarUrl;
       }
+      // Promote to active if any session in the group is actively synced.
+      if (isActiveTransport(session.transportState)) {
+        existing.hasActiveTransport = true;
+      }
     } else {
       groups.set(key, {
         key,
@@ -140,6 +154,7 @@ function groupPresenceSessions(sessions: TabPresenceSession[]): PresenceDisplayG
         sessionCount: 1,
         firstSeenAt: session.firstSeenAt || Date.now(),
         colorSeed: session.userId || session.sessionId,
+        hasActiveTransport: isActiveTransport(session.transportState),
       });
     }
   }
@@ -174,13 +189,17 @@ function TabPresenceDiscs({
       {visibleGroups.map((group, index) => {
         const initials = getInitials(group.displayName);
         const colorIndex = hashString(group.colorSeed) % 5;
-        const colors = [
+        const activeColors = [
           "bg-blue-500",
           "bg-emerald-500",
           "bg-violet-500",
           "bg-amber-500",
           "bg-rose-500",
         ];
+        // Active transport → coloured avatar. Dormant (sleeping/cooling down) → grey.
+        const avatarColorClass = group.hasActiveTransport
+          ? activeColors[colorIndex]
+          : "bg-gray-400 dark:bg-gray-500";
 
         return (
           <div
@@ -189,14 +208,16 @@ function TabPresenceDiscs({
             style={{ zIndex: groups.length - index }}
           >
             <div
-              className={`flex h-6 w-6 items-center justify-center overflow-hidden rounded-full border-2 border-background text-[10px] font-semibold uppercase text-white shadow-sm ${
-                colors[colorIndex]
-              }`}
+              className={`flex h-6 w-6 items-center justify-center overflow-hidden rounded-full border-2 border-background text-[10px] font-semibold uppercase text-white shadow-sm transition-colors duration-300 ${avatarColorClass}`}
               aria-label={group.displayName}
             >
               {group.avatarUrl ? (
                 // eslint-disable-next-line @next/next/no-img-element
-                <img src={group.avatarUrl} alt="" className="h-full w-full object-cover" />
+                <img
+                  src={group.avatarUrl}
+                  alt=""
+                  className={`h-full w-full object-cover ${group.hasActiveTransport ? "" : "opacity-60"}`}
+                />
               ) : (
                 initials
               )}
@@ -209,8 +230,9 @@ function TabPresenceDiscs({
                 <>
                   <p className="text-muted-foreground">{formatSessionStart(group.firstSeenAt)}</p>
                   <p className="text-muted-foreground">
+                    {group.hasActiveTransport ? "Live" : "Idle"} ·{" "}
                     {group.sessionCount} {group.sessionCount === 1 ? "session" : "sessions"} ·{" "}
-                    {group.surfaceCount} active {group.surfaceCount === 1 ? "view" : "views"}
+                    {group.surfaceCount} {group.surfaceCount === 1 ? "view" : "views"}
                   </p>
                 </>
               )}

--- a/components/content/viewer/ExcalidrawViewer.tsx
+++ b/components/content/viewer/ExcalidrawViewer.tsx
@@ -553,7 +553,7 @@ export function ExcalidrawViewer({
       {/* Read-only banner: shown when this drawing is owned by a note */}
       {isReadOnly && ownerNoteInfo && (
         <div className="flex items-center justify-between gap-3 border-b border-yellow-500/20 bg-yellow-500/10 px-6 py-2 text-xs">
-          <span className="text-yellow-300">
+          <span className="text-yellow-700 dark:text-yellow-300">
             View-only — this drawing lives inside
             {ownerNoteInfo.noteTitle ? ` “${ownerNoteInfo.noteTitle}”` : " a note"}. Edit it there to keep changes in sync.
           </span>

--- a/lib/domain/collaboration/presence-server.ts
+++ b/lib/domain/collaboration/presence-server.ts
@@ -28,7 +28,35 @@ interface PresenceStore {
   listeners: Map<string, Set<() => void>>;
 }
 
+// Two-tier staleness keyed off the record's transportState:
+// - Active transports heartbeat every 10-30s → 45s window keeps crashed tabs
+//   from leaving ghost badges for long.
+// - Dormant transports (sleep mode) deliberately heartbeat every 5 min → an
+//   8-minute window keeps their grey badge alive between beats. A hard-killed
+//   dormant tab lingers as a grey badge for up to ~8 min; graceful closes are
+//   cleared immediately by the surfaceCount=0 close beacon.
 const STALE_AFTER_MS = 45_000;
+const DORMANT_STALE_AFTER_MS = 8 * 60_000;
+const DORMANT_TRANSPORT_STATES = [
+  "localOnly",
+  "coolingDown",
+  "disconnectedButDirty",
+] as const;
+
+function freshnessFilter(now: number) {
+  return {
+    OR: [
+      {
+        transportState: { in: [...DORMANT_TRANSPORT_STATES] },
+        lastSeenAt: { gte: new Date(now - DORMANT_STALE_AFTER_MS) },
+      },
+      {
+        transportState: { notIn: [...DORMANT_TRANSPORT_STATES] },
+        lastSeenAt: { gte: new Date(now - STALE_AFTER_MS) },
+      },
+    ],
+  };
+}
 
 declare global {
   var __dgCollaborationPresenceStore: PresenceStore | undefined;
@@ -44,12 +72,11 @@ function getStore() {
 }
 
 async function prune(prisma: PrismaClient, contentId: string) {
+  const now = Date.now();
   await prisma.collaborationPresence.deleteMany({
     where: {
       contentId,
-      lastSeenAt: {
-        lt: new Date(Date.now() - STALE_AFTER_MS),
-      },
+      NOT: freshnessFilter(now),
     },
   });
 }
@@ -107,9 +134,7 @@ export async function listCollaborationPresence(prisma: PrismaClient, contentId:
       surfaceCount: {
         gt: 0,
       },
-      lastSeenAt: {
-        gte: new Date(Date.now() - STALE_AFTER_MS),
-      },
+      ...freshnessFilter(Date.now()),
     },
     orderBy: {
       firstSeenAt: "asc",

--- a/lib/domain/collaboration/runtime.ts
+++ b/lib/domain/collaboration/runtime.ts
@@ -272,6 +272,10 @@ interface DocumentRuntimeEntry {
   presenceHeartbeatTimer: ReturnType<typeof setTimeout> | null;
   presenceHeartbeatInFlight: boolean;
   presenceEventSource: EventSource | null;
+  // True once the tab has been hidden past VISIBILITY_SLEEP_DELAY_MS. Blocks
+  // the SSE presence stream from (re)opening and selects the deep-dormant
+  // heartbeat cadence. Cleared when the tab becomes visible again.
+  presenceStreamSuspended: boolean;
   broadcastChannel: BroadcastChannel | null;
   knownBrowserSessions: Map<string, BrowserSessionPresence>;
   pendingInitialContent: JSONContent | null;
@@ -325,6 +329,18 @@ const SESSION_ANNOUNCE_INTERVAL_MS = 2000;
 const PRESENCE_HEARTBEAT_INTERVAL_MS = 10_000;
 const PRESENCE_HEARTBEAT_IDLE_INTERVAL_MS = 30_000;
 const PRESENCE_HEARTBEAT_HIDDEN_INTERVAL_MS = 30_000;
+// Deep-dormant cadence: transport is deliberately asleep (sleep mode) and the
+// tab is hidden past the suspension threshold or idle past the sleep window.
+// Server-side staleness gives dormant transportStates an 8-minute window
+// (presence-server.ts DORMANT_STALE_AFTER_MS), so 5 min keeps the record alive.
+const PRESENCE_HEARTBEAT_SLEEP_INTERVAL_MS = 5 * 60 * 1000;
+// Transport states that mean "no live WebSocket". Used to route presence
+// leadership away from hibernating tabs and to pick the deep-dormant cadence.
+const DORMANT_TRANSPORT_STATES: ReadonlySet<ConnectionState> = new Set([
+  "localOnly",
+  "coolingDown",
+  "disconnectedButDirty",
+]);
 const PRESENCE_IDLE_AFTER_MS = 60_000;
 const PROVIDER_RECONNECT_BASE_MS = 1000;
 const PROVIDER_RECONNECT_MAX_MS = 5 * 60 * 1000; // 5 min — activity triggers immediate reconnect instead
@@ -661,6 +677,7 @@ class CollaborationRuntimeManager {
       presenceHeartbeatTimer: null,
       presenceHeartbeatInFlight: false,
       presenceEventSource: null,
+      presenceStreamSuspended: false,
       broadcastChannel: null,
       knownBrowserSessions: new Map(),
       pendingInitialContent: null,
@@ -737,6 +754,9 @@ class CollaborationRuntimeManager {
         entry.state.connectionState = "synced";
         this.scheduleInactivitySleep(entry);
         this.emit(entry);
+        // Announce the return to "synced" right away — the cooldown entry
+        // heartbeat may have just marked this record as dormant.
+        this.schedulePresenceHeartbeat(entry, 0);
         return;
       }
 
@@ -795,6 +815,16 @@ class CollaborationRuntimeManager {
     window.addEventListener("offline", entry.networkOfflineHandler);
     document.addEventListener("visibilitychange", entry.visibilityChangeHandler);
     window.addEventListener("pagehide", entry.pageHideHandler);
+    // Tabs restored/opened in the background never fire visibilitychange, so
+    // kick off the same hidden-sleep countdown the event handler would start.
+    if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+      entry.visibilitySleepTimer = setTimeout(() => {
+        entry.visibilitySleepTimer = null;
+        entry.presenceStreamSuspended = true;
+        this.closePresenceStream(entry);
+        this.maybeEnterSleepMode(entry);
+      }, VISIBILITY_SLEEP_DELAY_MS);
+    }
     this.entries.set(contentId, entry);
     updateLocalCacheManifest(entry);
     return entry;
@@ -1178,6 +1208,10 @@ class CollaborationRuntimeManager {
 
   private openPresenceStream(entry: DocumentRuntimeEntry) {
     if (entry.presenceEventSource || entry.consumers.size === 0) return;
+    // Deep-hidden tabs don't need live badge updates; the stream reopens on
+    // tab-visible. This kills the server-side 10s Postgres poll for the
+    // lifetime of the suspension.
+    if (entry.presenceStreamSuspended) return;
     const streamUrl = `/api/collaboration/presence/stream?contentId=${encodeURIComponent(
       entry.contentId
     )}&sessionId=${encodeURIComponent(this.sessionId)}`;
@@ -1205,6 +1239,24 @@ class CollaborationRuntimeManager {
 
   private getPresenceHeartbeatDelay(entry: DocumentRuntimeEntry) {
     if (entry.state.networkState === "offline") return PRESENCE_HEARTBEAT_HIDDEN_INTERVAL_MS;
+    // Deep-dormant tier: the transport is deliberately asleep (sleep mode
+    // completed — no provider, no reconnect intent) AND the tab is either
+    // suspended-hidden or idle past the sleep window. The record survives on
+    // the server's dormant staleness window, so 5 min is safe. Requiring
+    // !hocuspocusProvider keeps sessions that stayed connected (e.g. dirty
+    // edits blocked the sleep) on the fast cadence so their "synced" record
+    // isn't pruned under the 45s active-tier window.
+    const transportDormant =
+      !entry.hocuspocusProvider &&
+      entry.state.connectionState === "localOnly" &&
+      !entry.state.reconnectIntent;
+    if (
+      transportDormant &&
+      (entry.presenceStreamSuspended ||
+        Date.now() - entry.lastActivityAt >= INACTIVITY_SLEEP_DELAY_MS)
+    ) {
+      return PRESENCE_HEARTBEAT_SLEEP_INTERVAL_MS;
+    }
     if (typeof document !== "undefined" && document.visibilityState === "hidden") {
       return PRESENCE_HEARTBEAT_HIDDEN_INTERVAL_MS;
     }
@@ -1231,13 +1283,27 @@ class CollaborationRuntimeManager {
 
   private isPresenceLeader(entry: DocumentRuntimeEntry) {
     if (entry.consumers.size === 0) return false;
-    const activeSessionIds = [
-      this.sessionId,
+    // Prefer sessions with a live transport as leader: the leader's heartbeat
+    // cadence refreshes EVERY same-browser record, so a hibernating leader on
+    // the 5-min cadence would starve active-transport records (45s staleness).
+    // Fall back to all sessions when every tab is dormant (e.g. all asleep or
+    // all pre-promote) so exactly one still heartbeats.
+    const candidates: Array<{ sessionId: string; dormant: boolean }> = [
+      {
+        sessionId: this.sessionId,
+        dormant: DORMANT_TRANSPORT_STATES.has(entry.state.connectionState),
+      },
       ...Array.from(entry.knownBrowserSessions.values())
         .filter((session) => session.surfaceCount > 0)
-        .map((session) => session.sessionId),
-    ].sort();
-    return activeSessionIds[0] === this.sessionId;
+        .map((session) => ({
+          sessionId: session.sessionId,
+          dormant: DORMANT_TRANSPORT_STATES.has(session.transportState),
+        })),
+    ];
+    const live = candidates.filter((candidate) => !candidate.dormant);
+    const pool = live.length > 0 ? live : candidates;
+    const sortedIds = pool.map((candidate) => candidate.sessionId).sort();
+    return sortedIds[0] === this.sessionId;
   }
 
   private buildPresenceHeartbeatSessions(
@@ -1643,6 +1709,9 @@ class CollaborationRuntimeManager {
         this.emit(entry);
         // Start inactivity countdown after every successful sync.
         this.scheduleInactivitySleep(entry);
+        // Announce "synced" immediately so other sessions' badges flip from
+        // grey to live without waiting out a dormant heartbeat interval.
+        this.schedulePresenceHeartbeat(entry, 0);
       },
       onUnsyncedChanges: ({ number }) => {
         entry.state.unsyncedUpdateCount = number;
@@ -1970,6 +2039,10 @@ class CollaborationRuntimeManager {
       if (!entry.visibilitySleepTimer) {
         entry.visibilitySleepTimer = setTimeout(() => {
           entry.visibilitySleepTimer = null;
+          // Deep-hidden: stop the SSE presence stream (kills the server-side
+          // 10s Postgres poll) and drop to the dormant heartbeat cadence.
+          entry.presenceStreamSuspended = true;
+          this.closePresenceStream(entry);
           this.maybeEnterSleepMode(entry);
         }, VISIBILITY_SLEEP_DELAY_MS);
       }
@@ -1981,6 +2054,14 @@ class CollaborationRuntimeManager {
       }
       // Reset activity clock so inactivity timer gets a fresh window.
       entry.lastActivityAt = Date.now();
+      // Lift deep-hidden suspension: reopen the presence stream (if leader)
+      // and heartbeat immediately so our record refreshes and we re-learn who
+      // else is here without waiting out a dormant-cadence interval.
+      if (entry.presenceStreamSuspended) {
+        entry.presenceStreamSuspended = false;
+        this.syncPresenceTransport(entry);
+        this.schedulePresenceHeartbeat(entry, 0);
+      }
       // If we slept and came back to an active session, re-promote.
       if (
         entry.state.connectionState === "localOnly" &&
@@ -2042,6 +2123,11 @@ class CollaborationRuntimeManager {
     if (entry.cooldownTimer) clearTimeout(entry.cooldownTimer);
     entry.state.connectionState = "coolingDown";
     this.emit(entry);
+    // Push the dormant transportState to the server BEFORE the heartbeat
+    // cadence slows: the server's staleness tier is keyed off the stored
+    // transportState, so a record still marked "synced" would be pruned
+    // under the 45s active window once we drop to the 5-min cadence.
+    this.schedulePresenceHeartbeat(entry, 0);
 
     entry.cooldownTimer = setTimeout(() => {
       entry.cooldownTimer = null;
@@ -2062,6 +2148,9 @@ class CollaborationRuntimeManager {
       // → promote) or user typing (ydocUpdateHandler → maybePromoteFromCurrentTopology).
       entry.state.reconnectIntent = false;
       this.emit(entry);
+      // Announce localOnly at the fast cadence one last time; the next
+      // reschedule computes the dormant 5-min interval from this state.
+      this.schedulePresenceHeartbeat(entry, 0);
     }, COOLDOWN_MS);
   }
 

--- a/lib/domain/collaboration/runtime.ts
+++ b/lib/domain/collaboration/runtime.ts
@@ -327,7 +327,7 @@ const PRESENCE_HEARTBEAT_IDLE_INTERVAL_MS = 30_000;
 const PRESENCE_HEARTBEAT_HIDDEN_INTERVAL_MS = 30_000;
 const PRESENCE_IDLE_AFTER_MS = 60_000;
 const PROVIDER_RECONNECT_BASE_MS = 1000;
-const PROVIDER_RECONNECT_MAX_MS = 30_000;
+const PROVIDER_RECONNECT_MAX_MS = 5 * 60 * 1000; // 5 min — activity triggers immediate reconnect instead
 const BOOTSTRAP_SLOW_WARNING_MS = 10_000;
 const BOOTSTRAP_LOCAL_FALLBACK_MS = 25_000;
 const COOLDOWN_MS = 120_000;
@@ -750,6 +750,10 @@ class CollaborationRuntimeManager {
       ) {
         void this.promote(entry, "reconnect-after-offline");
       }
+
+      // If Hocuspocus dropped unexpectedly (reconnectIntent=true, passive timer
+      // ticking toward 5 min cap), jump straight to reconnect on user edit.
+      this.activityTriggeredReconnect(entry);
 
       if (
         entry.state.networkState === "offline" ||
@@ -1853,6 +1857,20 @@ class CollaborationRuntimeManager {
     entry.reconnectAttempts = 0;
   }
 
+  // Called when the user is demonstrably active (typing or tab focus). If a
+  // passive reconnect timer is pending, cancel it and promote immediately so
+  // the 5-minute cap doesn't delay a reconnect the user clearly wants now.
+  private activityTriggeredReconnect(entry: DocumentRuntimeEntry) {
+    if (
+      entry.state.reconnectIntent &&
+      !entry.hocuspocusProvider &&
+      !entry.promotionPromise
+    ) {
+      this.clearProviderReconnect(entry);
+      void this.promote(entry, "reconnect-after-offline");
+    }
+  }
+
   private shouldReconnectProvider(entry: DocumentRuntimeEntry) {
     return (
       entry.consumers.size > 0 &&
@@ -1972,6 +1990,10 @@ class CollaborationRuntimeManager {
       ) {
         void this.promote(entry, "reconnect-after-offline");
       }
+
+      // If Hocuspocus dropped unexpectedly (passive backoff timer running),
+      // jump straight to reconnect now that the user is back on the tab.
+      this.activityTriggeredReconnect(entry);
     }
   }
 

--- a/lib/domain/collaboration/runtime.ts
+++ b/lib/domain/collaboration/runtime.ts
@@ -262,6 +262,8 @@ interface DocumentRuntimeEntry {
   listeners: Set<() => void>;
   cooldownTimer: ReturnType<typeof setTimeout> | null;
   idleEvictionTimer: ReturnType<typeof setTimeout> | null;
+  visibilitySleepTimer: ReturnType<typeof setTimeout> | null;
+  inactivitySleepTimer: ReturnType<typeof setTimeout> | null;
   bootstrapSlowTimer: ReturnType<typeof setTimeout> | null;
   bootstrapFallbackTimer: ReturnType<typeof setTimeout> | null;
   bootstrapAbortController: AbortController | null;
@@ -330,6 +332,12 @@ const BOOTSTRAP_SLOW_WARNING_MS = 10_000;
 const BOOTSTRAP_LOCAL_FALLBACK_MS = 25_000;
 const COOLDOWN_MS = 120_000;
 const IDLE_EVICTION_MS = 300_000;
+// Sleep thresholds — disconnect Cloud Run WebSocket when no real editing is happening.
+// Visibility sleep: tab hidden for N ms → sleep even if "multi-session" (browser extension
+// open in background counts as multi-session but isn't real collaboration).
+// Inactivity sleep: no Y.js edits for N ms while connected → sleep.
+const VISIBILITY_SLEEP_DELAY_MS = 3 * 60 * 1000;   // 3 minutes hidden
+const INACTIVITY_SLEEP_DELAY_MS = 10 * 60 * 1000;  // 10 minutes idle
 const LOCAL_CACHE_MANIFEST_KEY = "dg-collab-local-cache-manifest";
 const LOCAL_CACHE_PRUNE_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -643,6 +651,8 @@ class CollaborationRuntimeManager {
       consumers: new Map(),
       cooldownTimer: null,
       idleEvictionTimer: null,
+      visibilitySleepTimer: null,
+      inactivitySleepTimer: null,
       bootstrapSlowTimer: null,
       bootstrapFallbackTimer: null,
       bootstrapAbortController: null,
@@ -708,6 +718,39 @@ class CollaborationRuntimeManager {
       if (entry.state.persistenceState !== "localReady") return;
 
       entry.lastActivityAt = Date.now();
+
+      // Cancel any pending sleep timers — the user is actively editing.
+      if (entry.inactivitySleepTimer) {
+        clearTimeout(entry.inactivitySleepTimer);
+        entry.inactivitySleepTimer = null;
+      }
+      if (entry.visibilitySleepTimer) {
+        clearTimeout(entry.visibilitySleepTimer);
+        entry.visibilitySleepTimer = null;
+      }
+
+      // If a sleep cooldown is in progress (coolingDown state), cancel it and
+      // resume the live connection — the user started editing again.
+      if (entry.state.connectionState === "coolingDown" && entry.cooldownTimer !== null) {
+        clearTimeout(entry.cooldownTimer);
+        entry.cooldownTimer = null;
+        entry.state.connectionState = "synced";
+        this.scheduleInactivitySleep(entry);
+        this.emit(entry);
+        return;
+      }
+
+      // If we slept (localOnly, no reconnectIntent) and the user starts typing,
+      // re-promote if there's another session present.
+      if (
+        entry.state.connectionState === "localOnly" &&
+        !entry.state.reconnectIntent &&
+        (entry.state.browserSessionTopology === "multiSession" ||
+          entry.state.remoteCollaborationTopology === "remotePresent")
+      ) {
+        void this.promote(entry, "reconnect-after-offline");
+      }
+
       if (
         entry.state.networkState === "offline" ||
         entry.state.connectionState === "disconnectedButDirty"
@@ -1594,6 +1637,8 @@ class CollaborationRuntimeManager {
         entry.state.localDirty = false;
         entry.state.unsyncedUpdateCount = 0;
         this.emit(entry);
+        // Start inactivity countdown after every successful sync.
+        this.scheduleInactivitySleep(entry);
       },
       onUnsyncedChanges: ({ number }) => {
         entry.state.unsyncedUpdateCount = number;
@@ -1899,6 +1944,35 @@ class CollaborationRuntimeManager {
     if (!entry) return;
     this.schedulePresenceHeartbeat(entry);
     this.syncPresenceTransport(entry);
+
+    const isHidden = typeof document !== "undefined" && document.visibilityState === "hidden";
+    if (isHidden) {
+      // Start a sleep countdown while the tab is in the background.
+      // Guard against double-scheduling (rapid hide/show cycles).
+      if (!entry.visibilitySleepTimer) {
+        entry.visibilitySleepTimer = setTimeout(() => {
+          entry.visibilitySleepTimer = null;
+          this.maybeEnterSleepMode(entry);
+        }, VISIBILITY_SLEEP_DELAY_MS);
+      }
+    } else {
+      // Tab became visible — cancel any pending sleep countdown.
+      if (entry.visibilitySleepTimer) {
+        clearTimeout(entry.visibilitySleepTimer);
+        entry.visibilitySleepTimer = null;
+      }
+      // Reset activity clock so inactivity timer gets a fresh window.
+      entry.lastActivityAt = Date.now();
+      // If we slept and came back to an active session, re-promote.
+      if (
+        entry.state.connectionState === "localOnly" &&
+        !entry.state.reconnectIntent &&
+        (entry.state.browserSessionTopology === "multiSession" ||
+          entry.state.remoteCollaborationTopology === "remotePresent")
+      ) {
+        void this.promote(entry, "reconnect-after-offline");
+      }
+    }
   }
 
   private handlePageHide(contentId: string) {
@@ -1931,6 +2005,60 @@ class CollaborationRuntimeManager {
       }
       this.emit(entry);
     }, COOLDOWN_MS);
+  }
+
+  // Permissive sleep — used by visibility and inactivity timers.
+  // Unlike maybeStartCooldown it does not require solo topology: we want
+  // the browser-extension-open-in-background case (multiSession but no
+  // real simultaneous editing) to sleep too.  Skips if dirty or offline.
+  private maybeEnterSleepMode(entry: DocumentRuntimeEntry) {
+    if (!entry.hocuspocusProvider || entry.state.connectionState !== "synced") return;
+    if (entry.state.localDirty || entry.state.unsyncedUpdateCount > 0) return;
+    if (entry.state.networkState !== "online") return;
+    if (entry.state.liveConsumerCount > 0) return;
+
+    if (entry.cooldownTimer) clearTimeout(entry.cooldownTimer);
+    entry.state.connectionState = "coolingDown";
+    this.emit(entry);
+
+    entry.cooldownTimer = setTimeout(() => {
+      entry.cooldownTimer = null;
+      if (
+        entry.state.localDirty ||
+        entry.state.unsyncedUpdateCount > 0 ||
+        entry.state.networkState !== "online"
+      ) {
+        // Something changed during cooldown — stay connected
+        entry.state.connectionState = entry.hocuspocusProvider ? "synced" : "localOnly";
+        this.emit(entry);
+        return;
+      }
+      this.destroyProviderOnly(entry);
+      entry.state.connectionState = "localOnly";
+      // Clear reconnectIntent so the normal reconnect loop doesn't immediately
+      // re-open a WebSocket.  Wakeup happens via presence (applyRemotePresenceSessions
+      // → promote) or user typing (ydocUpdateHandler → maybePromoteFromCurrentTopology).
+      entry.state.reconnectIntent = false;
+      this.emit(entry);
+    }, COOLDOWN_MS);
+  }
+
+  // Schedule an inactivity sleep timer.  Called after connect (onSynced) and
+  // reset after every local Y.js edit.  Fires maybeEnterSleepMode if the user
+  // hasn't typed for INACTIVITY_SLEEP_DELAY_MS.
+  private scheduleInactivitySleep(entry: DocumentRuntimeEntry) {
+    if (entry.inactivitySleepTimer) {
+      clearTimeout(entry.inactivitySleepTimer);
+      entry.inactivitySleepTimer = null;
+    }
+    if (!entry.hocuspocusProvider || entry.state.connectionState !== "synced") return;
+
+    entry.inactivitySleepTimer = setTimeout(() => {
+      entry.inactivitySleepTimer = null;
+      if (Date.now() - entry.lastActivityAt >= INACTIVITY_SLEEP_DELAY_MS) {
+        this.maybeEnterSleepMode(entry);
+      }
+    }, INACTIVITY_SLEEP_DELAY_MS);
   }
 
   private canDemoteProvider(entry: DocumentRuntimeEntry) {
@@ -1986,6 +2114,8 @@ class CollaborationRuntimeManager {
     document.removeEventListener("visibilitychange", entry.visibilityChangeHandler);
     window.removeEventListener("pagehide", entry.pageHideHandler);
     if (entry.cooldownTimer) clearTimeout(entry.cooldownTimer);
+    if (entry.visibilitySleepTimer) clearTimeout(entry.visibilitySleepTimer);
+    if (entry.inactivitySleepTimer) clearTimeout(entry.inactivitySleepTimer);
     // Abort any pending deferred initial promote so its callback doesn't
     // fire against a destroyed entry. Safe to call even if not scheduled.
     if (entry.initialPromoteCancel) {


### PR DESCRIPTION
## Summary

- **Sleep mode**: disconnects the Hocuspocus WebSocket when idle (hidden tab 3 min, no edits 10 min), eliminating Cloud Run keepalive cost for solo sessions. Wakes immediately on tab focus or keypress when another session is present.
- **Grey dormant badge**: collaboration avatar turns grey (not hidden) when that session's WebSocket is sleeping. Returns to colour on wake. Disappears only when there are truly no other sessions.
- **Slower passive reconnect backoff**: cap raised from 30 s → 5 min for unexpected drops. An active user (typing or focusing the tab) bypasses the timer and reconnects immediately instead.
- **Presence-layer economics**: the SSE presence stream (which polls Postgres every 10 s server-side) now suspends after 3 min hidden; deep-dormant sessions drop to a 5-minute heartbeat while staying visible as grey badges via a two-tier server staleness window.
- **Banner contrast fix**: collaboration notice/blocked banners now have `dark:` text companions so they're readable on the dark glass surface. Same fix applied to the Excalidraw read-only banner.

## Sprint 1 — Sleep mode + badge UX

- `lib/domain/collaboration/runtime.ts` — `VISIBILITY_SLEEP_DELAY_MS` (3 min), `INACTIVITY_SLEEP_DELAY_MS` (10 min), `maybeEnterSleepMode`, `scheduleInactivitySleep`; wired into `handleVisibilityChange`, `ydocUpdateHandler`, `onSynced`, `evictIfIdle`
- `components/content/headers/MainPanelHeader.tsx` — `isActiveTransport` helper, `hasActiveTransport` on `PresenceDisplayGroup`, grey avatar for dormant sessions, `opacity-60` on dormant image, "Live"/"Idle" tooltip prefix
- **Gate:** `pnpm typecheck` clean · `pnpm lint` 156/175

## Sprint 2 — Banner contrast

- `components/content/editor/MarkdownEditor.tsx` — notice: `amber-800` → `amber-700 dark:amber-300`; blocked: `red-700` → `red-700 dark:red-400`
- `components/content/viewer/ExcalidrawViewer.tsx` — read-only: `yellow-300` → `yellow-700 dark:yellow-300`
- **Gate:** no type changes, lint unchanged

## Sprint 3 — Reconnect backoff

- `lib/domain/collaboration/runtime.ts` — `PROVIDER_RECONNECT_MAX_MS`: 30 s → 5 min; new `activityTriggeredReconnect()` — cancels passive timer and promotes immediately on user keystroke or tab focus when `reconnectIntent=true`
- **Gate:** `pnpm typecheck` clean · `pnpm lint` 156/175

## Sprint 4 — Presence-layer cost (SSE stream + heartbeat cadence)

- `lib/domain/collaboration/runtime.ts` — `presenceStreamSuspended` flag: the 3-min hidden timer now also closes the SSE presence stream (server side polls Neon every 10 s per open stream); tab-visible lifts suspension with immediate heartbeat + reopen. Tabs that load already-hidden get the same countdown (previously never slept — no `visibilitychange` fires for born-hidden tabs).
- `lib/domain/collaboration/runtime.ts` — `PRESENCE_HEARTBEAT_SLEEP_INTERVAL_MS` (5 min) for deep-dormant sessions (sleep completed + hidden-suspended or idle 10 min+). Sleep transitions announce the dormant `transportState` at fast cadence *before* slowing, so the server tier never prunes a stale-labelled record. `isPresenceLeader` prefers live-transport sessions so a hibernating leader can't starve active same-browser records.
- `lib/domain/collaboration/presence-server.ts` — two-tier staleness keyed off stored `transportState`: active 45 s (unchanged), dormant (`localOnly`/`coolingDown`/`disconnectedButDirty`) 8 min. No schema change. Known tradeoff: a hard-killed dormant tab lingers as a grey badge up to ~8 min; graceful closes still clear instantly via the surfaceCount=0 beacon.
- **Cost effect:** forgotten background tab goes from ~11,500 Neon ops/day (8,640 stream polls + 2,880 heartbeats) to ~300/day, on top of Cloud Run WebSocket savings.
- **Gate:** `pnpm typecheck` clean · `pnpm lint` 156/175

## Revert plan

Each commit is independently revertable:
- `git revert 7aceddb` — removes presence stream suspension + dormant heartbeat tier (Sprint 4)
- `git revert e6072db` — removes reconnect backoff change only (Sprint 3)
- `git revert 98c027c` — removes banner contrast fixes only (Sprint 2)
- `git revert 0fcc051` — removes sleep mode + badge UX (core feature, Sprint 1)

## Pre-merge checklist

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 156/175, under ratchet
- [x] Browser smoke: grey badge appears after 3 min background tab; returns to colour on focus
- [x] Browser smoke: badge disappears when all other sessions close
- [x] Browser smoke: typing in a disconnected state triggers immediate reconnect attempt
- [x] Browser smoke: after 3+ min hidden, Network tab shows presence/stream EventSource closed; reopens on focus
- [x] Browser smoke: hidden tab's badge stays grey (not vanishing) on the visible tab past the 5-min heartbeat gap
- [x] Banner contrast: collaboration notice readable in dark mode
- [x] Post-merge: redeploy Hocuspocus via `cloudbuild.hocuspocus.yaml` (separate step — Cloud Run is not auto-deployed by Vercel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)