### PR TITLE
fix(workflows): n8n webhook body nesting — runs stranding at "running"

### DIFF
--- a/extensions/workflows/server/engines/n8n/compiler.ts
+++ b/extensions/workflows/server/engines/n8n/compiler.ts
@@ -50,9 +50,10 @@ function buildRefMap(
   triggerId: string
 ): Map<string, OutputRef> {
   const map = new Map<string, OutputRef>();
-  // input.* comes from the trigger webhook body: { runId, input }.
+  // input.* comes from the trigger webhook body: { runId, input }. n8n's Webhook
+  // node nests the POST body under `.body`, so it lives at `$json.body.input`.
   map.set("input", {
-    expr: (rest) => `$('${triggerId}').item.json.input${rest}`,
+    expr: (rest) => `$('${triggerId}').item.json.body.input${rest}`,
   });
   for (const node of graph.nodes) {
     if (node.id === triggerId) continue;
@@ -123,7 +124,8 @@ function callbackUrl(
   triggerId: string,
   action: string
 ): string {
-  return `=${opts.callbackBaseUrl}/api/workflows/callback/runs/{{ $('${triggerId}').item.json.runId }}/${action}`;
+  // Webhook body is nested under `.body` (see buildRefMap); read runId there.
+  return `=${opts.callbackBaseUrl}/api/workflows/callback/runs/{{ $('${triggerId}').item.json.body.runId }}/${action}`;
 }
 
 function httpAuthParams() {

--- a/extensions/workflows/server/engines/n8n/seed.ts
+++ b/extensions/workflows/server/engines/n8n/seed.ts
@@ -34,7 +34,11 @@ function credentials(opts: SeedOptions) {
 }
 
 function callbackUrl(opts: SeedOptions, action: string): string {
-  return `=${opts.callbackBaseUrl}/api/workflows/callback/runs/{{ $('${TRIGGER_NAME}').item.json.runId }}/${action}`;
+  // n8n's Webhook node nests the POST body under `.body`, so the runId DG posts
+  // to the webhook lives at `$json.body.runId` (not `$json.runId`). Reading it
+  // without `.body` yields undefined → the callback URL becomes `/runs//<action>`
+  // → 404 → the run strands at "running".
+  return `=${opts.callbackBaseUrl}/api/workflows/callback/runs/{{ $('${TRIGGER_NAME}').item.json.body.runId }}/${action}`;
 }
 
 export function buildSeedWorkflow(opts: SeedOptions): N8nWorkflow {


### PR DESCRIPTION
## The bug
DG-triggered n8n Flow runs started but **never finished** — stuck at "running" forever.

**Root cause:** n8n's Webhook node nests the incoming POST body under `.body`. DG posts `{ runId, input }` to the flow's webhook, so inside n8n it lands at `$json.body.runId` — but the seed and compiler read `$json.runId`. That resolves to `undefined`, so every callback URL became `…/callback/runs//<action>` (empty run id) → **404**. `DG: Running` errored on the 404, the workflow halted, `DG: Finish run` never fired, and the run stranded at "running". (`markRunning` in dispatch sets "running" on webhook-accept, which is why it *looked* like it started.)

Passed the "does n8n accept this workflow JSON" probe; failed at **runtime data threading** — the gap the earlier live validation didn't cover.

## The fix
The three trigger-body reads now include `.body`:
- `seed.ts` — callback runId → `$('Trigger').item.json.body.runId`
- `compiler.ts` — `input.*` map → `$('trigger').item.json.body.input`
- `compiler.ts` — callback runId → `$('trigger').item.json.body.runId`

**Gate:** `pnpm typecheck` clean · `pnpm lint` 151·0.

## ⚠️ Scope / deploy
- [x] Expressions are baked into the n8n workflow JSON at creation, so this only fixes **newly created** n8n Flows and **newly compiled** Trellis→n8n flows. Existing flows need the same one-token edit in n8n (`.item.json.runId` → `.item.json.body.runId` on the DG callback nodes) or a recreate.
- [x] No migration, no env changes.

## Post-merge smoke
- [ ] Create a fresh n8n Flow → **Run** (DG button) → run goes running → **finished** in the Workflows panel
- [ ] Verify `DG: Running`'s callback in n8n Executions hits `…/runs/<real-id>/running` (non-empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)