### PR TITLE
Plan 3 H3 — seeded DG helper templates (gate / event / artifact) for n8n Flows

### DIFF
--- a/extensions/workflows/server/engines/n8n/seed.ts
+++ b/extensions/workflows/server/engines/n8n/seed.ts
@@ -29,6 +29,23 @@ const TRIGGER_NAME = "Trigger";
 const RUNNING_NAME = "DG: Running";
 const FINISH_NAME = "DG: Finish run";
 
+// Disabled helper templates seeded below the main lane (H3). The user copies
+// them into their flow; they arrive pre-wired with this flow's credential and
+// callback URLs, so supervision works without hand-building HTTP nodes.
+const GATE_OPEN_NAME = "DG: Open gate";
+const GATE_WAIT_NAME = "DG: Wait for approval";
+const EVENT_NAME = "DG: Record event";
+const ARTIFACT_NAME = "DG: Attach artifact";
+
+const HELPER_NOTE = `## DG helper nodes (templates)
+These are **disabled** — copy the ones you need into your flow, connect them, then enable.
+
+- **Open gate → Wait for approval** — pauses the run until you approve it in Digital Garden's inbox. Keep the pair connected in this order. Using several gates in one flow? Give each open-node a unique \`token\`.
+- **Record event** — adds a timeline entry to the DG run (edit \`stepName\`/\`payload\`).
+- **Attach artifact** — links a DG note/file/document to the run (paste its content id; \`kind\` is \`note\`, \`file\`, or \`document\`).
+
+▶ Always run this flow from **Digital Garden's Run button** — the Trigger needs the \`runId\` DG sends. n8n's "Execute workflow" won't have one.`;
+
 function credentials(opts: SeedOptions) {
   return { httpHeaderAuth: { id: opts.credential.id, name: opts.credential.name } };
 }
@@ -94,13 +111,98 @@ export function buildSeedWorkflow(opts: SeedOptions): N8nWorkflow {
 
   return {
     name: opts.workflowName,
-    nodes: [trigger, running, finish],
+    nodes: [trigger, running, finish, ...buildHelperTemplates(opts)],
     connections: {
       [TRIGGER_NAME]: { main: [[{ node: RUNNING_NAME, type: "main", index: 0 }]] },
       [RUNNING_NAME]: { main: [[{ node: FINISH_NAME, type: "main", index: 0 }]] },
+      // Pre-connect the gate pair so copying both nodes carries the edge along.
+      [GATE_OPEN_NAME]: { main: [[{ node: GATE_WAIT_NAME, type: "main", index: 0 }]] },
     },
     settings: opts.errorWorkflowId
       ? { errorWorkflow: opts.errorWorkflowId }
       : {},
   };
+}
+
+/**
+ * The disabled helper templates parked below the main lane: a sticky note
+ * explaining them, the two-node gate pair (openGate callback → Wait(webhook)
+ * suspension; `$execution.resumeUrl` is the engine-side resume handle DG's
+ * approve path POSTs to), a timeline-event node, and an attach-artifact node.
+ * Node shapes mirror the compiler's validated builders (compiler.ts).
+ */
+function buildHelperTemplates(opts: SeedOptions): N8nNode[] {
+  const note: N8nNode = {
+    id: randomUUID(),
+    name: "DG helper nodes",
+    type: "n8n-nodes-base.stickyNote",
+    typeVersion: 1,
+    position: [-40, 240],
+    parameters: { content: HELPER_NOTE, width: 560, height: 340 },
+  };
+  const gateOpen: N8nNode = {
+    id: randomUUID(),
+    name: GATE_OPEN_NAME,
+    type: "n8n-nodes-base.httpRequest",
+    typeVersion: 4.2,
+    position: [0, 640],
+    disabled: true,
+    parameters: {
+      method: "POST",
+      url: callbackUrl(opts, "gate"),
+      sendBody: true,
+      specifyBody: "json",
+      jsonBody: `={{ ({ "token": "gate:approval", "title": "Approval needed", "body": "A step in this flow is waiting for your approval.", "engineGateRef": $execution.resumeUrl }) }}`,
+      authentication: "genericCredentialType",
+      genericAuthType: "httpHeaderAuth",
+    },
+    credentials: credentials(opts),
+  };
+  const gateWait: N8nNode = {
+    id: randomUUID(),
+    name: GATE_WAIT_NAME,
+    type: "n8n-nodes-base.wait",
+    typeVersion: 1.1,
+    position: [260, 640],
+    disabled: true,
+    parameters: { resume: "webhook" },
+    webhookId: randomUUID(),
+  };
+  const event: N8nNode = {
+    id: randomUUID(),
+    name: EVENT_NAME,
+    type: "n8n-nodes-base.httpRequest",
+    typeVersion: 4.2,
+    position: [0, 820],
+    disabled: true,
+    parameters: {
+      method: "POST",
+      url: callbackUrl(opts, "events"),
+      sendBody: true,
+      specifyBody: "json",
+      jsonBody: `={{ ({ "type": "log", "stepName": "My step", "payload": { "message": "Describe what happened" } }) }}`,
+      authentication: "genericCredentialType",
+      genericAuthType: "httpHeaderAuth",
+    },
+    credentials: credentials(opts),
+  };
+  const artifact: N8nNode = {
+    id: randomUUID(),
+    name: ARTIFACT_NAME,
+    type: "n8n-nodes-base.httpRequest",
+    typeVersion: 4.2,
+    position: [260, 820],
+    disabled: true,
+    parameters: {
+      method: "POST",
+      url: callbackUrl(opts, "artifacts"),
+      sendBody: true,
+      specifyBody: "json",
+      jsonBody: `={{ ({ "contentNodeId": "PASTE_CONTENT_NODE_ID", "kind": "note", "label": "Generated note" }) }}`,
+      authentication: "genericCredentialType",
+      genericAuthType: "httpHeaderAuth",
+    },
+    credentials: credentials(opts),
+  };
+  return [note, gateOpen, gateWait, event, artifact];
 }


