### PR TITLE
fix(workflows): n8n gate resume — Wait node method, app-side gate close, approve error triage

### DIFF
--- a/extensions/workflows/components/notification-renderers.tsx
+++ b/extensions/workflows/components/notification-renderers.tsx
@@ -46,8 +46,25 @@ function GateActions({ notification }: { notification: NotificationDTO }) {
         body: JSON.stringify({ token: gateToken, payload: { approved: true } }),
       });
       if (!response.ok) {
-        // Already-resumed gates return 409 — treat as informative, not scary.
-        toast.info("This gate is no longer waiting.");
+        // Only an already-resumed gate (409 GATE_MISMATCH) is informative;
+        // anything else is a real failure and must surface as one.
+        if (response.status === 409) {
+          toast.info("This gate is no longer waiting.");
+          return;
+        }
+        let message = "Failed to approve.";
+        try {
+          const json: unknown = await response.json();
+          if (json && typeof json === "object" && "error" in json) {
+            const err = (json as { error?: { message?: unknown } }).error;
+            if (err && typeof err.message === "string" && err.message) {
+              message = err.message;
+            }
+          }
+        } catch {
+          // keep the generic message
+        }
+        toast.error(message);
         return;
       }
       toast.success("Approved — workflow resuming");

--- a/extensions/workflows/server/engines/n8n/adapter.ts
+++ b/extensions/workflows/server/engines/n8n/adapter.ts
@@ -1,5 +1,6 @@
 import { logger } from "@/lib/core/logger";
 
+import { closeGate } from "../../runs";
 import type { WorkflowEngineAdapter } from "../types";
 import { n8nBaseUrl, postToN8nUrl } from "./client";
 
@@ -43,7 +44,7 @@ export const n8nEngineAdapter: WorkflowEngineAdapter = {
     return { engineRunId: null };
   },
 
-  async resumeGate(run, _token, payload) {
+  async resumeGate(run, token, payload) {
     if (!run.engineGateRef) {
       throw new Error("No engine resume handle stored for this gate.");
     }
@@ -53,6 +54,11 @@ export const n8nEngineAdapter: WorkflowEngineAdapter = {
         `n8n resume returned ${status}: ${text.slice(0, 200)}`
       );
     }
+    // n8n accepted the resume — close the gate app-side (waiting → running)
+    // now, mirroring the WDK path (wdk/gate.ts). Without this the run shows
+    // "waiting" until the finish callback, however long the rest of the flow
+    // takes, and a second approve click double-posts to a dead resume URL.
+    await closeGate(run.id, token, payload);
   },
 
   async cancel(run) {

--- a/extensions/workflows/server/engines/n8n/compiler.ts
+++ b/extensions/workflows/server/engines/n8n/compiler.ts
@@ -218,7 +218,9 @@ function buildGateNodes(
     name: node.id,
     ...N8N_TYPES.wait,
     position: nextPosition(),
-    parameters: { resume: "webhook" },
+    // httpMethod MUST be POST — the Wait resume webhook defaults to GET, and
+    // DG's approve path POSTs the payload (method mismatch = rejected resume).
+    parameters: { resume: "webhook", httpMethod: "POST" },
     webhookId: randomUUID(),
   };
   return { open, wait };

--- a/extensions/workflows/server/engines/n8n/seed.ts
+++ b/extensions/workflows/server/engines/n8n/seed.ts
@@ -165,7 +165,11 @@ function buildHelperTemplates(opts: SeedOptions): N8nNode[] {
     typeVersion: 1.1,
     position: [260, 640],
     disabled: true,
-    parameters: { resume: "webhook" },
+    // httpMethod MUST be POST: the Wait node registers its resume webhook for
+    // GET by default, but DG's approve path (adapter.resumeGate) POSTs the
+    // approval payload — a GET-only registration 404s ("no waiting webhook
+    // with a matching path/method") and the approve surfaces as a 502.
+    parameters: { resume: "webhook", httpMethod: "POST" },
     webhookId: randomUUID(),
   };
   const event: N8nNode = {


### PR DESCRIPTION
## The bug (found in the live H3 gate smoke test)
Approving a gate failed on both surfaces: workflows panel → **502**, notifications → **"This gate is no longer waiting"** (while the run was demonstrably waiting). n8n's log had the root cause verbatim:

```
Error in handling webhook request POST /webhook-waiting/17:
The workflow for execution "17" does not contain a waiting webhook with a matching path/method.
```

The Wait node's resume webhook **defaults to GET**; DG's approve path POSTs the approval payload. Method mismatch → n8n rejects → adapter throws → resume route returns 502 ENGINE_ERROR. The notification renderer then mislabeled every non-OK response as "already resumed" — same failure, two different lies. (Everything upstream worked: `engineGateRef` stored the correct `https://n8n.notetrellis.com/webhook-waiting/17` post-WEBHOOK_URL fix, and the POST traversed the tunnel.)

## Sprint 1 — Gate resume fixes
- **seed.ts + compiler.ts** — `Wait(resume: webhook)` nodes now set `httpMethod: "POST"`. Live-probed vs n8n 2.10.2: param round-trips intact.
- **adapter.ts** — `resumeGate` now calls `closeGate` after n8n accepts (mirrors `wdk/gate.ts`): run flips waiting → running immediately instead of staying "waiting" until the finish callback; kills the double-approve → dead-resume-URL window.
- **notification-renderers.tsx** — only 409 shows "no longer waiting"; other failures surface the server's error message.
- **Gate:** typecheck clean · lint 151·0 · build green · live probe ✅

## ⚠️ Scope
- [x] Wait-node method is baked into existing n8n workflow JSON — **flows created before this deploy** need the copied Wait node edited in n8n (open `DG: Wait for approval` → HTTP Method → **POST**) or the flow recreated.
- [x] No migration, no env changes.

## Post-merge smoke (prod)
- [ ] Fresh n8n Flow → copy gate pair into lane, enable, save, **Run** → run **waiting** + inbox approval appears
- [ ] **Approve** (either surface) → run flips to **running** then **finished**; n8n execution completes
- [ ] Second approve attempt after resolution → informative "no longer waiting", not an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)