### PR TITLE
n8n run loop, failure handling + error-handling settings

### DIFF
--- a/app/api/workflows/callback/error/route.ts
+++ b/app/api/workflows/callback/error/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { withRouteTrace } from "@/lib/core/logger";
+import { prisma } from "@/lib/database/client";
+import { finishRun } from "@/extensions/workflows/server/runs";
+import { isTerminalStatus } from "@/extensions/workflows/server/types";
+import { errorResponse, handleRouteError } from "@/extensions/workflows/server/http";
+import { requireServiceTokenAuth } from "@/extensions/workflows/server/service-token-http";
+import { readJsonBody } from "@/extensions/workflows/server/callback";
+
+const ROUTE_PATH = "/api/workflows/callback/error";
+
+/**
+ * Shared error-handler callback. The per-user "DG Error Handler" n8n workflow
+ * POSTs here (Error Trigger → HTTP) with the failed n8n `engineExecutionId`.
+ * We map it to the owner's run (whose `engineRunId` was stamped by the
+ * "DG: Running" node) and mark it failed — the mechanism that un-sticks a run
+ * whose n8n flow crashed. NOT per-run scoped (the handler has no runId), so it
+ * PAT-auths at the user level, then owner-scopes the run lookup.
+ */
+export async function POST(request: NextRequest) {
+  return withRouteTrace(request, { route: ROUTE_PATH }, async () => {
+    try {
+      const { userId } = await requireServiceTokenAuth(request);
+      const body = await readJsonBody(request);
+      const engineExecutionId =
+        typeof body.engineExecutionId === "string" ? body.engineExecutionId : "";
+      if (!engineExecutionId) {
+        return errorResponse(400, "VALIDATION_ERROR", "engineExecutionId is required.");
+      }
+
+      const run = await prisma.workflowRun.findFirst({
+        where: { ownerId: userId, engineRunId: engineExecutionId },
+        orderBy: { createdAt: "desc" },
+      });
+      if (!run) {
+        // Nothing to fail (unknown execution, or the run was already reconciled).
+        return NextResponse.json({ success: true, data: { matched: false } });
+      }
+      if (isTerminalStatus(run.status)) {
+        return NextResponse.json({
+          success: true,
+          data: { matched: true, runId: run.id, alreadyTerminal: true },
+        });
+      }
+
+      const message =
+        typeof body.message === "string" && body.message
+          ? body.message
+          : "The n8n workflow errored.";
+      await finishRun(run.id, { status: "failed", error: { message } });
+
+      return NextResponse.json({
+        success: true,
+        data: { matched: true, runId: run.id, status: "failed" },
+      });
+    } catch (error) {
+      return handleRouteError(error, "Failed to record workflow error");
+    }
+  });
+}

--- a/app/api/workflows/callback/runs/[id]/running/route.ts
+++ b/app/api/workflows/callback/runs/[id]/running/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { withRouteTrace } from "@/lib/core/logger";
-import { markRunning } from "@/extensions/workflows/server/runs";
+import { markRunning, setEngineRunId } from "@/extensions/workflows/server/runs";
 import {
   handleCallbackError,
+  readJsonBody,
   requireCallbackRun,
 } from "@/extensions/workflows/server/callback";
 
@@ -11,7 +12,12 @@ const ROUTE_PATH = "/api/workflows/callback/runs/[id]/running";
 
 type Params = Promise<{ id: string }>;
 