### PR DESCRIPTION
Continues Plan 3 (after #106 proved the run loop live). **H3 — supervision helpers for native n8n Flows.** The callback surface (gate/events/artifacts) already shipped in S2; what was missing was a way to *use* it while authoring in n8n's editor without hand-building HTTP nodes. Per the delivery decision: **seeded templates** (community node package deliberately not chosen — public npm; a private `~/.n8n/custom` palette package stays a backlog option).

---

## Sprint 1 — Seeded DG helper templates

Every new n8n Flow's seed now parks a template block below the main lane:

- **Sticky note** explaining the helpers + the "run from DG's Run button" rule.
- **`DG: Open gate` → `DG: Wait for approval`** (disabled, pre-connected pair): POSTs `{token, title, body, engineGateRef: $execution.resumeUrl}` to the gate callback, then suspends on a Wait(webhook). Approving in DG's inbox POSTs to the stored resume URL and the flow continues. Copying both nodes carries the edge along.
- **`DG: Record event`** (disabled): appends a `log` timeline entry to the run.
- **`DG: Attach artifact`** (disabled): links a DG note/file/document to the run by content id.

All helpers arrive pre-wired with the flow's own callback credential and correct `.body.runId` URLs (post-#106 shape). Node shapes mirror the compiler's validated gate builders.

**Gate:** typecheck clean · lint 151·0 · build green · **live probe vs n8n 2.10.2**: create → read-back (sticky kept, 4 disabled helpers kept, gate edge kept) → delete ✅

---

## ⚠️ Before testing gates (required, one-time)
- [x] **Set `WEBHOOK_URL=https://n8n.notetrellis.com/` on the n8n service in Coolify + restart.** n8n builds `$execution.resumeUrl` (the gate's resume handle DG POSTs to on approval) from `WEBHOOK_URL`. At its sslip.io default, every gate stores an **unreachable** resume URL and inbox approval fails. DG's Run button is unaffected (uses `N8N_BASE_URL`).
- [x] No migration, no app env changes. Existing flows don't get the templates (seed runs at creation) — create a fresh flow to see them.

## Pre-merge checklist
**Gates**
- [x] `pnpm typecheck` clean · `pnpm lint` 151·0 · `pnpm build` green
- [x] Live probe against n8n 2.10.2 (create/read-back/delete) ✅

**Post-merge smoke (in prod)**
- [ ] Coolify: `WEBHOOK_URL` set + n8n restarted (see above)
- [ ] New n8n Flow → sticky note + 4 disabled helpers appear below the lane
- [ ] Copy gate pair between `DG: Running` and `DG: Finish run`, enable, **Run** → run goes **waiting** + inbox item appears
- [ ] Approve in inbox → n8n Wait resumes → run **finished**
- [ ] `DG: Record event` → entry shows on the run timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
