### PR TITLE
Plan 3 H4 — delete lifecycle: n8n teardown, workflow zombie tabs, undeletable workflows

### DIFF
--- a/app/api/content/content/[id]/route.ts
+++ b/app/api/content/content/[id]/route.ts
@@ -1498,11 +1498,26 @@ export async function DELETE(
               },
             }),
 
-            // Create trash bin entry
-            prisma.trashBin.create({
-              data: {
+            // Trash bin entry — upsert, not create: contentId is unique and a
+            // delete→restore→delete cycle used to leave the old row behind,
+            // making every re-delete 500 on the constraint ("undeletable"
+            // content whose delete silently did nothing).
+            prisma.trashBin.upsert({
+              where: { contentId: id },
+              create: {
                 contentId: id,
                 deletedBy: session.user.id,
+                scheduledDeletion,
+                contentSnapshot: {
+                  title: existing.title,
+                  slug: existing.slug,
+                  parentId: existing.parentId,
+                  hasChildren: existing.children.length > 0,
+                },
+              },
+              update: {
+                deletedBy: session.user.id,
+                deletedAt: now,
                 scheduledDeletion,
                 contentSnapshot: {
                   title: existing.title,
@@ -1520,6 +1535,46 @@ export async function DELETE(
       // instead of returning a stale cached copy. The setCachedContent
       // guard for deletedAt prevents re-population from in-flight reads.
       invalidateCachedContent(id);
+
+      // Scrub the node from every workspace's saved pane state + assignments.
+      // Stored paneState isn't touched by the soft delete, so without this the
+      // workspace snapshot restore resurrects the deleted node's tab in the
+      // main panel (and the tab renders as if the content were never deleted).
+      try {
+        const { removeContentFromWorkspaces } = await import(
+          "@/extensions/workplaces/server/service"
+        );
+        await removeContentFromWorkspaces(session.user.id, id);
+      } catch (error) {
+        logger.warn({
+          layer: "route",
+          event: "content.delete.workspace_scrub_failed",
+          summary: `failed to scrub ${id} from workspaces`,
+          attrs: { content_id: id },
+          error,
+        });
+      }
+
+      // n8n Flows own an engine-side workflow whose production webhook stays
+      // live otherwise. Trash = deactivate (restore reactivates; purge tears
+      // down fully in lib/features/trash). Best-effort — n8n being down must
+      // not block the delete.
+      if (existing.contentType === "workflow") {
+        try {
+          const { deactivateN8nFlowForContent } = await import(
+            "@/extensions/workflows/server/engines/n8n/teardown"
+          );
+          await deactivateN8nFlowForContent(id);
+        } catch (error) {
+          logger.warn({
+            layer: "route",
+            event: "content.delete.n8n_deactivate_failed",
+            summary: `failed to deactivate n8n workflow for ${id}`,
+            attrs: { content_id: id },
+            error,
+          });
+        }
+      }
 
       // Chat nodes are Conversation-backed (ContentNode = shell,
       // Conversation = live data). Deleting the node deletes the chat, so

--- a/extensions/workflows/server/engines/n8n/native.ts
+++ b/extensions/workflows/server/engines/n8n/native.ts
@@ -116,6 +116,8 @@ export async function createNativeN8nFlow(
               webhookPath,
               credentialId: cred.id,
               credentialName: cred.name,
+              // Recorded so purge-time teardown can revoke the callback token.
+              serviceTokenId: minted.record.id,
               mode: "native",
             },
           } as unknown as Prisma.InputJsonValue,

--- a/extensions/workflows/server/engines/n8n/teardown.ts
+++ b/extensions/workflows/server/engines/n8n/teardown.ts
@@ -1,0 +1,123 @@
+import { logger } from "@/lib/core/logger";
+import { prisma } from "@/lib/database/client";
+
+import { revokeServiceToken } from "../../service-token";
+import {
+  deleteN8nCredential,
+  deleteN8nWorkflow,
+  isN8nConfigured,
+  setN8nWorkflowActive,
+} from "./client";
+
+/**
+ * Engine-side lifecycle for n8n Flows, keyed off the DG content lifecycle:
+ *   trash (soft delete) → deactivate the n8n workflow (webhook stops firing)
+ *   restore from trash  → reactivate it
+ *   purge (hard delete) → delete the n8n workflow + callback credential,
+ *                         revoke the flow's service token, and drop the
+ *                         WorkflowDefinition (cascades that flow's runs).
+ *
+ * Every operation is best-effort: an unreachable n8n must never block a
+ * delete/restore/purge. Failures are logged and swallowed.
+ */
+
+interface N8nFlowMeta {
+  workflowId?: string;
+  credentialId?: string;
+  serviceTokenId?: string;
+  mode?: string;
+}
+
+/** Read `metadata.n8n` off the flow's WorkflowPayload (null for non-n8n flows). */
+async function loadN8nMeta(contentId: string): Promise<N8nFlowMeta | null> {
+  const payload = await prisma.workflowPayload.findUnique({
+    where: { contentId },
+    select: { metadata: true },
+  });
+  const metadata = payload?.metadata;
+  if (metadata && typeof metadata === "object" && "n8n" in metadata) {
+    const n8n = (metadata as { n8n?: unknown }).n8n;
+    if (n8n && typeof n8n === "object" && !Array.isArray(n8n)) {
+      return n8n as N8nFlowMeta;
+    }
+  }
+  return null;
+}
+
+function warn(event: string, contentId: string, error: unknown) {
+  logger.warn({
+    layer: "route",
+    event: `workflows_n8n:${event}`,
+    summary: error instanceof Error ? error.message : String(error),
+    attrs: { contentId },
+  });
+}
+
+/** Trash: stop the production webhook so a trashed flow can't be dispatched engine-side. */
+export async function deactivateN8nFlowForContent(contentId: string): Promise<void> {
+  if (!isN8nConfigured()) return;
+  const meta = await loadN8nMeta(contentId);
+  if (!meta?.workflowId) return;
+  try {
+    await setN8nWorkflowActive(meta.workflowId, false);
+  } catch (error) {
+    warn("trash_deactivate_failed", contentId, error);
+  }
+}
+
+/** Restore: bring the production webhook back so the restored flow runs again. */
+export async function reactivateN8nFlowForContent(contentId: string): Promise<void> {
+  if (!isN8nConfigured()) return;
+  const meta = await loadN8nMeta(contentId);
+  if (!meta?.workflowId) return;
+  try {
+    await setN8nWorkflowActive(meta.workflowId, true);
+  } catch (error) {
+    warn("restore_reactivate_failed", contentId, error);
+  }
+}
+
+/**
+ * Purge: full engine-side teardown. MUST run BEFORE the ContentNode hard
+ * delete — the WorkflowPayload row (and its n8n ids) cascades away with it.
+ */
+export async function teardownN8nFlowForContent(
+  contentId: string,
+  ownerId: string
+): Promise<void> {
+  const meta = await loadN8nMeta(contentId);
+
+  if (meta && isN8nConfigured()) {
+    if (meta.workflowId) {
+      try {
+        await deleteN8nWorkflow(meta.workflowId);
+      } catch (error) {
+        warn("purge_workflow_delete_failed", contentId, error);
+      }
+    }
+    if (meta.credentialId) {
+      try {
+        await deleteN8nCredential(meta.credentialId);
+      } catch (error) {
+        warn("purge_credential_delete_failed", contentId, error);
+      }
+    }
+  }
+  if (meta?.serviceTokenId) {
+    try {
+      await revokeServiceToken(ownerId, meta.serviceTokenId);
+    } catch (error) {
+      warn("purge_token_revoke_failed", contentId, error);
+    }
+  }
+
+  // Drop the dispatch definition (cascades this flow's runs) so the workflows
+  // panel stops listing a flow that no longer exists anywhere.
+  try {
+    await prisma.workflowDefinition.deleteMany({
+      where: { ownerId, slug: `content:${contentId}` },
+    });
+  } catch (error) {
+    warn("purge_definition_delete_failed", contentId, error);
+  }
+}

--- a/extensions/workplaces/server/service.ts
+++ b/extensions/workplaces/server/service.ts
@@ -792,6 +792,41 @@ export async function saveWorkspaceState(
   return formatWorkspace(updatedWorkspace);
 }
 
+/**
+ * Scrub a content id out of every workspace the owner has — pane tabs
+ * (paneState JSON) and assignment items. Called on content delete: without
+ * this, the deleted node lingers in stored pane state and the workspace
+ * restore/snapshot sync resurrects its tab in the main panel.
+ */
+export async function removeContentFromWorkspaces(
+  ownerId: string,
+  contentId: string,
+) {
+  await prisma.contentWorkspaceItem.deleteMany({
+    where: { contentId, workspace: { ownerId } },
+  });
+
+  const workspaces = await prisma.contentWorkspace.findMany({
+    where: { ownerId },
+    select: { id: true, paneState: true },
+  });
+  for (const workspace of workspaces) {
+    const state = normalizeWorkspaceStatePayload(workspace.paneState);
+    const ids = getStateContentIds(state);
+    if (!ids.includes(contentId)) continue;
+    const allowed = new Set(ids.filter((id) => id !== contentId));
+    const filtered = filterWorkspaceStateToContentIds(state, allowed);
+    await prisma.contentWorkspace.update({
+      where: { id: workspace.id },
+      data: {
+        layoutMode: filtered.layoutMode,
+        activePaneId: filtered.activePaneId,
+        paneState: filtered as unknown as Prisma.InputJsonValue,
+      },
+    });
+  }
+}
+
 async function getAncestorIds(ownerId: string, contentId: string) {
   const ancestors: string[] = [];
   let current = await prisma.contentNode.findFirst({

--- a/lib/features/trash/service.ts
+++ b/lib/features/trash/service.ts
@@ -88,11 +88,28 @@ export async function restoreTrashItem(
     });
     return count > 0;
   }
-  const { count } = await prisma.contentNode.updateMany({
+  const node = await prisma.contentNode.findFirst({
     where: { id, ownerId: userId, deletedAt: { not: null } },
-    data: { deletedAt: null, deletedBy: null },
+    select: { id: true, contentType: true },
   });
-  return count > 0;
+  if (!node) return false;
+  await prisma.$transaction([
+    prisma.contentNode.update({
+      where: { id },
+      data: { deletedAt: null, deletedBy: null },
+    }),
+    // Clear the trash entry — contentId is unique on TrashBin, and a leftover
+    // row made every future delete of a restored node 500 on the constraint.
+    prisma.trashBin.deleteMany({ where: { contentId: id } }),
+  ]);
+  if (node.contentType === "workflow") {
+    // n8n Flows were deactivated engine-side on trash; bring the webhook back.
+    const { reactivateN8nFlowForContent } = await import(
+      "@/extensions/workflows/server/engines/n8n/teardown"
+    );
+    await reactivateN8nFlowForContent(id).catch(() => undefined);
+  }
+  return true;
 }
 
 /** Permanently delete a single soft-deleted item now. Ownership-gated. */
@@ -113,9 +130,18 @@ export async function purgeTrashItem(
   }
   const node = await prisma.contentNode.findFirst({
     where: { id, ownerId: userId, deletedAt: { not: null } },
-    select: { id: true },
+    select: { id: true, contentType: true },
   });
   if (!node) return false;
+  if (node.contentType === "workflow") {
+    // Engine teardown must read the WorkflowPayload (n8n ids) BEFORE the row
+    // delete cascades it away: delete n8n workflow + credential, revoke the
+    // callback token, drop the WorkflowDefinition (cascades its runs).
+    const { teardownN8nFlowForContent } = await import(
+      "@/extensions/workflows/server/engines/n8n/teardown"
+    );
+    await teardownN8nFlowForContent(id, userId).catch(() => undefined);
+  }
   await prisma.contentNode.delete({ where: { id } });
   return true;
 }
@@ -155,10 +181,32 @@ export async function purgeExpiredTrash(): Promise<{
   const expiredContentNodes = await prisma.contentNode.findMany({
     where: { deletedAt: { lt: cutoff } },
     select: {
+      id: true,
       ownerId: true,
+      contentType: true,
       filePayload: { select: { storageKey: true } },
     },
   });
+
+  // n8n Flows: tear down the engine side (n8n workflow + credential, callback
+  // token, WorkflowDefinition) BEFORE the row delete cascades the
+  // WorkflowPayload that holds the n8n ids — mirrors the blob cleanup below.
+  for (const node of expiredContentNodes) {
+    if (node.contentType !== "workflow") continue;
+    try {
+      const { teardownN8nFlowForContent } = await import(
+        "@/extensions/workflows/server/engines/n8n/teardown"
+      );
+      await teardownN8nFlowForContent(node.id, node.ownerId);
+    } catch (error) {
+      logger.warn({
+        layer: "route",
+        event: "trash.purge.workflow_teardown_failed",
+        summary: `failed n8n teardown for expired flow ${node.id}`,
+        error,
+      });
+    }
+  }
   // Resolve each owner's provider once, then drop their blobs.
   const keysByOwner = new Map<string, string[]>();
   for (const node of expiredContentNodes) {


### PR DESCRIPTION
Plan 3 **H4 — the delete lifecycle**. Fixes the two reported bugs — n8n Flows that "restore after delete" and tabs that spontaneously reappear in the main panel — and completes engine-side teardown so deleting a flow actually deletes it everywhere.

## What was actually happening (three independent bugs)

1. **Zombie tabs / "restored" flows** — soft delete only stamps `deletedAt` on the ContentNode. The open-tab set lives in `ContentWorkspace.paneState` JSON (plus `ContentWorkspaceItem` rows), which nothing scrubbed — so the workspace snapshot restore re-added the deleted flow's tab, and since GET-by-id serves soft-deleted content, the tab rendered a fully live-looking flow (n8n iframe and all). Nothing was "restoring"; three systems never learned about the delete.
2. **Undeletable content** — `TrashBin.contentId` is `@unique`, the DELETE route did `trashBin.create`, and restore never removed the row. Any delete→restore→delete cycle hit the unique constraint → the whole soft-delete transaction 500'd → "deleting doesn't do anything." Affects **all content types**, not just workflows.
3. **No engine teardown** — the n8n workflow, its callback credential, its service token, and the WorkflowDefinition all outlived the flow forever.

## Sprint 1 — Delete/restore/purge lifecycle

- **Workspace scrub on delete** (`removeContentFromWorkspaces` in the workplaces service, called from the content DELETE route): removes the id from every workspace's `paneState` panes + assignment items. Kills tab resurrection for **every** content type.
- **Idempotent trash entry**: `trashBin.create` → `upsert`; restore now deletes the TrashBin row in the same transaction. Both directions of bug 2 fixed (and legacy stuck rows self-heal on the next delete).
- **n8n engine lifecycle** (`engines/n8n/teardown.ts`, all best-effort — n8n being down never blocks a delete):
  - **Trash** → deactivate the n8n workflow (production webhook stops).
  - **Restore** → reactivate it.
  - **Purge** (manual + 30-day cron) → delete the n8n workflow + callback credential, revoke the flow's service token, drop the WorkflowDefinition (cascades its runs). Runs **before** the row delete cascades the WorkflowPayload holding the n8n ids — mirrors the existing file-blob pattern.
- New flows record `serviceTokenId` in payload metadata so purge can revoke the callback token (pre-existing flows: token outlives purge; revoke manually in settings if desired).

**Gate:** typecheck clean · lint 151·0 · build green.

## ⚠️ Scope
- [x] No migration, no env changes.
- [x] Flows deleted **before** this deploy: their n8n workflows/credentials still linger in n8n — purge them from DG trash (teardown runs then), or delete manually in n8n once.
- [x] Dispatch already refuses trashed flows (`deletedAt` guard existed).

## Post-merge smoke (prod)
- [ ] Delete an n8n Flow → gone from tree; its tab does NOT reappear (check after reload + workspace switch); n8n shows the workflow **inactive**
- [ ] Restore it from trash → back in tree, n8n workflow **active** again, Run works
- [ ] Delete → purge from trash → n8n workflow + credential **gone in n8n**; workflows panel no longer lists it
- [ ] Delete→restore→delete a plain note (regression check on the TrashBin upsert)
- [ ] Parity soak: capture → AI → Slack flow end-to-end (last P3 item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