-/** Engine callback: mark a queued/waiting run as running (it started executing). */
+/**
+ * Engine callback: mark a queued/waiting run as running. May also record the
+ * engine-side execution id (`engineExecutionId`) — the seed's "DG: Running"
+ * node sends n8n's `$execution.id` so the shared error handler can later map a
+ * failed execution back to this run.
+ */
 export async function POST(
   request: NextRequest,
   { params }: { params: Params }
@@ -21,6 +27,10 @@ export async function POST(
       const { id } = await params;
       const { run } = await requireCallbackRun(request, id);
       await markRunning(run.id);
+      const body = await readJsonBody(request);
+      if (typeof body.engineExecutionId === "string" && body.engineExecutionId) {
+        await setEngineRunId(run.id, body.engineExecutionId);
+      }
       return NextResponse.json({
         success: true,
         data: { runId: run.id, status: "running" },

--- a/app/api/workflows/n8n/error-handler/route.ts
+++ b/app/api/workflows/n8n/error-handler/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { withRouteTrace } from "@/lib/core/logger";
+import { requireAuth } from "@/lib/infrastructure/auth/middleware";
+import {
+  ensureN8nErrorHandler,
+  getStoredN8nErrorHandler,
+} from "@/extensions/workflows/server/engines/n8n/error-handler";
+import { handleRouteError } from "@/extensions/workflows/server/http";
+
+const ROUTE_PATH = "/api/workflows/n8n/error-handler";
+
+/** Current DG Error Handler status (no create). */
+export async function GET(request: NextRequest) {
+  return withRouteTrace(request, { route: ROUTE_PATH }, async () => {
+    try {
+      const session = await requireAuth();
+      const handler = await getStoredN8nErrorHandler(session.user.id);
+      return NextResponse.json({
+        success: true,
+        data: { configured: Boolean(handler), ...(handler ?? {}) },
+      });
+    } catch (error) {
+      return handleRouteError(error, "Failed to load error handler status");
+    }
+  });
+}
+
+/** Get-or-create the owner's DG Error Handler (idempotent). */
+export async function POST(request: NextRequest) {
+  return withRouteTrace(request, { route: ROUTE_PATH }, async () => {
+    try {
+      const session = await requireAuth();
+      const result = await ensureN8nErrorHandler(session.user.id);
+      return NextResponse.json({ success: true, data: result });
+    } catch (error) {
+      return handleRouteError(error, "Failed to set up error handler");
+    }
+  });
+}

--- a/extensions/workflows/server/dispatch.ts
+++ b/extensions/workflows/server/dispatch.ts
@@ -13,7 +13,7 @@ import {
   N8N_PAYLOAD_ENGINE,
   readN8nMetadata,
 } from "./engines/n8n/meta";
-import { createRun, finishRun, setEngineRunId } from "./runs";
+import { createRun, finishRun, markRunning, setEngineRunId } from "./runs";
 
 export type DispatchErrorCode =
   | "UNKNOWN_WORKFLOW"
@@ -335,7 +335,15 @@ export async function dispatchWorkflowFromContent(
       engine: definition.engine,
       input: data,
     });
-    return startEngineForRun(definition, run);
+    const result = await startEngineForRun(definition, run);
+    // n8n's webhook returns on receipt; if it accepted the trigger the flow is
+    // executing, so reflect "running" until a callback finishes it. No-op if a
+    // fast flow already fired its finish callback — markRunning only touches
+    // queued/waiting runs.
+    if (!isDispatchFailure(result)) {
+      await markRunning(run.id);
+    }
+    return result;
   }
 
   if (node.workflowPayload.engine !== WDK_INTERPRETER_ENGINE) {

--- a/extensions/workflows/server/engines/n8n/error-handler.ts
+++ b/extensions/workflows/server/engines/n8n/error-handler.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "crypto";
+
+import { logger } from "@/lib/core/logger";
+import { prisma } from "@/lib/database/client";
+import { Prisma } from "@/lib/database/generated/prisma";
+
+import { createServiceTokenRecord } from "../../service-token";
+import {
+  createN8nHeaderAuthCredential,
+  createN8nWorkflow,
+  getN8nWorkflow,
+  isN8nConfigured,
+  n8nBaseUrl,
+} from "./client";
+import type { N8nNode, N8nWorkflow } from "./types";
+
+/**
+ * The shared, per-user "DG Error Handler" n8n workflow: an Error Trigger →
+ * HTTP Request that POSTs the failed execution id to /callback/error. Each n8n
+ * Flow's `settings.errorWorkflow` points at this, so a crashed flow reports its
+ * failure back to DG (which maps the execution id → run → finish(failed)).
+ * The user can open + customize it from DG settings.
+ */
+
+const ERROR_TRIGGER_NAME = "Error Trigger";
+const REPORT_NAME = "DG: Report failure";
+
+export function buildErrorHandlerWorkflow(opts: {
+  callbackBaseUrl: string;
+  credential: { id: string; name: string };
+}): N8nWorkflow {
+  const trigger: N8nNode = {
+    id: randomUUID(),
+    name: ERROR_TRIGGER_NAME,
+    type: "n8n-nodes-base.errorTrigger",
+    typeVersion: 1,
+    position: [0, 0],
+    parameters: {},
+  };
+  const report: N8nNode = {
+    id: randomUUID(),
+    name: REPORT_NAME,
+    type: "n8n-nodes-base.httpRequest",
+    typeVersion: 4.2,
+    position: [280, 0],
+    parameters: {
+      method: "POST",
+      url: `${opts.callbackBaseUrl}/api/workflows/callback/error`,
+      sendBody: true,
+      specifyBody: "json",
+      jsonBody: `={{ ({ "engineExecutionId": String($json.execution?.id ?? ""), "message": String($json.execution?.error?.message ?? "The n8n workflow errored.") }) }}`,
+      authentication: "genericCredentialType",
+      genericAuthType: "httpHeaderAuth",
+    },
+    credentials: {
+      httpHeaderAuth: { id: opts.credential.id, name: opts.credential.name },
+    },
+  };
+  return {
+    name: "DG Error Handler",
+    nodes: [trigger, report],
+    connections: {
+      [ERROR_TRIGGER_NAME]: {
+        main: [[{ node: REPORT_NAME, type: "main", index: 0 }]],
+      },
+    },
+    settings: {},
+  };
+}
+
+interface StoredErrorHandler {
+  workflowId?: string;
+  credentialId?: string;
+}
+
+function readStoredErrorHandler(settings: unknown): StoredErrorHandler {
+  if (settings && typeof settings === "object" && "workflows" in settings) {
+    const workflows = (settings as { workflows?: unknown }).workflows;
+    if (workflows && typeof workflows === "object" && "n8nErrorHandler" in workflows) {
+      const handler = (workflows as { n8nErrorHandler?: unknown }).n8nErrorHandler;
+      if (handler && typeof handler === "object" && !Array.isArray(handler)) {
+        return handler as StoredErrorHandler;
+      }
+    }
+  }
+  return {};
+}
+
+export interface EnsureErrorHandlerResult {
+  workflowId: string;
+  editorUrl: string;
+  created: boolean;
+}
+
+/**
+ * Get-or-create the owner's DG Error Handler workflow (idempotent by the id
+ * stored in User.settings.workflows.n8nErrorHandler). Returns its id + editor
+ * deep-link. Callers set each flow's `settings.errorWorkflow` to this id.
+ */
+export async function ensureN8nErrorHandler(
+  ownerId: string
+): Promise<EnsureErrorHandlerResult> {
+  if (!isN8nConfigured()) {
+    throw new Error("n8n is not configured (set N8N_BASE_URL and N8N_API_KEY).");
+  }
+  const callbackBaseUrl = process.env.WORKFLOWS_CALLBACK_BASE_URL?.replace(/\/+$/, "");
+  if (!callbackBaseUrl) {
+    throw new Error(
+      "WORKFLOWS_CALLBACK_BASE_URL is not set — n8n needs a public URL to call back to."
+    );
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: ownerId },
+    select: { settings: true },
+  });
+  const stored = readStoredErrorHandler(user?.settings);
+  if (stored.workflowId) {
+    const existing = await getN8nWorkflow(stored.workflowId);
+    if (existing) {
+      return {
+        workflowId: stored.workflowId,
+        editorUrl: `${n8nBaseUrl()}/workflow/${stored.workflowId}`,
+        created: false,
+      };
+    }
+    // Stored id no longer exists in n8n — fall through and recreate.
+  }
+
+  const minted = await createServiceTokenRecord(ownerId, {
+    name: "n8n error handler",
+  });
+  const cred = await createN8nHeaderAuthCredential(
+    "DG Callback — Error Handler",
+    minted.token
+  );
+  const wf = await createN8nWorkflow(
+    buildErrorHandlerWorkflow({
+      callbackBaseUrl,
+      credential: { id: cred.id, name: cred.name },
+    })
+  );
+
+  const currentSettings =
+    user?.settings && typeof user.settings === "object" && !Array.isArray(user.settings)
+      ? { ...(user.settings as Record<string, unknown>) }
+      : {};
+  const currentWorkflows =
+    currentSettings.workflows && typeof currentSettings.workflows === "object"
+      ? { ...(currentSettings.workflows as Record<string, unknown>) }
+      : {};
+  currentWorkflows.n8nErrorHandler = {
+    workflowId: wf.id,
+    credentialId: cred.id,
+  };
+  currentSettings.workflows = currentWorkflows;
+
+  await prisma.user.update({
+    where: { id: ownerId },
+    data: { settings: currentSettings as unknown as Prisma.InputJsonValue },
+  });
+
+  logger.info({
+    layer: "route",
+    event: "workflows_n8n:error_handler_created",
+    summary: "created per-user DG error handler",
+    attrs: { ownerId, workflowId: wf.id },
+  });
+
+  return {
+    workflowId: wf.id,
+    editorUrl: `${n8nBaseUrl()}/workflow/${wf.id}`,
+    created: true,
+  };
+}

--- a/extensions/workflows/server/engines/n8n/error-handler.ts
+++ b/extensions/workflows/server/engines/n8n/error-handler.ts
@@ -173,3 +173,19 @@ export async function ensureN8nErrorHandler(
     created: true,
   };
 }
+
+/** Read the stored DG Error Handler (no create), for the settings status view. */
+export async function getStoredN8nErrorHandler(
+  ownerId: string
+): Promise<{ workflowId: string; editorUrl: string } | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: ownerId },
+    select: { settings: true },
+  });
+  const stored = readStoredErrorHandler(user?.settings);
+  if (!stored.workflowId) return null;
+  return {
+    workflowId: stored.workflowId,
+    editorUrl: `${n8nBaseUrl()}/workflow/${stored.workflowId}`,
+  };
+}

--- a/extensions/workflows/server/engines/n8n/native.ts
+++ b/extensions/workflows/server/engines/n8n/native.ts
@@ -13,6 +13,7 @@ import {
   n8nBaseUrl,
   setN8nWorkflowActive,
 } from "./client";
+import { ensureN8nErrorHandler } from "./error-handler";
 import { N8N_ADAPTER_ENGINE, N8N_PAYLOAD_ENGINE } from "./meta";
 import { buildSeedWorkflow } from "./seed";
 
@@ -53,12 +54,26 @@ export async function createNativeN8nFlow(
     minted.token
   );
 
+  // Ensure the per-user DG Error Handler so a crash reports back (best-effort;
+  // a flow can exist without it, just won't auto-fail its run on error).
+  let errorWorkflowId: string | undefined;
+  try {
+    errorWorkflowId = (await ensureN8nErrorHandler(ownerId)).workflowId;
+  } catch (error) {
+    logger.warn({
+      layer: "route",
+      event: "workflows_n8n:ensure_error_handler_failed",
+      summary: error instanceof Error ? error.message : String(error),
+    });
+  }
+
   const webhookPath = randomUUID();
   const seed = buildSeedWorkflow({
     workflowName: title,
     callbackBaseUrl,
     webhookPath,
     credential: { id: cred.id, name: cred.name },
+    errorWorkflowId,
   });
   const wf = await createN8nWorkflow(seed);
   try {

--- a/extensions/workflows/server/engines/n8n/seed.ts
+++ b/extensions/workflows/server/engines/n8n/seed.ts
@@ -4,10 +4,14 @@ import type { N8nNode, N8nWorkflow } from "./types";
 
 /**
  * The starter n8n workflow DG seeds for a native ("n8n Flow") authoring
- * session: a Webhook trigger (so DG can start runs) → a "DG: Finish run" node
- * (so a run always completes back in DG's timeline). The user builds their
- * integration nodes IN BETWEEN, in n8n's own editor. Optional supervision/event
- * callbacks are dropped in from the DG helper-node set.
+ * session:
+ *   Webhook "Trigger" → "DG: Running" → "DG: Finish run"
+ * The Trigger lets DG start runs; "DG: Running" stamps n8n's execution id onto
+ * the DG run (so the error handler can map failures back); "DG: Finish run"
+ * completes the run. The user builds their integration nodes in between, in
+ * n8n's own editor. `settings.errorWorkflow` points at the per-user DG Error
+ * Handler so a crash reports back. NOTE: the callbacks reference `$('Trigger')`
+ * by name — keep the webhook trigger; don't replace it with a manual trigger.
  *
  * Node shapes match the ones validated against live n8n 2.10.2 (see compiler.ts).
  */
@@ -17,13 +21,20 @@ export interface SeedOptions {
   callbackBaseUrl: string;
   webhookPath: string;
   credential: { id: string; name: string };
+  /** Per-user DG Error Handler workflow id → n8n `settings.errorWorkflow`. */
+  errorWorkflowId?: string;
 }
 
 const TRIGGER_NAME = "Trigger";
+const RUNNING_NAME = "DG: Running";
 const FINISH_NAME = "DG: Finish run";
 
 function credentials(opts: SeedOptions) {
   return { httpHeaderAuth: { id: opts.credential.id, name: opts.credential.name } };
+}
+
+function callbackUrl(opts: SeedOptions, action: string): string {
+  return `=${opts.callbackBaseUrl}/api/workflows/callback/runs/{{ $('${TRIGGER_NAME}').item.json.runId }}/${action}`;
 }
 
 export function buildSeedWorkflow(opts: SeedOptions): N8nWorkflow {
@@ -41,15 +52,33 @@ export function buildSeedWorkflow(opts: SeedOptions): N8nWorkflow {
     webhookId: opts.webhookPath,
   };
 
+  const running: N8nNode = {
+    id: randomUUID(),
+    name: RUNNING_NAME,
+    type: "n8n-nodes-base.httpRequest",
+    typeVersion: 4.2,
+    position: [240, 0],
+    parameters: {
+      method: "POST",
+      url: callbackUrl(opts, "running"),
+      sendBody: true,
+      specifyBody: "json",
+      jsonBody: `={{ ({ "engineExecutionId": String($execution.id) }) }}`,
+      authentication: "genericCredentialType",
+      genericAuthType: "httpHeaderAuth",
+    },
+    credentials: credentials(opts),
+  };
+
   const finish: N8nNode = {
     id: randomUUID(),
     name: FINISH_NAME,
     type: "n8n-nodes-base.httpRequest",
     typeVersion: 4.2,
-    position: [480, 0],
+    position: [720, 0],
     parameters: {
       method: "POST",
-      url: `=${opts.callbackBaseUrl}/api/workflows/callback/runs/{{ $('${TRIGGER_NAME}').item.json.runId }}/finish`,
+      url: callbackUrl(opts, "finish"),
       sendBody: true,
       specifyBody: "json",
       jsonBody: `={{ ({ "status": "succeeded", "output": { "outcome": "completed" } }) }}`,
@@ -61,10 +90,13 @@ export function buildSeedWorkflow(opts: SeedOptions): N8nWorkflow {
 
   return {
     name: opts.workflowName,
-    nodes: [trigger, finish],
+    nodes: [trigger, running, finish],
     connections: {
-      [TRIGGER_NAME]: { main: [[{ node: FINISH_NAME, type: "main", index: 0 }]] },
+      [TRIGGER_NAME]: { main: [[{ node: RUNNING_NAME, type: "main", index: 0 }]] },
+      [RUNNING_NAME]: { main: [[{ node: FINISH_NAME, type: "main", index: 0 }]] },
     },
-    settings: {},
+    settings: opts.errorWorkflowId
+      ? { errorWorkflow: opts.errorWorkflowId }
+      : {},
   };
 }

--- a/extensions/workflows/settings/WorkflowErrorHandlingSection.tsx
+++ b/extensions/workflows/settings/WorkflowErrorHandlingSection.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ExternalLink, Loader2, ShieldCheck, Wrench } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/client/ui/button";
+import { SettingSection } from "@/components/settings/ui";
+
+/**
+ * Per-user "Workflow error handling" settings. n8n Flows route crashes to a
+ * shared DG Error Handler workflow (which marks the run failed) — set up /
+ * editable here. Trellis flows fail their run automatically (built-in), shown
+ * for symmetry.
+ */
+export function WorkflowErrorHandlingSection() {
+  const [loading, setLoading] = useState(true);
+  const [handler, setHandler] = useState<{ configured: boolean; editorUrl?: string }>({
+    configured: false,
+  });
+  const [setting, setSetting] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/workflows/n8n/error-handler");
+      const json = await res.json();
+      if (res.ok && json.success) setHandler(json.data);
+    } catch {
+      // leave as not-configured; the Set-up button still works
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleSetup = useCallback(async () => {
+    setSetting(true);
+    try {
+      const res = await fetch("/api/workflows/n8n/error-handler", { method: "POST" });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        throw new Error(json.error?.message || "Failed to set up error handler");
+      }
+      setHandler({ configured: true, editorUrl: json.data.editorUrl });
+      toast.success(json.data.created ? "Error handler created" : "Error handler ready");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to set up error handler"
+      );
+    } finally {
+      setSetting(false);
+    }
+  }, []);
+
+  return (
+    <SettingSection
+      title="Workflow error handling"
+      description="What happens when a workflow run fails."
+    >
+      {/* n8n Flows */}
+      <div className="space-y-3 rounded-lg border border-black/10 p-4 dark:border-white/10">
+        <span className="inline-block rounded-full bg-[#ea4b71]/10 px-2 py-0.5 text-xs font-medium text-[#ea4b71]">
+          n8n Flows
+        </span>
+        <p className="text-sm text-muted-foreground">
+          A shared <strong>DG Error Handler</strong> catches any n8n Flow crash and
+          marks its run <strong>failed</strong> in your inbox. Customize it in
+          n8n if you want to add alerts of your own.
+        </p>
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : handler.configured ? (
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-green-600 dark:text-green-400">
+              <ShieldCheck className="h-3.5 w-3.5" /> Active
+            </span>
+            {handler.editorUrl && (
+              <a
+                href={handler.editorUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-md border border-black/10 px-3 py-1.5 text-xs font-medium transition-colors hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/10"
+              >
+                <ExternalLink className="h-3.5 w-3.5" /> Edit in n8n
+              </a>
+            )}
+          </div>
+        ) : (
+          <Button type="button" size="sm" onClick={handleSetup} disabled={setting}>
+            {setting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Wrench className="h-4 w-4" />
+            )}
+            <span className="ml-1.5">Set up error handler</span>
+          </Button>
+        )}
+      </div>
+
+      {/* Trellis Flows */}
+      <div className="space-y-1.5 rounded-lg border border-black/10 p-4 dark:border-white/10">
+        <span className="inline-block rounded-full bg-primary/15 px-2 py-0.5 text-xs font-medium text-primary">
+          Trellis Flows
+        </span>
+        <p className="text-sm text-muted-foreground">
+          Trellis (the built-in engine) marks a run <strong>failed</strong>{" "}
+          automatically when a step errors — no setup needed. The failure shows in
+          your inbox with the error message.
+        </p>
+      </div>
+    </SettingSection>
+  );
+}

--- a/extensions/workflows/settings/WorkflowsSettingsPage.tsx
+++ b/extensions/workflows/settings/WorkflowsSettingsPage.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/client/ui/button";
 import { Input } from "@/components/client/ui/input";
 import { SettingSection } from "@/components/settings/ui";
 import type { ServiceTokenDto } from "@/extensions/workflows/shared";
+import { WorkflowErrorHandlingSection } from "./WorkflowErrorHandlingSection";
 
 function formatDate(iso: string | null): string {
   if (!iso) return "—";
@@ -278,6 +279,8 @@ export default function WorkflowsSettingsPage() {
           </p>
         )}
       </SettingSection>
+
+      <WorkflowErrorHandlingSection />
     </div>
   );
 }


### PR DESCRIPTION
Continues **Plan 3** (after #104 shipped H1 + the embedded n8n editor): makes DG faithfully **track n8n-flow runs, including failures**, and adds a per-user error-handling settings section. No schema change — the error handler is stored in `User.settings`.

---

## Sprint 1 — Run-loop hardening + n8n failure handling

- **Run state:** n8n dispatch marks a run **"running"** once n8n accepts the webhook (was stuck at "queued"). No-op if a fast flow already finished.
- **Failure handling** (the hard part — correlating an n8n crash back to the DG run):
  - Per-user **"DG Error Handler"** n8n workflow (`Error Trigger → POST /callback/error`), created idempotently, stored in `User.settings.workflows.n8nErrorHandler`; each n8n Flow's `settings.errorWorkflow` points at it.
  - `POST /api/workflows/callback/error` (user-scoped PAT) maps the failed n8n `engineExecutionId` → the owner's run → `finish(failed)`.
  - **Correlation link:** the seed now runs `Trigger → DG: Running → DG: Finish run`; `DG: Running` stamps n8n's `$execution.id` onto the run (the `running` callback records `engineExecutionId`), so the error handler can find it.
- `createNativeN8nFlow` ensures the error handler + wires `errorWorkflow` (best-effort). Error-handler + updated-seed shapes **validated against live n8n 2.10.2**.
- **Gate:** typecheck/lint 151·0/build green; n8n shapes validated live.

## Sprint 2 — Error-handling settings section

- Per-user **"Workflow error handling"** section on the workflows extension settings page: n8n Flows show the DG Error Handler status with a **Set up** / **Edit in n8n** control; Trellis Flows note their built-in auto-fail behavior (symmetry). `GET/POST /api/workflows/n8n/error-handler` (status / get-or-create).
- **Gate:** typecheck/lint/build green.

---

## ⚠️ Before merge / deploy
- [x] **No migration** — the error handler lives in `User.settings` (JSON). Nothing to run.
- [x] Prod env vars already set in #104 (`N8N_BASE_URL`, `N8N_API_KEY`, `WORKFLOWS_CALLBACK_BASE_URL`). No change.

## Pre-merge checklist
**Gates**
- [x] `pnpm typecheck` clean · `pnpm lint` 151·0 · `pnpm build` green (incl. `extensions:check`)
- [x] Error-handler + seed shapes validated against live n8n 2.10.2

**Post-merge (test in prod)**
- [ ] Create an n8n Flow → **Run** it → run appears + **finishes** in the DG inbox/panel
- [ ] A flow that **errors** → run flips to **failed** (via the error handler)
- [ ] Settings → Workflows → "Set up error handler" works + "Edit in n8n" opens it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
