### PR TITLE
Browser Reach B1 — side panel mini-DG shell, Recents, freezable overlays, and two collaboration fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,9 @@ All stores in `state/`. Pattern: `create<T>()(persist((set, get) => ({...}), { n
 
 ### Collaboration Architecture
 
-**Transport:** Hocuspocus server hosted on Google Cloud Run (not local). Do not check port 1234 or suggest `pnpm dev:collab` for production testing.
+**Transport:** Hocuspocus runs on Google Cloud Run in **production**. **Local dev now REQUIRES a local Hocuspocus** (`pnpm dev:collab`, ws://localhost:1234) — the dev database moved to local Docker Postgres, and the hosted server authorizes documents against Neon, so it cannot see locally-created content (symptom: "Live collaboration authentication could not be completed" on every note). Run `pnpm dev:collab` **from the same checkout as the dev server** (it loads that directory's `.env.local` and TipTap schema), and set `NEXT_PUBLIC_HOCUSPOCUS_URL=ws://localhost:1234` — never `0.0.0.0` (a bind address; browsers can't connect to it).
+
+**Deploying Hocuspocus:** `gcloud builds submit --config cloudbuild.hocuspocus.yaml .` ships **the current working directory**. With multiple worktrees at different commits, always deploy from a checkout at `origin/main` — verify with `git rev-list --count HEAD..origin/main` returning `0` first. Note `uptimeMs` from `/readyz` measures time since the last cold start (`min-instances=0`), **not** time since deploy — never infer staleness from it; use `gcloud builds list` instead.
 
 **Y.js document storage:** `CollaborationDocument` Prisma table stores binary `ydocState`. On load, the server bootstraps from TipTap JSON if no Y.js state exists. Presence (awareness) state is persisted to Postgres to handle Vercel serverless split.
 

--- a/app/embed/content/[id]/EmbedContentClient.tsx
+++ b/app/embed/content/[id]/EmbedContentClient.tsx
@@ -89,7 +89,12 @@ export function EmbedContentClient({
     return unsub;
   }, []);
 
-  // Listen for `open` messages from the parent overlay
+  // Listen for `open` messages from the parent overlay.
+  // NOTE (C2): origin cannot be allowlisted here — the overlay runs in the
+  // host page's context, so legitimate messages arrive from ANY site the
+  // user browses. Hardening this path needs a handshake nonce minted by the
+  // extension and echoed in messages (BROWSER-REACH B2/B3), not an origin
+  // check. The panel path (/embed/panel) IS strictly origin-validated.
   useEffect(() => {
     function handleMessage(event: MessageEvent) {
       if (!event.data || typeof event.data !== "object") return;

--- a/app/embed/layout.tsx
+++ b/app/embed/layout.tsx
@@ -129,7 +129,12 @@ export default async function EmbedLayout({
         inset: 0,
         display: "flex",
         flexDirection: "column",
-        background: "var(--surface-primary, #0d0d0d)",
+        // `--surface-primary` is not a token this app defines, so this always
+        // fell through to the hard-coded dark value — light-theme surfaces
+        // then composited their translucent backgrounds over near-black and
+        // came out muddy/low-contrast. `--background` is the real themed
+        // token and follows the resolved theme.
+        background: "var(--background, #0d0d0d)",
         overflow: "hidden",
         zIndex: 100,
       }}

--- a/app/embed/panel/PanelShellClient.tsx
+++ b/app/embed/panel/PanelShellClient.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { DndWrapper } from "@/components/content/DndWrapper";
+import { LeftSidebar } from "@/components/content/LeftSidebar";
+import { MainPanelWorkspace } from "@/components/content/MainPanelWorkspace";
+import { MultiConversationSidebar } from "@/components/content/ai/MultiConversationSidebar";
+import { useContentStore, TOP_LEFT_PANE_ID } from "@/state/content-store";
+import { useRightPanelCollapseStore } from "@/state/right-panel-collapse-store";
+import { useExtensionShellNavigationControls } from "@/lib/extensions/client-registry";
+import { isAllowedEmbedMessageOrigin } from "@/lib/domain/browser-extension/embed-message-origins";
+import { createElement } from "react";
+
+const TREE_COLLAPSED_KEY = "dg-panel-tree-collapsed";
+
+/**
+ * Mini-DG shell for the extension side panel (BROWSER-REACH B1).
+ *
+ * Two views over one persistent mount (display-toggled so state survives):
+ *   Garden — file tree stacked over the tabbed content workspace. Single-click
+ *            in the tree opens content as a workspace tab (decision #12's
+ *            default dispatch comes free from the app's normal behavior).
+ *   Chat   — the app chat surface (transient in B1; conversation binding and
+ *            target-chip work arrive with the core-plan surfaces).
+ *
+ * postMessage protocol (versioned envelope, C2):
+ *   in  ← {v:1, source:"dg-panel-host", type:"page-context", payload:{url,title,faviconUrl}}
+ *   out → {v:1, source:"dg-panel-embed", type:"ready"}
+ * Incoming messages are dropped unless their origin passes
+ * isAllowedEmbedMessageOrigin (exact chrome-extension origin allowlist).
+ */
+
+interface PanelPageContext {
+  url: string;
+  title: string;
+  faviconUrl?: string;
+}
+
+type PanelView = "garden" | "chat";
+
+export function PanelShellClient() {
+  const [view, setView] = useState<PanelView>("garden");
+  const [pageContext, setPageContext] = useState<PanelPageContext | null>(null);
+  const [treeCollapsed, setTreeCollapsed] = useState(false);
+  const setRightCollapsed = useRightPanelCollapseStore((s) => s.setCollapsed);
+  const layoutMode = useContentStore((s) => s.layoutMode);
+  const setLayoutMode = useContentStore((s) => s.setLayoutMode);
+  // Shell-slot navigation controls (the workspace chooser lives here) —
+  // rendered above the file tree per owner direction; the full navigation
+  // bar (back/forward, pane layout) is suppressed in the panel.
+  const shellNavigationControls = useExtensionShellNavigationControls();
+  const selectedContentId = useContentStore((s) => s.selectedContentId);
+
+  // The panel has no room for the right sidebar; keep it collapsed.
+  useEffect(() => {
+    setRightCollapsed(true);
+  }, [setRightCollapsed]);
+
+  // Single-pane by necessity at panel width. Enforced silently through the
+  // store's own setLayoutMode (which reflows tabs into one pane), so nothing
+  // app-side is overridden — the panel context just never leaves "single".
+  useEffect(() => {
+    if (layoutMode !== "single") setLayoutMode("single");
+  }, [layoutMode, setLayoutMode]);
+
+  // Tree collapse preference persists per embed context.
+  useEffect(() => {
+    try {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time localStorage hydration
+      setTreeCollapsed(localStorage.getItem(TREE_COLLAPSED_KEY) === "true");
+    } catch {
+      // Storage unavailable (partitioned iframe edge cases) — default open.
+    }
+  }, []);
+
+  function toggleTreeCollapsed() {
+    setTreeCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(TREE_COLLAPSED_KEY, String(next));
+      } catch {
+        // Non-fatal.
+      }
+      return next;
+    });
+  }
+
+  // C2-hardened message listener: exact-origin validation, versioned envelope.
+  useEffect(() => {
+    function handleMessage(event: MessageEvent) {
+      if (!isAllowedEmbedMessageOrigin(event.origin)) return;
+      const data = event.data;
+      if (!data || typeof data !== "object") return;
+      if (data.v !== 1 || data.source !== "dg-panel-host") return;
+
+      if (data.type === "page-context" && data.payload?.url) {
+        setPageContext({
+          url: String(data.payload.url),
+          title: String(data.payload.title ?? ""),
+          faviconUrl: data.payload.faviconUrl
+            ? String(data.payload.faviconUrl)
+            : undefined,
+        });
+      }
+    }
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
+
+  // Announce readiness to the panel host (extension page). The host validates
+  // our origin on its side; the envelope is versioned from day one.
+  useEffect(() => {
+    window.parent.postMessage(
+      { v: 1, source: "dg-panel-embed", type: "ready" },
+      "*"
+    );
+  }, []);
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Slim view switcher — app chrome, not extension chrome */}
+      <div
+        role="tablist"
+        aria-label="Panel view"
+        style={{
+          display: "flex",
+          gap: 4,
+          padding: "6px 8px",
+          borderBottom: "1px solid var(--border-primary, #2a2a2a)",
+          flexShrink: 0,
+        }}
+      >
+        {(
+          [
+            ["garden", "Garden"],
+            ["chat", "Chat"],
+          ] as const
+        ).map(([key, label]) => (
+          <button
+            key={key}
+            role="tab"
+            aria-selected={view === key}
+            onClick={() => setView(key)}
+            style={{
+              flex: 1,
+              padding: "4px 10px",
+              fontSize: 12,
+              borderRadius: 6,
+              border: "1px solid transparent",
+              cursor: "pointer",
+              background:
+                view === key
+                  ? "var(--surface-secondary, #1e1e1e)"
+                  : "transparent",
+              color:
+                view === key
+                  ? "var(--text-primary, #f5f5f5)"
+                  : "var(--text-secondary, #9a9a9a)",
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Garden view: tree over tabbed workspace. Kept mounted when hidden. */}
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          display: view === "garden" ? "flex" : "none",
+          flexDirection: "column",
+        }}
+      >
+        <DndWrapper>
+          {/* Slim collapse bar — reclaims the tree's space for notes. */}
+          <button
+            type="button"
+            onClick={toggleTreeCollapsed}
+            aria-expanded={!treeCollapsed}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "3px 10px",
+              fontSize: 11,
+              border: 0,
+              borderBottom: "1px solid var(--border-primary, #2a2a2a)",
+              background: "transparent",
+              color: "var(--text-secondary, #9a9a9a)",
+              cursor: "pointer",
+              flexShrink: 0,
+            }}
+          >
+            <span
+              style={{
+                display: "inline-block",
+                transition: "transform 0.15s",
+                transform: treeCollapsed ? "rotate(-90deg)" : "none",
+              }}
+            >
+              ▾
+            </span>
+            Files
+          </button>
+          {/* No overflow:auto here — LeftSidebar's virtualized tree owns its
+              scrolling and needs a bounded flex box (minHeight:0), not a
+              scrollable ancestor competing with it. */}
+          <div
+            style={{
+              flexBasis: "42%",
+              minHeight: treeCollapsed ? 0 : 120,
+              display: treeCollapsed ? "none" : "flex",
+              flexDirection: "column",
+              overflow: "hidden",
+              borderBottom: "1px solid var(--border-primary, #2a2a2a)",
+            }}
+          >
+            {/* Workspace chooser — top of the collapsible Files section, so it
+                collapses away with the tree (owner direction 2026-07-20) */}
+            {shellNavigationControls.length > 0 && (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "4px 8px",
+                  borderBottom: "1px solid var(--border-primary, #2a2a2a)",
+                  flexShrink: 0,
+                }}
+              >
+                {shellNavigationControls.map((Control) =>
+                  createElement(Control, {
+                    key: Control.displayName ?? Control.name,
+                    paneId: TOP_LEFT_PANE_ID,
+                  })
+                )}
+              </div>
+            )}
+            <LeftSidebar />
+          </div>
+          <div
+            style={{
+              flex: 1,
+              minHeight: 0,
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
+            <MainPanelWorkspace />
+          </div>
+        </DndWrapper>
+      </div>
+
+      {/* Chat view. Kept mounted when hidden so the conversation survives
+          view switches. pageContext is held for B2 (context scopes); the
+          page pill itself is extension chrome per decision #10. */}
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          display: view === "chat" ? "flex" : "none",
+          flexDirection: "column",
+        }}
+        data-page-context-url={pageContext?.url ?? undefined}
+      >
+        {/* Full multi-conversation surface (tabs + picker + new chat), the
+            same component the right sidebar mounts — a bare ChatPanel gave
+            no way to open or start conversations. Bound to whatever content
+            is active in the panel, so chats follow the Garden selection. */}
+        <MultiConversationSidebar contentId={selectedContentId} />
+      </div>
+    </div>
+  );
+}

--- a/app/embed/panel/PanelShellClient.tsx
+++ b/app/embed/panel/PanelShellClient.tsx
@@ -1,17 +1,29 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { DndWrapper } from "@/components/content/DndWrapper";
 import { LeftSidebar } from "@/components/content/LeftSidebar";
 import { MainPanelWorkspace } from "@/components/content/MainPanelWorkspace";
 import { MultiConversationSidebar } from "@/components/content/ai/MultiConversationSidebar";
 import { useContentStore, TOP_LEFT_PANE_ID } from "@/state/content-store";
 import { useRightPanelCollapseStore } from "@/state/right-panel-collapse-store";
+import { useSettingsStore } from "@/state/settings-store";
 import { useExtensionShellNavigationControls } from "@/lib/extensions/client-registry";
 import { isAllowedEmbedMessageOrigin } from "@/lib/domain/browser-extension/embed-message-origins";
 import { createElement } from "react";
 
 const TREE_COLLAPSED_KEY = "dg-panel-tree-collapsed";
+const COLOR_SCHEME_QUERY = "(prefers-color-scheme: dark)";
+
+function subscribeToColorScheme(onChange: () => void) {
+  const query = window.matchMedia(COLOR_SCHEME_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function getSystemPrefersDark() {
+  return window.matchMedia(COLOR_SCHEME_QUERY).matches;
+}
 
 /**
  * Mini-DG shell for the extension side panel (BROWSER-REACH B1).
@@ -38,7 +50,11 @@ interface PanelPageContext {
 
 type PanelView = "garden" | "chat";
 
-export function PanelShellClient() {
+export function PanelShellClient({
+  themePreference = "system",
+}: {
+  themePreference?: "light" | "dark" | "system";
+}) {
   const [view, setView] = useState<PanelView>("garden");
   const [pageContext, setPageContext] = useState<PanelPageContext | null>(null);
   const [treeCollapsed, setTreeCollapsed] = useState(false);
@@ -50,6 +66,28 @@ export function PanelShellClient() {
   // bar (back/forward, pane layout) is suppressed in the panel.
   const shellNavigationControls = useExtensionShellNavigationControls();
   const selectedContentId = useContentStore((s) => s.selectedContentId);
+
+  // Server-resolved preference; "system" defers to the iframe's own media
+  // query, subscribed through useSyncExternalStore so it stays SSR-safe and
+  // needs no setState-in-effect.
+  const systemPrefersDark = useSyncExternalStore(
+    subscribeToColorScheme,
+    getSystemPrefersDark,
+    () => false
+  );
+  const isDark =
+    themePreference === "system" ? systemPrefersDark : themePreference === "dark";
+
+  // Two consumers read the theme from different places: Tailwind's `dark:`
+  // variants need a `.dark` ancestor class, while JS-computed styles (the chat
+  // gradient) read useResolvedTheme → the settings store, which is empty in the
+  // partitioned iframe. The class is applied in render below; seed the store here.
+  useEffect(() => {
+    useSettingsStore.setState((state) => ({
+      ui: { ...state.ui, theme: isDark ? "dark" : "light" },
+    }));
+    document.documentElement.classList.toggle("dark", isDark);
+  }, [isDark]);
 
   // The panel has no room for the right sidebar; keep it collapsed.
   useEffect(() => {
@@ -118,6 +156,7 @@ export function PanelShellClient() {
 
   return (
     <div
+      className={isDark ? "dark" : undefined}
       style={{
         flex: 1,
         minHeight: 0,

--- a/app/embed/panel/PanelShellClient.tsx
+++ b/app/embed/panel/PanelShellClient.tsx
@@ -9,6 +9,10 @@ import { ContextMenu } from "@/components/content/context-menu/ContextMenu";
 import { fileTreeActionProvider } from "@/components/content/context-menu/file-tree-actions";
 import { editorActionProvider } from "@/components/content/context-menu/editor-actions";
 import type { ContextMenuActionProvider } from "@/components/content/context-menu/types";
+import {
+  requestOverlayOpen,
+  OVERLAY_CORNERS,
+} from "@/lib/domain/browser-extension/panel-bridge";
 import { useContentStore, TOP_LEFT_PANE_ID } from "@/state/content-store";
 import { useRightPanelCollapseStore } from "@/state/right-panel-collapse-store";
 import { useSettingsStore } from "@/state/settings-store";
@@ -31,7 +35,59 @@ const PANEL_HIDDEN_ACTION_IDS = new Set([
   "open-in-pane",
 ]);
 
+/**
+ * Panel-only "Open as overlay": project a tree item onto the page. Added as
+ * its own section right after the first so it sits near the top of a menu
+ * that's already tall at panel width.
+ */
+function withOverlayAction(
+  sections: ReturnType<ContextMenuActionProvider>,
+  contentIds: string[]
+): ReturnType<ContextMenuActionProvider> {
+  if (contentIds.length === 0) return sections;
+  const label =
+    contentIds.length > 1
+      ? `Open ${contentIds.length} as overlays`
+      : "Open as overlay";
+  const overlaySection = {
+    actions: [
+      {
+        id: "open-as-overlay",
+        label,
+        sectionLabel: "PAGE",
+        onClick: () => {
+          // Stagger corners so a multi-select doesn't stack every panel in
+          // the same spot.
+          contentIds.forEach((contentId, index) => {
+            requestOverlayOpen(contentId, {
+              corner: OVERLAY_CORNERS[index % OVERLAY_CORNERS.length],
+            });
+          });
+        },
+      },
+    ],
+  };
+  return [sections[0], overlaySection, ...sections.slice(1)].filter(Boolean);
+}
+
 const compactFileTreeActionProvider: ContextMenuActionProvider = (ctx) => {
+  const context = ctx as unknown as {
+    selectedIds?: string[];
+    clickedId?: string | null;
+  };
+  const targetIds =
+    context.selectedIds && context.selectedIds.length > 0
+      ? context.selectedIds
+      : context.clickedId
+        ? [context.clickedId]
+        : [];
+  return withOverlayAction(
+    baseCompactSections(ctx),
+    targetIds
+  );
+};
+
+const baseCompactSections: ContextMenuActionProvider = (ctx) => {
   return fileTreeActionProvider(ctx)
     .map((section) => {
       const actions = section.actions.filter(

--- a/app/embed/panel/PanelShellClient.tsx
+++ b/app/embed/panel/PanelShellClient.tsx
@@ -170,6 +170,10 @@ export function PanelShellClient() {
         ))}
       </div>
 
+      {/* DndWrapper spans BOTH views: the tree needs it for drag-and-drop, and
+          ChatInput's useDrop (drag a note onto the composer) throws
+          "Expected drag drop context" without a provider above it. */}
+      <DndWrapper>
       {/* Garden view: tree over tabbed workspace. Kept mounted when hidden. */}
       <div
         style={{
@@ -179,7 +183,7 @@ export function PanelShellClient() {
           flexDirection: "column",
         }}
       >
-        <DndWrapper>
+        <>
           {/* Slim collapse bar — reclaims the tree's space for notes. */}
           <button
             type="button"
@@ -256,7 +260,7 @@ export function PanelShellClient() {
           >
             <MainPanelWorkspace />
           </div>
-        </DndWrapper>
+        </>
       </div>
 
       {/* Chat view. Kept mounted when hidden so the conversation survives
@@ -277,6 +281,7 @@ export function PanelShellClient() {
             is active in the panel, so chats follow the Garden selection. */}
         <MultiConversationSidebar contentId={selectedContentId} />
       </div>
+      </DndWrapper>
     </div>
   );
 }

--- a/app/embed/panel/PanelShellClient.tsx
+++ b/app/embed/panel/PanelShellClient.tsx
@@ -5,6 +5,9 @@ import { DndWrapper } from "@/components/content/DndWrapper";
 import { LeftSidebar } from "@/components/content/LeftSidebar";
 import { MainPanelWorkspace } from "@/components/content/MainPanelWorkspace";
 import { MultiConversationSidebar } from "@/components/content/ai/MultiConversationSidebar";
+import { ContextMenu } from "@/components/content/context-menu/ContextMenu";
+import { fileTreeActionProvider } from "@/components/content/context-menu/file-tree-actions";
+import { editorActionProvider } from "@/components/content/context-menu/editor-actions";
 import { useContentStore, TOP_LEFT_PANE_ID } from "@/state/content-store";
 import { useRightPanelCollapseStore } from "@/state/right-panel-collapse-store";
 import { useSettingsStore } from "@/state/settings-store";
@@ -321,6 +324,19 @@ export function PanelShellClient({
         <MultiConversationSidebar contentId={selectedContentId} />
       </div>
       </DndWrapper>
+
+      {/* Global context menu — the app mounts this in ResizablePanels, which
+          the panel doesn't use. Without it, right-click fell through to the
+          browser's native menu. It portals to document.body at z-120 (above
+          #embed-root's 100) and menu-positioning flips/shifts against
+          window.innerWidth/Height — inside the iframe that IS the panel
+          viewport, so it stays in bounds at panel width for free. */}
+      <ContextMenu
+        actionProviders={{
+          "file-tree": fileTreeActionProvider,
+          "main-editor": editorActionProvider,
+        }}
+      />
     </div>
   );
 }

--- a/app/embed/panel/PanelShellClient.tsx
+++ b/app/embed/panel/PanelShellClient.tsx
@@ -8,6 +8,7 @@ import { MultiConversationSidebar } from "@/components/content/ai/MultiConversat
 import { ContextMenu } from "@/components/content/context-menu/ContextMenu";
 import { fileTreeActionProvider } from "@/components/content/context-menu/file-tree-actions";
 import { editorActionProvider } from "@/components/content/context-menu/editor-actions";
+import type { ContextMenuActionProvider } from "@/components/content/context-menu/types";
 import { useContentStore, TOP_LEFT_PANE_ID } from "@/state/content-store";
 import { useRightPanelCollapseStore } from "@/state/right-panel-collapse-store";
 import { useSettingsStore } from "@/state/settings-store";
@@ -16,6 +17,41 @@ import { isAllowedEmbedMessageOrigin } from "@/lib/domain/browser-extension/embe
 import { createElement } from "react";
 
 const TREE_COLLAPSED_KEY = "dg-panel-tree-collapsed";
+
+/**
+ * The full file-tree menu is nearly as tall as the panel itself. Trim the
+ * actions that don't apply here: clipboard operations (the panel isn't where
+ * you shuffle files around) and "Open In Pane" (the panel is single-pane by
+ * necessity, so it offers a choice that can't be honored).
+ */
+const PANEL_HIDDEN_ACTION_IDS = new Set([
+  "copy",
+  "cut",
+  "paste",
+  "open-in-pane",
+]);
+
+const compactFileTreeActionProvider: ContextMenuActionProvider = (ctx) => {
+  return fileTreeActionProvider(ctx)
+    .map((section) => {
+      const actions = section.actions.filter(
+        (action) => !PANEL_HIDDEN_ACTION_IDS.has(action.id)
+      );
+      // An item-level heading rides on the first action of its group; if that
+      // action is dropped, hand the heading to the next survivor so the rest
+      // of the group isn't orphaned.
+      const orphanedLabel = section.actions.find(
+        (action) =>
+          PANEL_HIDDEN_ACTION_IDS.has(action.id) && action.sectionLabel
+      )?.sectionLabel;
+      if (orphanedLabel && actions.length > 0 && !actions[0].sectionLabel) {
+        actions[0] = { ...actions[0], sectionLabel: orphanedLabel };
+      }
+      return { ...section, actions };
+    })
+    // Drop sections emptied by the filter so no stray heading remains.
+    .filter((section) => section.actions.length > 0);
+};
 const COLOR_SCHEME_QUERY = "(prefers-color-scheme: dark)";
 
 function subscribeToColorScheme(onChange: () => void) {
@@ -333,7 +369,7 @@ export function PanelShellClient({
           viewport, so it stays in bounds at panel width for free. */}
       <ContextMenu
         actionProviders={{
-          "file-tree": fileTreeActionProvider,
+          "file-tree": compactFileTreeActionProvider,
           "main-editor": editorActionProvider,
         }}
       />

--- a/app/embed/panel/page.tsx
+++ b/app/embed/panel/page.tsx
@@ -1,0 +1,34 @@
+/**
+ * Embed Panel Page — the mini-DG shell served inside the extension's side
+ * panel (BROWSER-REACH B1). File tree + tabbed content workspace + chat at
+ * panel width. The extension contributes only a thin context bar above this
+ * iframe; everything rendered here is the real app.
+ *
+ * Auth mirrors /embed/content/[id]: cookie path first, then the ?_t= URL
+ * token fallback for cross-site iframe contexts.
+ */
+
+import { redirect } from "next/navigation";
+import { getSession, validateSession } from "@/lib/infrastructure/auth";
+import { PanelShellClient } from "./PanelShellClient";
+
+type SearchParams = Promise<{ _t?: string }>;
+
+export default async function EmbedPanelPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  let session = await getSession();
+
+  if (!session) {
+    const { _t } = await searchParams;
+    if (_t) {
+      session = await validateSession(_t);
+    }
+  }
+
+  if (!session) redirect("/sign-in");
+
+  return <PanelShellClient />;
+}

--- a/app/embed/panel/page.tsx
+++ b/app/embed/panel/page.tsx
@@ -10,7 +10,34 @@
 
 import { redirect } from "next/navigation";
 import { getSession, validateSession } from "@/lib/infrastructure/auth";
+import { prisma } from "@/lib/database/client";
 import { PanelShellClient } from "./PanelShellClient";
+
+type ThemePreference = "light" | "dark" | "system";
+
+/**
+ * The app normally applies `.dark` via a pre-hydration script reading
+ * localStorage["notes:settings"]. Inside the extension iframe that storage is
+ * partitioned and empty, so no class is applied and every `dark:` variant
+ * silently renders light — a light chat surface inside a dark panel. The
+ * preference is also persisted server-side, so resolve it here where we
+ * already have the session and hand it to the client.
+ */
+async function readThemePreference(userId: string): Promise<ThemePreference> {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { settings: true },
+    });
+    const ui = (user?.settings as { ui?: { theme?: string } } | null)?.ui;
+    if (ui?.theme === "light" || ui?.theme === "dark" || ui?.theme === "system") {
+      return ui.theme;
+    }
+  } catch {
+    // Settings are advisory here — fall through to the client's own resolution.
+  }
+  return "system";
+}
 
 type SearchParams = Promise<{ _t?: string }>;
 
@@ -30,5 +57,7 @@ export default async function EmbedPanelPage({
 
   if (!session) redirect("/sign-in");
 
-  return <PanelShellClient />;
+  const themePreference = await readThemePreference(session.user.id);
+
+  return <PanelShellClient themePreference={themePreference} />;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -161,6 +161,23 @@ body:has(.embed-layout-page) {
   overflow: hidden !important;
 }
 
+/* Radix menus/popovers/selects portal to <body>, i.e. OUTSIDE #embed-root —
+ * which is fixed-positioned at z-index:100. Portalled content ships at z-50,
+ * so every dropdown opened inside an embed rendered *behind* the panel and
+ * looked like a dead click (side-panel workspace chooser, chat pickers).
+ * Raise portalled layers above the embed container. Scoped to embed
+ * documents so the main app's stacking is untouched. */
+body:has(.embed-layout-page) [data-radix-popper-content-wrapper] {
+  z-index: 200 !important;
+}
+
+body:has(.embed-layout-page) [data-radix-portal],
+body:has(.embed-layout-page) > [role="dialog"],
+body:has(.embed-layout-page) > [data-radix-menu-content],
+body:has(.embed-layout-page) > [data-sonner-toaster] {
+  z-index: 200 !important;
+}
+
 /* Hide default nav + remove padding for the platform marketing page (notetrellis.com) */
 body:has(.platform-home-page) .notes-route-hides-default-nav {
   display: none !important;

--- a/components/content/LeftSidebar.tsx
+++ b/components/content/LeftSidebar.tsx
@@ -13,6 +13,7 @@ import { LeftSidebarHeader } from "./headers/LeftSidebarHeader";
 import { LeftSidebarContent } from "./content/LeftSidebarContent";
 import { LeftSidebarCollapsed } from "./LeftSidebarCollapsed";
 import { LeftSidebarExtensions } from "./content/LeftSidebarExtensions";
+import { RecentsPanel } from "./RecentsPanel";
 import { InboxLeftPanel } from "@/components/client/inbox/InboxLeftPanel";
 import { PeopleMountPickerDialog } from "./people/PeopleMountPickerDialog";
 import { FileUploadDialog } from "./dialogs/FileUploadDialog";
@@ -298,6 +299,8 @@ export function LeftSidebar() {
         {activeView === "extensions" && <LeftSidebarExtensions />}
 
         {activeView === "inbox" && <InboxLeftPanel />}
+
+        {activeView === "recents" && <RecentsPanel />}
 
         {ExtensionPanel && createElement(ExtensionPanel)}
 

--- a/components/content/MainPanelNavigation.tsx
+++ b/components/content/MainPanelNavigation.tsx
@@ -7,6 +7,7 @@
 "use client";
 
 import { createElement, useEffect, useState, useCallback, useRef, memo } from "react";
+import { usePathname } from "next/navigation";
 import type { ComponentType, RefObject } from "react";
 import {
   ChevronDown,
@@ -97,6 +98,7 @@ interface MainPanelNavigationProps {
 NavigationButtons.displayName = "NavigationButtons";
 
 export function MainPanelNavigation({ paneId }: MainPanelNavigationProps) {
+  const pathname = usePathname();
   const layoutMode = useContentStore((state) => state.layoutMode);
   const paneContentId = useContentStore((state) => getPaneActiveContentId(state, paneId));
   const activeTabTitle = useContentStore((state) => {
@@ -245,6 +247,11 @@ export function MainPanelNavigation({ paneId }: MainPanelNavigationProps) {
     LAYOUT_OPTIONS.find((option) => option.mode === layoutMode) ?? LAYOUT_OPTIONS[0];
   const CurrentLayoutIcon = currentLayout.icon;
 
+  // The side-panel embed is single-pane by necessity (panel width) — hide the
+  // pane-layout selector there while keeping the workspace chooser and the
+  // rest of the bar. Enforcement of the mode itself lives in PanelShellClient.
+  const isPanelEmbed = pathname?.startsWith("/embed/panel") ?? false;
+
   return (
     <>
       <div className="flex items-center justify-between gap-3 border-b border-white/10 px-2 py-1">
@@ -264,6 +271,7 @@ export function MainPanelNavigation({ paneId }: MainPanelNavigationProps) {
               paneId,
             })
           )}
+          {!isPanelEmbed && (
           <div className="relative">
             <button
               ref={layoutButtonRef}
@@ -312,6 +320,7 @@ export function MainPanelNavigation({ paneId }: MainPanelNavigationProps) {
               </div>
             )}
           </div>
+          )}
           {shellNavigationTrailingControls.map((Control) =>
             createElement(Control, {
               key: Control.displayName ?? Control.name,

--- a/components/content/MainPanelWorkspace.tsx
+++ b/components/content/MainPanelWorkspace.tsx
@@ -63,7 +63,10 @@ function WorkspacePane({
   // affects the in-place toggle.
   const mobileFocus = useMobileUiStore((state) => state.focusMode);
   const pathname = usePathname();
-  const isEmbedMode = pathname?.startsWith("/embed/") ?? false;
+  // Chrome suppression applies to the single-content overlay embed only.
+  // The side-panel embed (/embed/panel) is a full mini-DG shell and needs
+  // the tab strip + workspace navigation (BROWSER-REACH B1).
+  const isEmbedMode = pathname?.startsWith("/embed/content") ?? false;
   const isDropTarget = Boolean(draggedTabId) && layoutMode !== "single";
 
   return (
@@ -436,7 +439,10 @@ export function MainPanelWorkspace({
   // the workspace bar + shell controllers below.
   const mobileFocus = useMobileUiStore((state) => state.focusMode);
   const isFocusMode = (pathname?.includes("/content/focus/") ?? false) || mobileFocus;
-  const isEmbedMode = pathname?.startsWith("/embed/") ?? false;
+  // Chrome suppression applies to the single-content overlay embed only.
+  // The side-panel embed (/embed/panel) is a full mini-DG shell and needs
+  // the tab strip + workspace navigation (BROWSER-REACH B1).
+  const isEmbedMode = pathname?.startsWith("/embed/content") ?? false;
   const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
   const [draggedFromPaneId, setDraggedFromPaneId] = useState<WorkspacePaneId | null>(null);
   const [hoveredSinglePaneTargetId, setHoveredSinglePaneTargetId] = useState<string | null>(null);
@@ -676,7 +682,12 @@ export function MainPanelWorkspace({
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      {!isFocusMode && !isEmbedMode ? <MainPanelNavigation paneId={activePaneId} /> : null}
+      {/* The side-panel embed hides the whole navigation bar (no back/forward,
+          no pane layout at panel width); the workspace chooser renders in the
+          panel shell above the file tree instead (BROWSER-REACH B1). */}
+      {!isFocusMode && !isEmbedMode && !(pathname?.startsWith("/embed/panel") ?? false) ? (
+        <MainPanelNavigation paneId={activePaneId} />
+      ) : null}
       <div key={layoutMode} className="relative flex-1 min-h-0">
         {paneLayout}
         {layoutMode !== "quad" && (

--- a/components/content/MainPanelWorkspace.tsx
+++ b/components/content/MainPanelWorkspace.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/state/content-store";
 import { useMobileUiStore } from "@/state/mobile-ui-store";
 import { MainPanelNavigation } from "./MainPanelNavigation";
+import { PanelOverlayCornerTargets } from "./PanelOverlayCornerTargets";
 import { MainPanelHeader } from "./headers/MainPanelHeader";
 import { MainPanelContent } from "./content/MainPanelContent";
 import { useExtensionShellControllers } from "@/lib/extensions/client-registry";
@@ -443,6 +444,7 @@ export function MainPanelWorkspace({
   // The side-panel embed (/embed/panel) is a full mini-DG shell and needs
   // the tab strip + workspace navigation (BROWSER-REACH B1).
   const isEmbedMode = pathname?.startsWith("/embed/content") ?? false;
+  const isPanelEmbedSurfacePath = pathname?.startsWith("/embed/panel") ?? false;
   const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
   const [draggedFromPaneId, setDraggedFromPaneId] = useState<WorkspacePaneId | null>(null);
   const [hoveredSinglePaneTargetId, setHoveredSinglePaneTargetId] = useState<string | null>(null);
@@ -690,7 +692,15 @@ export function MainPanelWorkspace({
       ) : null}
       <div key={layoutMode} className="relative flex-1 min-h-0">
         {paneLayout}
-        {layoutMode !== "quad" && (
+        {/* Side panel: pane-placement previews are meaningless at single-pane
+            panel width, so the drag offers page corners instead — the panel
+            can't be dragged onto, so it shows a miniature of the page. */}
+        {isPanelEmbedSurfacePath ? (
+          <PanelOverlayCornerTargets
+            draggedTabId={draggedTabId}
+            onDrop={resetDragState}
+          />
+        ) : layoutMode !== "quad" ? (
           <WorkspaceReshapeTargets
             layoutMode={layoutMode}
             draggedTabId={draggedTabId}
@@ -701,7 +711,7 @@ export function MainPanelWorkspace({
             onTargetHover={setHoveredSinglePaneTargetId}
             onTargetDrop={handleTabDrop}
           />
-        )}
+        ) : null}
       </div>
       {!isFocusMode
         ? shellControllers.map((Controller) =>

--- a/components/content/PanelOverlayCornerTargets.tsx
+++ b/components/content/PanelOverlayCornerTargets.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+/**
+ * Four-corner overlay placement chooser (BROWSER-REACH, side panel only).
+ *
+ * In the app, dragging a tab shows pane-placement previews. That's meaningless
+ * in the side panel, which is single-pane by necessity — but the drag gesture
+ * is still the natural way to say "put this over there."
+ *
+ * A drag cannot cross from the panel document into the web page (separate
+ * top-level documents), so instead of dragging *onto* the page, the panel
+ * shows a miniature of it: four quadrants standing in for the page's corners.
+ * Dropping on one opens that content as an overlay in the matching corner.
+ * The affordance only exists mid-drag, so it costs no permanent chrome.
+ */
+
+import { useState } from "react";
+import { useContentStore } from "@/state/content-store";
+import {
+  requestOverlayOpen,
+  OVERLAY_CORNERS,
+  type OverlayCorner,
+} from "@/lib/domain/browser-extension/panel-bridge";
+
+const CORNER_LABELS: Record<OverlayCorner, string> = {
+  "top-left": "Top left",
+  "top-right": "Top right",
+  "bottom-left": "Bottom left",
+  "bottom-right": "Bottom right",
+};
+
+export function PanelOverlayCornerTargets({
+  draggedTabId,
+  onDrop,
+}: {
+  draggedTabId: string | null;
+  onDrop: () => void;
+}) {
+  const [hovered, setHovered] = useState<OverlayCorner | null>(null);
+  const contentId = useContentStore((state) =>
+    draggedTabId ? (state.tabs[draggedTabId]?.contentId ?? null) : null
+  );
+
+  if (!draggedTabId || !contentId) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-40 p-2">
+      <div className="pointer-events-none absolute inset-x-0 top-1 text-center text-[10px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        Drop to place on page
+      </div>
+      <div className="grid h-full w-full grid-cols-2 grid-rows-2 gap-2 pt-5">
+        {OVERLAY_CORNERS.map((corner) => {
+          const isHovered = hovered === corner;
+          return (
+            <div
+              key={corner}
+              // Each quadrant is a live drop target; the grid mirrors the page.
+              className={`pointer-events-auto flex items-center justify-center rounded-lg border-2 border-dashed text-[11px] transition-colors ${
+                isHovered
+                  ? "border-gold-primary bg-gold-primary/15 text-gold-primary"
+                  : "border-black/15 bg-white/70 text-gray-500 dark:border-white/20 dark:bg-black/40 dark:text-gray-400"
+              }`}
+              onDragOver={(event) => {
+                event.preventDefault();
+                event.dataTransfer.dropEffect = "move";
+                if (hovered !== corner) setHovered(corner);
+              }}
+              onDragLeave={() => {
+                if (hovered === corner) setHovered(null);
+              }}
+              onDrop={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setHovered(null);
+                requestOverlayOpen(contentId, { corner });
+                onDrop();
+              }}
+            >
+              {CORNER_LABELS[corner]}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/content/RecentsPanel.tsx
+++ b/components/content/RecentsPanel.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * Recents Panel — Obsidian-style recently-viewed list for the left sidebar.
+ *
+ * Reuses the navigation-history store (the back/forward stacks): entries from
+ * every pane are merged, deduped by contentId (keeping the newest timestamp),
+ * and sorted most-recent-first. Clicking an item opens it in the active pane —
+ * the same path the back-history dropdown uses.
+ */
+
+import { useMemo } from "react";
+import { useNavigationHistoryStore } from "@/state/navigation-history-store";
+import { useContentStore } from "@/state/content-store";
+
+const TYPE_ICONS: Record<string, string> = {
+  folder: "M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z",
+  note: "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z",
+  external:
+    "M13.828 10.172a4 4 0 010 5.656l-4 4a4 4 0 01-5.656-5.656l1.102-1.101m9.554-9.554l1.102-1.101a4 4 0 015.656 5.656l-4 4a4 4 0 01-5.656 0",
+};
+
+const DEFAULT_ICON =
+  "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z";
+
+function formatRelativeTime(timestamp: number): string {
+  const deltaSeconds = Math.round((timestamp - Date.now()) / 1000);
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  const table: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ["year", 60 * 60 * 24 * 365],
+    ["month", 60 * 60 * 24 * 30],
+    ["week", 60 * 60 * 24 * 7],
+    ["day", 60 * 60 * 24],
+    ["hour", 60 * 60],
+    ["minute", 60],
+  ];
+  for (const [unit, seconds] of table) {
+    if (Math.abs(deltaSeconds) >= seconds) {
+      return rtf.format(Math.round(deltaSeconds / seconds), unit);
+    }
+  }
+  return "just now";
+}
+
+export function RecentsPanel() {
+  const byPaneId = useNavigationHistoryStore((state) => state.byPaneId);
+  const setSelectedContentId = useContentStore(
+    (state) => state.setSelectedContentId
+  );
+
+  const recents = useMemo(() => {
+    const newestById = new Map<
+      string,
+      { contentId: string; timestamp: number; title?: string; contentType?: string }
+    >();
+    for (const paneState of Object.values(byPaneId)) {
+      for (const item of paneState.history) {
+        if (!item.contentId) continue;
+        const existing = newestById.get(item.contentId);
+        if (!existing || item.timestamp > existing.timestamp) {
+          newestById.set(item.contentId, {
+            contentId: item.contentId,
+            timestamp: item.timestamp,
+            title: item.title,
+            contentType: item.contentType,
+          });
+        }
+      }
+    }
+    return [...newestById.values()].sort((a, b) => b.timestamp - a.timestamp);
+  }, [byPaneId]);
+
+  if (recents.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-gray-500 dark:text-gray-400">
+        Recently viewed notes and files will appear here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto py-1">
+      {recents.map((item) => (
+        <button
+          key={item.contentId}
+          type="button"
+          onClick={() => setSelectedContentId(item.contentId)}
+          className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+        >
+          <svg
+            className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d={TYPE_ICONS[item.contentType ?? ""] ?? DEFAULT_ICON}
+            />
+          </svg>
+          <span className="min-w-0 flex-1 truncate text-sm text-gray-800 dark:text-gray-200">
+            {item.title ?? "Untitled"}
+          </span>
+          <span className="shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+            {formatRelativeTime(item.timestamp)}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/content/ai/ChatPanel.tsx
+++ b/components/content/ai/ChatPanel.tsx
@@ -14,6 +14,7 @@
 "use client";
 
 import { useRef, useEffect, useCallback, useState, useMemo } from "react";
+import { usePathname } from "next/navigation";
 import { Trash2, Bot, Pencil, Maximize2, ChevronDown } from "lucide-react";
 import { PROVIDER_CATALOG } from "@/lib/domain/ai/providers/catalog";
 import { getProviderTheme } from "@/lib/design/system/ai-providers";
@@ -81,6 +82,32 @@ interface ChatPanelProps {
    * behavior) — messages live in memory only and disappear on reload.
    */
   onTransientPromoted?: (newConversationId: string) => void;
+}
+
+/**
+ * Browser side panel only: the last target folder the user picked there.
+ * App chats derive their target from the content they're rooted to, but a
+ * browser chat has no such root — remembering the pick is what keeps it
+ * placeful across pages and sessions (BROWSER-REACH decision #7).
+ */
+const PANEL_TARGET_KEY = "dg-panel-target-folder";
+
+function readRememberedPanelTarget(): {
+  id: string;
+  title: string | null;
+} | null {
+  try {
+    const raw = localStorage.getItem(PANEL_TARGET_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { id?: unknown; title?: unknown };
+    if (typeof parsed?.id !== "string") return null;
+    return {
+      id: parsed.id,
+      title: typeof parsed.title === "string" ? parsed.title : null,
+    };
+  } catch {
+    return null;
+  }
 }
 
 export function ChatPanel({
@@ -222,6 +249,10 @@ export function ChatPanel({
 
   // Target folder (AI v3 core S3): seed from the bound conversation; user
   // changes persist via PATCH (owner+is-folder validated server-side).
+  // Browser side panel gets target persistence the app doesn't need.
+  const chatPathname = usePathname();
+  const isPanelEmbed = chatPathname?.startsWith("/embed/panel") ?? false;
+
   const [targetFolder, setTargetFolder] = useState<{
     id: string;
     title: string | null;
@@ -297,13 +328,36 @@ export function ChatPanel({
       // rendering blank.
       setTargetFolder(effectiveLocation);
       setTargetInherited(true);
+    } else if (isPanelEmbed) {
+      // Browser panel: no conversation and nothing to inherit from, so fall
+      // back to the last target the user picked here. Browser chats aren't
+      // rooted in content the way app chats are — the panel's remembered
+      // target is what makes them placeful.
+      const remembered = readRememberedPanelTarget();
+      setTargetFolder(remembered);
+      setTargetInherited(false);
     } else {
       setTargetFolder(null);
       setTargetInherited(false);
     }
-  }, [initialTargetFolder, initialTargetInherited, effectiveLocation]);
+  }, [initialTargetFolder, initialTargetInherited, effectiveLocation, isPanelEmbed]);
   const handleTargetChange = useCallback(
     (next: { id: string; title: string | null } | null) => {
+      // Browser panel only: remember the pick so the next chat opened in the
+      // side panel starts already targeted. The app's own chats keep deriving
+      // their target from the content they're rooted to.
+      if (isPanelEmbed) {
+        try {
+          if (next) {
+            localStorage.setItem(PANEL_TARGET_KEY, JSON.stringify(next));
+          } else {
+            localStorage.removeItem(PANEL_TARGET_KEY);
+          }
+        } catch {
+          // Storage unavailable in a partitioned iframe — selection still
+          // applies for this session.
+        }
+      }
       // Explicit pick overrides inheritance; clearing an override falls
       // back to the location-inferred target (chats serve their location).
       if (next) {
@@ -322,7 +376,7 @@ export function ChatPanel({
         body: JSON.stringify({ targetFolderId: next?.id ?? null }),
       }).catch(() => {});
     },
-    [conversationId, effectiveLocation],
+    [conversationId, effectiveLocation, isPanelEmbed],
   );
 
   // Change handler: update local state immediately (drives the engine body)
@@ -365,9 +419,15 @@ export function ChatPanel({
             method: "POST",
             credentials: "include",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(
-              contentId ? { snapshotContentNodeIds: [contentId] } : {},
-            ),
+            body: JSON.stringify({
+              ...(contentId ? { snapshotContentNodeIds: [contentId] } : {}),
+              // Carry a target chosen before the conversation existed
+              // (the chip is now usable in transient chats) so the very
+              // first turn already files its outputs in the right place.
+              ...(targetFolder && !targetInherited
+                ? { targetFolderId: targetFolder.id }
+                : {}),
+            }),
           });
           if (!res.ok) throw new Error("Couldn't save the chat");
           const body = (await res.json()) as { data?: { id?: string } };
@@ -397,7 +457,17 @@ export function ChatPanel({
       return;
     }
     handleSend();
-  }, [conversationId, onTransientPromoted, contentId, input, handleSend]);
+    // targetFolder/targetInherited are real deps: a stale closure would create
+    // the conversation without a target the user picked before sending.
+  }, [
+    conversationId,
+    onTransientPromoted,
+    contentId,
+    input,
+    handleSend,
+    targetFolder,
+    targetInherited,
+  ]);
 
   // Resend the queued transient first message once conversationId catches up.
   useEffect(() => {
@@ -645,7 +715,10 @@ export function ChatPanel({
             target={targetFolder}
             inherited={targetInherited}
             location={effectiveLocation}
-            disabled={!conversationId}
+            // Selectable before the conversation exists: the pick is held in
+            // local state, carried into the POST that creates the conversation,
+            // and (in the browser panel) remembered for the next chat.
+            disabled={false}
             onChange={handleTargetChange}
           />
         </div>

--- a/components/content/ai/MultiConversationSidebar.tsx
+++ b/components/content/ai/MultiConversationSidebar.tsx
@@ -378,6 +378,11 @@ export function MultiConversationSidebar({ contentId }: Props) {
     <div
       className="flex h-full flex-col"
       style={{ background: surfaceBackground }}
+      // useResolvedTheme has no `window` during SSR and returns "light", so
+      // the server paints the light gradient while the client paints dark.
+      // The client value is correct and wins on the next render; suppress the
+      // unavoidable first-paint attribute diff rather than warn on every mount.
+      suppressHydrationWarning
     >
       <div className="relative">
         <SidebarChatTabs

--- a/components/content/editor/MarkdownEditor.tsx
+++ b/components/content/editor/MarkdownEditor.tsx
@@ -424,6 +424,15 @@ export function MarkdownEditor({
       runtimeConnectionState === "disconnectedButDirty" ||
       runtimeEditPolicy?.reason === "offline-local-durable" ||
       runtimeEditPolicy?.reason === "degraded-local-fallback");
+  // Read via ref inside the editor's onUpdate. This flag flips on TRANSIENT
+  // connection states (the very first keystroke while disconnected flips
+  // disconnectedButDirty) — keeping it in the useEditor deps recreated the
+  // whole editor mid-keystroke, stealing the caret on every edit whenever
+  // collaboration couldn't connect (2026-07-20 incident).
+  const shouldSkipRestAutosaveRef = useRef(shouldSkipRestAutosaveForCollaboration);
+  useEffect(() => {
+    shouldSkipRestAutosaveRef.current = shouldSkipRestAutosaveForCollaboration;
+  }, [shouldSkipRestAutosaveForCollaboration]);
 
   useEffect(() => {
     if (!collaborationState) {
@@ -661,7 +670,7 @@ export function MarkdownEditor({
         clearTimeout(saveTimeoutRef.current);
       }
 
-      if (collaborationState?.provider || shouldSkipRestAutosaveForCollaboration) {
+      if (collaborationState?.provider || shouldSkipRestAutosaveRef.current) {
         return;
       }
 
@@ -768,7 +777,13 @@ export function MarkdownEditor({
         }, autoSaveDelay);
       }
     },
-  }, [editorMode, effectiveEditable, shouldSkipRestAutosaveForCollaboration]);
+    // Recreate the editor ONLY when the collaboration provider's presence
+    // changes (editorMode encodes it) — that transition genuinely requires a
+    // new editor instance. Everything else is handled without recreation:
+    // editability via the setEditable effect below, autosave skipping via
+    // shouldSkipRestAutosaveRef. Recreating on those transient flags is what
+    // turned every connection blip into a stolen caret.
+  }, [editorMode]);
 
   useEffect(() => {
     if (!editor) return;

--- a/components/content/editor/MarkdownEditor.tsx
+++ b/components/content/editor/MarkdownEditor.tsx
@@ -226,7 +226,9 @@ export function MarkdownEditor({
 }: MarkdownEditorProps) {
   const openMenu = useContextMenuStore((s) => s.openMenu);
   const pathname = usePathname();
-  const isEmbedMode = pathname?.startsWith("/embed/") ?? false;
+  // Only the single-content overlay embed lacks the context-menu portal; the
+  // side panel mounts it in its own shell, so it gets the app's real menu.
+  const isEmbedMode = pathname?.startsWith("/embed/content") ?? false;
 
   // Pre-load template/snippet data so right-click context menu has categories ready
   useEffect(() => {

--- a/components/content/headers/LeftSidebarHeader.tsx
+++ b/components/content/headers/LeftSidebarHeader.tsx
@@ -12,6 +12,7 @@ import { useLeftPanelCollapseStore } from "@/state/left-panel-collapse-store";
 import { useLeftPanelViewStore } from "@/state/left-panel-view-store";
 import { LeftSidebarHeaderActions } from "./LeftSidebarHeaderActions";
 import { Inbox, PanelLeftClose, PanelLeft } from "lucide-react";
+import { usePathname } from "next/navigation";
 import { renderExtensionIcon } from "@/lib/extensions";
 import { useExtensionHeaderNavItems } from "@/lib/extensions/client-registry";
 import { useNotificationsStore } from "@/state/notifications-store";
@@ -64,17 +65,21 @@ export function LeftSidebarHeader({
   const { isSearchOpen, toggleSearch } = useSearchStore();
   const { mode, toggleMode } = useLeftPanelCollapseStore();
   const { activeView, setActiveView } = useLeftPanelViewStore();
+  const pathname = usePathname();
+  const isPanelEmbed = pathname?.startsWith("/embed/panel") ?? false;
   const extensionNavItems = useExtensionHeaderNavItems();
   const unreadCount = useNotificationsStore((state) => state.unreadCount);
 
   // Daily Notes is type "action" with id "open-periodic-note", Publishing is type "view" with view "publishing-view"
   const subAffordanceIds = new Set(["open-periodic-note", "publishing-view"]);
 
-  // True whenever the user is anywhere in the files section (files, search, or a sub-affordance view).
-  // Drives: container background, folder tab active state, and sub-row visibility — all from one source.
+  // True whenever the user is anywhere in the files section (files, search,
+  // recents, or a sub-affordance view). Drives: container background, folder
+  // tab active state, and sub-row visibility — all from one source.
   const showFilesSection =
     activeView === "files" ||
     activeView === "search" ||
+    activeView === "recents" ||
     subAffordanceIds.has(activeView);
 
   const headerExtensionItems = extensionNavItems.filter(({ item }) => {
@@ -200,21 +205,24 @@ export function LeftSidebarHeader({
           </button>
         </div>
 
-        {/* Panel collapse toggle */}
-        <div className="flex shrink-0 items-center gap-1">
-          <button
-            onClick={toggleMode}
-            className={`rounded p-1 transition-colors ${tabInactive}`}
-            title={mode === "full" ? "Collapse sidebar (Cmd+B)" : "Expand sidebar (Cmd+B)"}
-            type="button"
-          >
-            {mode === "full" ? (
-              <PanelLeftClose className="h-4 w-4" />
-            ) : (
-              <PanelLeft className="h-4 w-4" />
-            )}
-          </button>
-        </div>
+        {/* Panel collapse toggle — hidden in the side-panel embed, which has
+            its own tree collapse bar (BROWSER-REACH B1) */}
+        {!isPanelEmbed && (
+          <div className="flex shrink-0 items-center gap-1">
+            <button
+              onClick={toggleMode}
+              className={`rounded p-1 transition-colors ${tabInactive}`}
+              title={mode === "full" ? "Collapse sidebar (Cmd+B)" : "Expand sidebar (Cmd+B)"}
+              type="button"
+            >
+              {mode === "full" ? (
+                <PanelLeftClose className="h-4 w-4" />
+              ) : (
+                <PanelLeft className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Sub-affordance row — visible for any view in the files section */}
@@ -246,6 +254,28 @@ export function LeftSidebarHeader({
                 strokeLinejoin="round"
                 strokeWidth={2}
                 d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+          </button>
+
+          {/* Recents — Obsidian-style recently-viewed list (navigation history) */}
+          <button
+            onClick={() => {
+              setActiveView(activeView === "recents" ? "files" : "recents");
+              if (isSearchOpen) toggleSearch();
+            }}
+            className={`rounded p-0.5 transition-colors ${
+              activeView === "recents" ? subActive : subInactive
+            }`}
+            title="Recents"
+            type="button"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
               />
             </svg>
           </button>

--- a/components/content/headers/MainPanelHeader.tsx
+++ b/components/content/headers/MainPanelHeader.tsx
@@ -2,6 +2,8 @@
 
 import { createElement, useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
+import { usePathname } from "next/navigation";
+import { requestOverlayOpen } from "@/lib/domain/browser-extension/panel-bridge";
 import {
   ExternalLink,
   File,
@@ -289,6 +291,8 @@ export function MainPanelHeader({
   // one redundant content fetch per tab on every cold load.
   const workspaceStoreReady = useWorkspaceStore((state) => state.hasLoadedOnce);
   const shellTabMenuSections = useExtensionShellTabMenuSections();
+  const headerPathname = usePathname();
+  const isPanelEmbed = headerPathname?.startsWith("/embed/panel") ?? false;
 
   const [editingTabId, setEditingTabId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState("");
@@ -580,7 +584,7 @@ export function MainPanelHeader({
                   }
                 }}
                 onContextMenu={(event) => {
-                  if (shellTabMenuSections.length === 0) return;
+                  if (shellTabMenuSections.length === 0 && !isPanelEmbed) return;
                   event.preventDefault();
                   setTabMenu({ tabId: tab.id, x: event.clientX, y: event.clientY });
                 }}
@@ -659,6 +663,25 @@ export function MainPanelHeader({
           style={{ left: tabMenu.x, top: tabMenu.y }}
           onClick={(event) => event.stopPropagation()}
         >
+          {/* Side panel only: project this tab onto the page. Drag-to-corner
+              gives precise placement; this is the one-click default. */}
+          {isPanelEmbed && tabMenuTab.contentId ? (
+            <>
+              <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Page
+              </div>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/10"
+                onClick={() => {
+                  requestOverlayOpen(tabMenuTab.contentId as string);
+                  setTabMenu(null);
+                }}
+              >
+                Open as overlay
+              </button>
+            </>
+          ) : null}
           {shellTabMenuSections.map((Section) =>
             createElement(Section, {
               key: Section.displayName ?? Section.name,

--- a/extensions/browser-bookmarks/browser-extension/manifest.json
+++ b/extensions/browser-bookmarks/browser-extension/manifest.json
@@ -11,8 +11,12 @@
     "activeTab",
     "contextMenus",
     "alarms",
-    "scripting"
+    "scripting",
+    "sidePanel"
   ],
+  "side_panel": {
+    "default_path": "panel.html"
+  },
   "host_permissions": ["http://*/*", "https://*/*"],
   "icons": {
     "16": "icons/icon-16.png",

--- a/extensions/browser-bookmarks/browser-extension/panel.html
+++ b/extensions/browser-bookmarks/browser-extension/panel.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Digital Garden</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #0d0d0d;
+        color: #f5f5f5;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          sans-serif;
+        overflow: hidden;
+      }
+      #dg-panel-root {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+      /* ── Context bar — the ONLY extension chrome in the panel ─────────── */
+      #dg-context-bar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 10px;
+        border-bottom: 1px solid #262626;
+        background: #131313;
+        flex-shrink: 0;
+        min-height: 30px;
+      }
+      #dg-page-favicon {
+        width: 14px;
+        height: 14px;
+        border-radius: 3px;
+        flex-shrink: 0;
+        display: none;
+      }
+      #dg-page-title {
+        font-size: 11.5px;
+        color: #b8b8b8;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        flex: 1;
+        min-width: 0;
+      }
+      #dg-panel-frame {
+        flex: 1;
+        border: 0;
+        width: 100%;
+        min-height: 0;
+      }
+      /* ── States ───────────────────────────────────────────────────────── */
+      .dg-panel-state {
+        flex: 1;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        gap: 10px;
+        padding: 24px;
+        text-align: center;
+        font-size: 13px;
+        color: #9a9a9a;
+      }
+      .dg-panel-state[data-active="true"] {
+        display: flex;
+      }
+      .dg-panel-state a {
+        color: #8ab4f8;
+      }
+      /* ── First-run tooltip (two-surface principle) ────────────────────── */
+      #dg-first-run {
+        position: absolute;
+        top: 42px;
+        left: 12px;
+        right: 12px;
+        background: #1c2b1e;
+        border: 1px solid #2f4a33;
+        border-radius: 10px;
+        padding: 12px 14px;
+        font-size: 12.5px;
+        line-height: 1.5;
+        color: #cfe4d2;
+        box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
+        z-index: 10;
+        display: none;
+      }
+      #dg-first-run[data-visible="true"] {
+        display: block;
+      }
+      #dg-first-run strong {
+        color: #eaf6ec;
+      }
+      #dg-first-run button {
+        margin-top: 8px;
+        padding: 4px 12px;
+        font-size: 12px;
+        border-radius: 6px;
+        border: 1px solid #3d5c42;
+        background: #24382a;
+        color: #eaf6ec;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="dg-panel-root">
+      <div id="dg-context-bar">
+        <img id="dg-page-favicon" alt="" />
+        <span id="dg-page-title">…</span>
+        <button
+          id="dg-panel-reload"
+          type="button"
+          title="Reload panel"
+          style="
+            background: none;
+            border: 0;
+            color: #9a9a9a;
+            cursor: pointer;
+            font-size: 13px;
+            padding: 2px 4px;
+            flex-shrink: 0;
+          "
+        >
+          ↻
+        </button>
+      </div>
+
+      <div id="dg-first-run">
+        <strong>Your sidebar keeps tabs and chats across pages.</strong><br />
+        Content you open here stays put while you browse. Pop anything out for
+        an immersive view on the page — and dock it back when you're done.
+        <br />
+        <button id="dg-first-run-dismiss" type="button">Got it</button>
+      </div>
+
+      <div class="dg-panel-state" id="dg-state-loading" data-active="true">
+        Loading your garden…
+      </div>
+      <div class="dg-panel-state" id="dg-state-unconfigured">
+        <div>
+          The extension isn't connected to your Digital Garden yet.<br />
+          Set the app URL in the extension options to use the panel.
+        </div>
+      </div>
+
+      <iframe
+        id="dg-panel-frame"
+        allow="clipboard-write"
+        style="display: none"
+      ></iframe>
+    </div>
+    <script src="dist/panel.js"></script>
+  </body>
+</html>

--- a/extensions/browser-bookmarks/browser-extension/src/background/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/background/index.js
@@ -1889,6 +1889,25 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  // sidePanel.open() must run before any await or the user-gesture context
+  // that authorized it (launcher click → this message) is lost. Handle it
+  // synchronously, outside the async IIFE below.
+  if (message.type === "open-side-panel") {
+    const tabId = sender?.tab?.id;
+    const windowId = sender?.tab?.windowId;
+    const target = tabId != null ? { tabId } : { windowId };
+    chrome.sidePanel
+      .open(target)
+      .then(() => sendResponse({ ok: true, data: true }))
+      .catch((error) =>
+        sendResponse({
+          ok: false,
+          error: error instanceof Error ? error.message : "Failed to open side panel",
+        })
+      );
+    return true;
+  }
+
   (async () => {
     if (message.type === "get-config") {
       sendResponse({ ok: true, data: await getConfig() });

--- a/extensions/browser-bookmarks/browser-extension/src/background/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/background/index.js
@@ -874,7 +874,12 @@ async function showTreePanelInActiveTab() {
   }
 }
 
-async function openContentInActiveTab(contentId, contentKind = "external", runId) {
+async function openContentInActiveTab(
+  contentId,
+  contentKind = "external",
+  runId,
+  corner
+) {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab?.id) {
     throw new Error("No active tab is available");
@@ -887,6 +892,7 @@ async function openContentInActiveTab(contentId, contentKind = "external", runId
         contentId,
         contentKind,
         runId, // workflow panels: deep-link the embed viewer to this run
+        corner, // side-panel pop-out: which page corner to open in
       },
     });
     return { openedInOverlay: true, tabId: tab.id };
@@ -2002,7 +2008,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         data: await openContentInActiveTab(
           message.payload?.contentId,
           message.payload?.contentKind || "external",
-          message.payload?.runId
+          message.payload?.runId,
+          message.payload?.corner
         ),
       });
       return;

--- a/extensions/browser-bookmarks/browser-extension/src/overlay/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/overlay/index.js
@@ -1014,6 +1014,11 @@ function overlayStyles() {
       cursor: grab; touch-action: none;
     }
     .dg-panel-collapsed[data-open="true"] { display: inline-flex; pointer-events: auto; }
+    /* Freeze affordance — clickable in both open and collapsed states */
+    .dg-floating-panel[data-frozen="true"] .dg-freeze-toggle { color: #7cc7ff; opacity: 1; }
+    .dg-chip-freeze { font-style: normal; margin: 0 2px; opacity: 0.5; cursor: pointer; }
+    .dg-chip-freeze:hover { opacity: 0.9; }
+    .dg-panel-collapsed[data-frozen="true"] .dg-chip-freeze { opacity: 1; color: #7cc7ff; }
     .dg-panel-banner { padding: 10px 12px; margin: 0 14px; border-radius: 14px; background: rgba(216,176,92,0.12); color: #f2e2b6; font-size: 12px; line-height: 1.45; }
 
     /* ── Target / embed UI ── */
@@ -1218,6 +1223,7 @@ function scheduleTabPersist(state) {
         width: panel.width,
         height: panel.height,
         opacity: panel.opacity,
+        frozen: panel.frozen === true,
       }));
     runtimeMessage({ type: "save-tab-panels", payload: { panels } }).catch(
       () => {}
@@ -1241,8 +1247,10 @@ async function restoreTabStickyPanels(state) {
     if (!descriptor?.contentId || state.openPanels.has(descriptor.contentId)) {
       continue;
     }
-    // Skip panels opened on a different hostname — they belong to another site.
-    if (descriptor.host && descriptor.host !== currentHost) {
+    // Skip panels opened on a different hostname — they belong to another
+    // site. Exception: FROZEN panels follow the user everywhere (open or
+    // collapsed) until closed or unfrozen.
+    if (!descriptor.frozen && descriptor.host && descriptor.host !== currentHost) {
       continue;
     }
     const item = { id: descriptor.contentId, title: descriptor.title || null };
@@ -1259,6 +1267,7 @@ async function restoreTabStickyPanels(state) {
       height: descriptor.height ?? null,
       opacity: descriptor.opacity ?? 1,
       embeddedSelector: null, // page changed — no element to anchor to
+      frozen: descriptor.frozen === true,
       metadata: {},
     };
     createContentPanel(state, item, descriptor.kind || "note", persisted);
@@ -2521,6 +2530,19 @@ function makePanelDraggable(state, panel) {
   });
 }
 
+// Frozen panels: visual sync + toggle. Frozen = restored on every page in
+// this tab (open or collapsed) regardless of hostname, until closed/unfrozen.
+function syncPanelFrozenVisual(panel) {
+  panel.container.dataset.frozen = panel.frozen ? "true" : "false";
+  panel.collapsedChip.dataset.frozen = panel.frozen ? "true" : "false";
+}
+
+function togglePanelFrozen(state, panel) {
+  panel.frozen = panel.frozen !== true;
+  syncPanelFrozenVisual(panel);
+  scheduleTabPersist(state);
+}
+
 function createContentPanel(state, item, kind, persisted = null) {
   const existing = state.openPanels.get(item.id);
   if (existing) {
@@ -2544,6 +2566,7 @@ function createContentPanel(state, item, kind, persisted = null) {
         <button class="dg-toolbar-button" type="button" data-panel-action="open-tree" title="Browse file tree">◂ Tree</button>
         <button class="dg-toolbar-button" type="button" data-panel-action="app" title="Open in app">↗</button>
         <button class="dg-toolbar-button" type="button" data-panel-action="refresh" title="Refresh note">↺</button>
+        <button class="dg-toolbar-button dg-freeze-toggle" type="button" data-panel-action="freeze" title="Freeze — keep this panel open on every page">❆</button>
         <button class="dg-toolbar-button" type="button" data-panel-action="collapse" title="Collapse">—</button>
         <button class="dg-toolbar-button" type="button" data-panel-action="close" title="Close">×</button>
       </div>
@@ -2554,7 +2577,7 @@ function createContentPanel(state, item, kind, persisted = null) {
   const collapsedChip = document.createElement("button");
   collapsedChip.className = "dg-panel-collapsed";
   collapsedChip.type = "button";
-  collapsedChip.innerHTML = `<span>${escapeHtml(title)}</span><strong>Open</strong>`;
+  collapsedChip.innerHTML = `<span>${escapeHtml(title)}</span><em class="dg-chip-freeze" title="Freeze — keep this panel open on every page">❆</em><strong>Open</strong>`;
 
   state.panelsMount.appendChild(container);
   state.panelsMount.appendChild(collapsedChip);
@@ -2580,6 +2603,9 @@ function createContentPanel(state, item, kind, persisted = null) {
     opacity: persisted?.opacity ?? 1,
     embeddedSelector: persisted?.embeddedSelector || null,
     embeddedPlacement: persisted?.embeddedPlacement || "after",
+    // Frozen panels survive cross-hostname navigation (restored on ANY page,
+    // open or collapsed) until the user closes or unfreezes them.
+    frozen: persisted?.frozen === true,
     metadata: persisted?.metadata || {},
     currentContent: null,
     autosaveTimer: null,
@@ -2591,6 +2617,7 @@ function createContentPanel(state, item, kind, persisted = null) {
 
   state.openPanels.set(item.id, panel);
   scheduleTabPersist(state); // remember this note for in-tab navigation
+  syncPanelFrozenVisual(panel);
   makePanelDraggable(state, panel);
   wirePanelDirectEditor(state, panel);
   applyPanelGeometry(state, panel);
@@ -2668,6 +2695,11 @@ function createContentPanel(state, item, kind, persisted = null) {
       return;
     }
 
+    if (action === "freeze") {
+      togglePanelFrozen(state, panel);
+      return;
+    }
+
     if (action === "collapse") {
       closePanel(state, panel.contentId, "collapsed");
       return;
@@ -2677,6 +2709,14 @@ function createContentPanel(state, item, kind, persisted = null) {
       closePanel(state, panel.contentId, "closed");
     }
   });
+
+  // Freeze glyph on the collapsed chip — toggles without reopening the panel.
+  collapsedChip
+    .querySelector(".dg-chip-freeze")
+    ?.addEventListener("click", (event) => {
+      event.stopPropagation();
+      togglePanelFrozen(state, panel);
+    });
 
   collapsedChip.addEventListener("click", () => {
     if (Date.now() < panel.suppressChipClickUntil) return;
@@ -3208,13 +3248,23 @@ function wireRootEvents(state) {
 
   // ── Floating launcher button ───────────────────────────────────────────────
 
-  state.launcherBtn.addEventListener("click", () => {
+  state.launcherBtn.addEventListener("click", (event) => {
     if (Date.now() < state.suppressMainButtonClickUntil) return;
-    if (state.panelOpen) {
-      closeSnapPanel(state);
-    } else {
-      void openSnapPanel(state);
+    // Decision #11 (BROWSER-REACH B1): the launch-handle opens the side panel.
+    // Alt/Shift-click keeps the legacy in-page overlay reachable while the
+    // panel absorbs its flows session by session.
+    if (event.altKey || event.shiftKey) {
+      if (state.panelOpen) {
+        closeSnapPanel(state);
+      } else {
+        void openSnapPanel(state);
+      }
+      return;
     }
+    chrome.runtime.sendMessage({ type: "open-side-panel" }, () => {
+      // Older Chromium without sidePanel support falls back to the overlay.
+      if (chrome.runtime.lastError) void openSnapPanel(state);
+    });
   });
 
   let launcherDrag = null;

--- a/extensions/browser-bookmarks/browser-extension/src/overlay/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/overlay/index.js
@@ -2876,15 +2876,54 @@ function beginEmbedTargeting(state, panel) {
   document.body.style.cursor = "crosshair";
 }
 
-async function openAssociatedContent(state, contentId, contentKind, runId) {
+// Corner placement for panels popped out of the side panel. The side panel
+// shows four quadrants during a tab drag; whichever the user drops on maps to
+// a corner of the page here. Sized to leave a comfortable margin so the panel
+// never sits flush against the viewport edge.
+function geometryForCorner(corner) {
+  const margin = 24;
+  const width = Math.min(460, Math.round(window.innerWidth * 0.42));
+  const height = Math.min(
+    Math.round(window.innerHeight * 0.62),
+    Math.max(320, Math.round(window.innerHeight * 0.5))
+  );
+  const left = margin;
+  const right = Math.max(margin, window.innerWidth - width - margin);
+  const top = margin;
+  const bottom = Math.max(margin, window.innerHeight - height - margin);
+  const positions = {
+    "top-left": { x: left, y: top },
+    "top-right": { x: right, y: top },
+    "bottom-left": { x: left, y: bottom },
+    "bottom-right": { x: right, y: bottom },
+  };
+  const position = positions[corner] || positions["top-right"];
+  return {
+    state: "open",
+    layoutMode: "floating",
+    dockSide: "right",
+    positionX: position.x,
+    positionY: position.y,
+    width,
+    height,
+    opacity: 1,
+    embeddedSelector: null,
+    metadata: {},
+  };
+}
+
+async function openAssociatedContent(state, contentId, contentKind, runId, corner) {
   // "embed" = any content type the embed shell can render (file, folder, visualization, etc.)
   const kind = contentKind === "external" ? "external" : contentKind === "note" ? "note" : "embed";
   // Workflow run deep-link: consumed once by openEmbedForPanel, which appends
   // ?run= so the embed viewer lands directly on that run's detail.
   state.pendingRunDeepLink = runId ? { contentId, runId } : null;
   const context = state.resourceContext;
-  const persisted =
-    context?.viewStates?.find((entry) => entry.contentId === contentId) || null;
+  // An explicit corner (popped out of the side panel) wins over any persisted
+  // geometry — the user just told us where they want it.
+  const persisted = corner
+    ? geometryForCorner(corner)
+    : context?.viewStates?.find((entry) => entry.contentId === contentId) || null;
   const source =
     (context?.associations || []).find((entry) => entry.content.id === contentId)?.content ||
     (context?.externalContents || []).find((entry) => entry.id === contentId) ||
@@ -3171,7 +3210,8 @@ function wireRootEvents(state) {
             state,
             message.payload?.contentId,
             message.payload?.contentKind || "external",
-            message.payload?.runId
+            message.payload?.runId,
+            message.payload?.corner
           );
           sendResponse?.({ ok: true });
         } catch (error) {

--- a/extensions/browser-bookmarks/browser-extension/src/panel/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/panel/index.js
@@ -122,6 +122,34 @@ window.addEventListener("message", (event) => {
       postPageContext(pendingPageContext);
       pendingPageContext = null;
     }
+    return;
+  }
+
+  // Pop-out: the panel asks for content to open as an overlay on the page.
+  // A drag can't cross from this document into the page, so the panel offers
+  // four quadrants instead and tells us which corner the user chose.
+  if (data.type === "open-overlay" && data.payload?.contentId) {
+    chrome.runtime.sendMessage(
+      {
+        type: "open-content-in-active-tab",
+        payload: {
+          contentId: data.payload.contentId,
+          contentKind: data.payload.contentKind || "embed",
+          corner: data.payload.corner,
+        },
+      },
+      () => {
+        // Overlay unavailable on this page (restricted URL, no content
+        // script) — surface it in the context bar rather than failing mute.
+        if (chrome.runtime.lastError) {
+          const previous = titleEl.textContent;
+          titleEl.textContent = "Can't open an overlay on this page";
+          setTimeout(() => {
+            titleEl.textContent = previous;
+          }, 2600);
+        }
+      }
+    );
   }
 });
 

--- a/extensions/browser-bookmarks/browser-extension/src/panel/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/panel/index.js
@@ -1,0 +1,194 @@
+/**
+ * Side-panel host script (BROWSER-REACH B1).
+ *
+ * The panel page is deliberately thin: a context bar (the only extension
+ * chrome) above an iframe hosting the app's /embed/panel mini-DG shell.
+ * Everything intelligent renders inside the iframe.
+ *
+ * C2 message envelope (versioned from day one):
+ *   out → iframe: {v:1, source:"dg-panel-host", type:"page-context", payload}
+ *   in  ← iframe: {v:1, source:"dg-panel-embed", type:"ready"}
+ * All outgoing postMessages target the EXACT app origin; all incoming
+ * messages are dropped unless event.origin matches it and event.source is
+ * our iframe (ShadowPrompt lesson: no wildcard origins, no source trust).
+ */
+
+const frame = document.getElementById("dg-panel-frame");
+const loadingState = document.getElementById("dg-state-loading");
+const unconfiguredState = document.getElementById("dg-state-unconfigured");
+const faviconEl = document.getElementById("dg-page-favicon");
+const titleEl = document.getElementById("dg-page-title");
+const firstRun = document.getElementById("dg-first-run");
+const firstRunDismiss = document.getElementById("dg-first-run-dismiss");
+const reloadBtn = document.getElementById("dg-panel-reload");
+
+const FIRST_RUN_KEY = "panelFirstRunSeenAt";
+
+let appOrigin = null;
+let frameReady = false;
+let pendingPageContext = null;
+
+function sendRuntimeMessage(message) {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(message, (response) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      if (!response?.ok) {
+        reject(new Error(response?.error || "Unknown error"));
+        return;
+      }
+      resolve(response.data);
+    });
+  });
+}
+
+function showState(el) {
+  for (const state of [loadingState, unconfiguredState]) {
+    state.dataset.active = state === el ? "true" : "false";
+  }
+  frame.style.display = el ? "none" : "block";
+}
+
+// ── Page context (active tab → context bar + iframe) ─────────────────────────
+
+function postPageContext(context) {
+  if (!frameReady || !appOrigin) {
+    pendingPageContext = context;
+    return;
+  }
+  frame.contentWindow?.postMessage(
+    {
+      v: 1,
+      source: "dg-panel-host",
+      type: "page-context",
+      payload: context,
+    },
+    appOrigin
+  );
+}
+
+function renderPageContext(tab) {
+  if (!tab) return;
+  const title = tab.title || tab.url || "";
+  titleEl.textContent = title;
+  titleEl.title = tab.url || "";
+  if (tab.favIconUrl && /^https?:/.test(tab.favIconUrl)) {
+    faviconEl.src = tab.favIconUrl;
+    faviconEl.style.display = "block";
+  } else {
+    faviconEl.style.display = "none";
+  }
+  postPageContext({
+    url: tab.url || "",
+    title,
+    faviconUrl: tab.favIconUrl || undefined,
+  });
+}
+
+async function refreshActiveTab() {
+  try {
+    const [tab] = await chrome.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+    renderPageContext(tab);
+  } catch {
+    // Restricted contexts (no active tab) — leave the bar as-is.
+  }
+}
+
+chrome.tabs.onActivated.addListener(() => void refreshActiveTab());
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tab?.active && (changeInfo.title || changeInfo.url || changeInfo.favIconUrl)) {
+    renderPageContext(tab);
+  }
+});
+
+// ── Iframe messaging (exact-origin, versioned envelope) ──────────────────────
+
+window.addEventListener("message", (event) => {
+  if (!appOrigin || event.origin !== appOrigin) return;
+  if (event.source !== frame.contentWindow) return;
+  const data = event.data;
+  if (!data || typeof data !== "object") return;
+  if (data.v !== 1 || data.source !== "dg-panel-embed") return;
+
+  if (data.type === "ready") {
+    frameReady = true;
+    showState(null);
+    if (pendingPageContext) {
+      postPageContext(pendingPageContext);
+      pendingPageContext = null;
+    }
+  }
+});
+
+// ── First-run tooltip (two-surface principle, decision #1) ───────────────────
+
+async function maybeShowFirstRun() {
+  const stored = await chrome.storage.local.get(FIRST_RUN_KEY);
+  if (stored[FIRST_RUN_KEY]) return;
+  firstRun.dataset.visible = "true";
+}
+
+firstRunDismiss.addEventListener("click", () => {
+  firstRun.dataset.visible = "false";
+  void chrome.storage.local.set({ [FIRST_RUN_KEY]: Date.now() });
+});
+
+// ── Boot ─────────────────────────────────────────────────────────────────────
+
+// The iframe stays hidden until its `load` event — which fires for ANY
+// document, including browser network-error pages — then swaps in atomically.
+// This kills the loading-label/iframe stacking and the boot layout shift.
+// The versioned `ready` message remains the signal that the real shell is up.
+frame.addEventListener("load", () => {
+  loadingState.dataset.active = "false";
+  frame.style.display = "block";
+});
+
+async function boot() {
+  frameReady = false;
+  showState(loadingState);
+
+  let config;
+  try {
+    config = await sendRuntimeMessage({ type: "get-config" });
+  } catch {
+    config = null;
+  }
+
+  if (!config?.appBaseUrl) {
+    showState(unconfiguredState);
+    return;
+  }
+
+  const baseUrl = config.appBaseUrl.replace(/\/$/, "");
+  appOrigin = new URL(baseUrl).origin;
+
+  // Same session flow as the overlay: fetch an embed session token BEFORE
+  // setting src so ?_t= is present when the page loads (cross-site-cookie
+  // fallback for browsers that block the /embed cookie in iframes).
+  let sessionToken = null;
+  try {
+    const session = await sendRuntimeMessage({ type: "refresh-embed-session" });
+    sessionToken = session?.sessionToken || session?.token || null;
+  } catch {
+    // Cookie path may still work; load without the token.
+  }
+
+  const panelUrl = new URL(`${baseUrl}/embed/panel`);
+  if (sessionToken) panelUrl.searchParams.set("_t", sessionToken);
+  // Hidden until the `load` listener swaps it in — no stacked states.
+  frame.style.display = "none";
+  frame.src = panelUrl.toString();
+
+  void refreshActiveTab();
+  void maybeShowFirstRun();
+}
+
+reloadBtn.addEventListener("click", () => void boot());
+
+void boot();

--- a/extensions/workplaces/shell/WorkplacesShellNavigationTrailingControls.tsx
+++ b/extensions/workplaces/shell/WorkplacesShellNavigationTrailingControls.tsx
@@ -1,50 +1,193 @@
 "use client";
 
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CircleX } from "lucide-react";
 import { toast } from "sonner";
 import { useWorkspaceStore } from "@/extensions/workplaces/state/workspace-store";
-import { useContentStore } from "@/state/content-store";
+import {
+  useContentStore,
+  getVisiblePaneIds,
+  getPaneLabel,
+  type WorkspacePaneId,
+} from "@/state/content-store";
+
+/**
+ * Clear-tabs control.
+ *
+ * Click        → clear every tab in the workplace (the common case).
+ * Hold (250ms) → menu of targets: each visible pane individually, or all panes.
+ *
+ * The hold-for-options gesture mirrors the back button's hold-for-history in
+ * MainPanelNavigation, so the whole navigation bar shares one interaction
+ * grammar: tap does the obvious thing, hold reveals the choices.
+ */
+
+const HOLD_THRESHOLD_MS = 250;
 
 export function WorkplacesShellNavigationTrailingControls() {
   const clearAllWorkspaceTabs = useContentStore(
     (state) => state.clearAllWorkspaceTabs
   );
+  const closeContentTab = useContentStore((state) => state.closeContentTab);
   const workspaceTabCount = useContentStore(
     (state) => Object.keys(state.tabs).length
   );
+  const layoutMode = useContentStore((state) => state.layoutMode);
+  const panes = useContentStore((state) => state.panes);
   const persistActiveWorkspace = useWorkspaceStore(
     (state) => state.persistActiveWorkspace
   );
 
-  const handleClearWorkspaceTabs = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isHoldingRef = useRef(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const visiblePaneIds = getVisiblePaneIds(layoutMode);
+  const isMultiPane = visiblePaneIds.length > 1;
+
+  const persist = useCallback(
+    (message: string) => {
+      void persistActiveWorkspace()
+        .then(() => toast.success(message))
+        .catch((error) => {
+          console.error(
+            "[WorkplacesShellNavigationTrailingControls] Failed to persist cleared workplace:",
+            error
+          );
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Failed to persist cleared workplace tabs"
+          );
+        });
+    },
+    [persistActiveWorkspace]
+  );
+
+  const clearAll = useCallback(() => {
     if (workspaceTabCount === 0) return;
     clearAllWorkspaceTabs();
-    void persistActiveWorkspace()
-      .then(() => {
-        toast.success("Cleared all workplace tabs");
-      })
-      .catch((error) => {
-        console.error(
-          "[WorkplacesShellNavigationTrailingControls] Failed to persist cleared workplace:",
-          error
-        );
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : "Failed to persist cleared workplace tabs"
-        );
-      });
+    persist("Cleared all workplace tabs");
+  }, [clearAllWorkspaceTabs, persist, workspaceTabCount]);
+
+  const clearPane = useCallback(
+    (paneId: WorkspacePaneId) => {
+      const tabIds = panes[paneId]?.tabIds ?? [];
+      if (tabIds.length === 0) return;
+      // Snapshot first: closeContentTab mutates the pane's tabIds as it goes.
+      [...tabIds].forEach((tabId) => closeContentTab(tabId));
+      persist(`Cleared ${getPaneLabel(layoutMode, paneId).toLowerCase()}`);
+    },
+    [closeContentTab, layoutMode, panes, persist]
+  );
+
+  useEffect(() => {
+    if (!isMenuOpen) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (menuRef.current?.contains(target)) return;
+      if (buttonRef.current?.contains(target)) return;
+      setIsMenuOpen(false);
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [isMenuOpen]);
+
+  useEffect(() => {
+    return () => {
+      if (holdTimerRef.current) clearTimeout(holdTimerRef.current);
+    };
+  }, []);
+
+  const handleMouseDown = () => {
+    if (workspaceTabCount === 0) return;
+    isHoldingRef.current = true;
+    holdTimerRef.current = setTimeout(() => {
+      if (isHoldingRef.current) setIsMenuOpen(true);
+    }, HOLD_THRESHOLD_MS);
+  };
+
+  const handleMouseUp = () => {
+    if (holdTimerRef.current) {
+      clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+    // A short press that didn't open the menu is the plain "clear all" action.
+    if (!isMenuOpen && isHoldingRef.current) clearAll();
+    isHoldingRef.current = false;
+  };
+
+  const handleMouseLeave = () => {
+    if (holdTimerRef.current) {
+      clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+    isHoldingRef.current = false;
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleClearWorkspaceTabs}
-      disabled={workspaceTabCount === 0}
-      className="inline-flex items-center justify-center rounded-md border border-white/10 p-1.5 text-gray-500 transition-colors hover:bg-black/5 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-35 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-red-400"
-      title="Clear all tabs in this workplace"
-    >
-      <CircleX className="h-3.5 w-3.5" />
-    </button>
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
+        disabled={workspaceTabCount === 0}
+        className="inline-flex items-center justify-center rounded-md border border-white/10 p-1.5 text-gray-500 transition-colors hover:bg-black/5 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-35 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-red-400"
+        title={
+          isMultiPane
+            ? "Clear all tabs — hold to choose a pane"
+            : "Clear all tabs — hold for options"
+        }
+      >
+        <CircleX className="h-3.5 w-3.5" />
+      </button>
+
+      {isMenuOpen && (
+        <div
+          ref={menuRef}
+          className="absolute right-0 top-full z-50 mt-2 min-w-52 rounded-md border border-white/10 bg-white/95 p-1 shadow-lg backdrop-blur-sm dark:bg-gray-900/95"
+        >
+          <div className="px-2.5 py-1.5 text-[10px] uppercase tracking-[0.18em] text-gray-500">
+            Clear tabs
+          </div>
+
+          {isMultiPane &&
+            visiblePaneIds.map((paneId) => {
+              const count = panes[paneId]?.tabIds.length ?? 0;
+              return (
+                <button
+                  key={paneId}
+                  type="button"
+                  disabled={count === 0}
+                  onClick={() => {
+                    clearPane(paneId);
+                    setIsMenuOpen(false);
+                  }}
+                  className="flex w-full items-center justify-between gap-3 rounded px-2.5 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-black/5 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-200 dark:hover:bg-white/5 dark:hover:text-white"
+                >
+                  <span>{getPaneLabel(layoutMode, paneId)}</span>
+                  <span className="text-xs text-gray-400">{count}</span>
+                </button>
+              );
+            })}
+
+          <button
+            type="button"
+            onClick={() => {
+              clearAll();
+              setIsMenuOpen(false);
+            }}
+            className="flex w-full items-center justify-between gap-3 rounded px-2.5 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-red-500/10 hover:text-red-600 dark:text-gray-200 dark:hover:bg-red-500/10 dark:hover:text-red-400"
+          >
+            <span>{isMultiPane ? "All panes" : "All tabs"}</span>
+            <span className="text-xs text-gray-400">{workspaceTabCount}</span>
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/lib/domain/browser-extension/embed-message-origins.ts
+++ b/lib/domain/browser-extension/embed-message-origins.ts
@@ -1,0 +1,39 @@
+/**
+ * Embed message-origin validation (BROWSER-REACH C2 hardening).
+ *
+ * Embed pages run inside iframes hosted by two classes of parent:
+ *   1. The extension's side-panel page — origin `chrome-extension://<id>`
+ *   2. The in-page overlay — origin is the host webpage (unknowable in advance)
+ *
+ * postMessage listeners in embed clients must validate `event.origin` before
+ * acting. Policy (ShadowPrompt lesson — no wildcard origins):
+ *   - same-origin messages are always allowed (the app talking to itself)
+ *   - chrome-extension origins are allowed only if they match the configured
+ *     allowlist (`NEXT_PUBLIC_EMBED_EXTENSION_IDS`, comma-separated IDs)
+ *   - when the allowlist is unset (dev / not yet configured), any
+ *     structurally-valid chrome-extension origin is accepted so local
+ *     unpacked installs work; configure the env var in production.
+ */
+
+/** Chromium extension IDs are exactly 32 chars drawn from a–p. */
+const CHROME_EXTENSION_ORIGIN_RE = /^chrome-extension:\/\/[a-p]{32}$/;
+
+export function getAllowedExtensionOrigins(): string[] | null {
+  const raw = process.env.NEXT_PUBLIC_EMBED_EXTENSION_IDS;
+  if (!raw?.trim()) return null;
+  return raw
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean)
+    .map((id) => `chrome-extension://${id}`);
+}
+
+export function isAllowedEmbedMessageOrigin(origin: string): boolean {
+  if (typeof window !== "undefined" && origin === window.location.origin) {
+    return true;
+  }
+  if (!CHROME_EXTENSION_ORIGIN_RE.test(origin)) return false;
+  const allowlist = getAllowedExtensionOrigins();
+  if (allowlist === null) return true;
+  return allowlist.includes(origin);
+}

--- a/lib/domain/browser-extension/panel-bridge.ts
+++ b/lib/domain/browser-extension/panel-bridge.ts
@@ -1,0 +1,54 @@
+/**
+ * Panel → extension bridge (BROWSER-REACH C2, app side).
+ *
+ * The side panel is an iframe inside an extension page. Anything that has to
+ * happen *on the web page* — opening an overlay, for instance — must be asked
+ * for through the panel host, which relays to the background service worker.
+ *
+ * Everything here is a no-op outside the panel, so callers can wire these
+ * affordances unconditionally and let the surface decide.
+ */
+
+export type OverlayCorner =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
+
+export const OVERLAY_CORNERS: OverlayCorner[] = [
+  "top-left",
+  "top-right",
+  "bottom-left",
+  "bottom-right",
+];
+
+/** True when this document is the extension side panel's embed. */
+export function isPanelEmbedSurface(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.location.pathname.startsWith("/embed/panel");
+}
+
+/**
+ * Ask the extension to open `contentId` as an overlay on the current page.
+ * `corner` is where on the page it should land — the panel's four quadrants
+ * map onto it, since a drag can't cross from the panel into the page.
+ */
+export function requestOverlayOpen(
+  contentId: string,
+  options: { corner?: OverlayCorner; contentKind?: string } = {}
+): void {
+  if (!isPanelEmbedSurface()) return;
+  window.parent.postMessage(
+    {
+      v: 1,
+      source: "dg-panel-embed",
+      type: "open-overlay",
+      payload: {
+        contentId,
+        corner: options.corner ?? "top-right",
+        contentKind: options.contentKind ?? "embed",
+      },
+    },
+    "*"
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -98,7 +98,15 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        // Embed routes are loaded inside the browser extension iframe
+        // Embed routes are loaded inside the browser extension iframe — both
+        // the in-page overlay (ancestor = any web page) and the side panel
+        // (ancestor = chrome-extension://<id>).
+        //
+        // CSP subtlety: `frame-ancestors *` matches ONLY network schemes
+        // (http/https/ws/wss) — custom schemes like chrome-extension:// must
+        // be listed explicitly or the side panel gets ERR_BLOCKED_BY_RESPONSE.
+        // When NEXT_PUBLIC_EMBED_EXTENSION_IDS is set, only those extension
+        // origins may frame embeds; unset (dev) allows any extension.
         source: "/embed/:path*",
         headers: [
           {
@@ -110,7 +118,14 @@ const nextConfig: NextConfig = {
               "img-src 'self' data: https: blob:",
               "connect-src 'self' http: https: wss: ws:",
               "frame-src https://embed.diagrams.net https://*.diagrams.net",
-              "frame-ancestors *",
+              `frame-ancestors * ${
+                process.env.NEXT_PUBLIC_EMBED_EXTENSION_IDS?.trim()
+                  ? process.env.NEXT_PUBLIC_EMBED_EXTENSION_IDS.split(",")
+                      .map((id) => `chrome-extension://${id.trim()}`)
+                      .filter((s) => s !== "chrome-extension://")
+                      .join(" ")
+                  : "chrome-extension:"
+              }`,
             ].join("; "),
           },
         ],

--- a/scripts/build-extension.mjs
+++ b/scripts/build-extension.mjs
@@ -38,6 +38,14 @@ await Promise.all([
     outfile: path.join(outDir, "popup.js"),
   }),
 
+  // Side panel — IIFE (extension page hosting the /embed/panel iframe)
+  esbuild.build({
+    ...sharedOptions,
+    format: "iife",
+    entryPoints: [path.join(srcDir, "panel/index.js")],
+    outfile: path.join(outDir, "panel.js"),
+  }),
+
   // Overlay content script — IIFE (content scripts share scope, must not leak top-level vars)
   esbuild.build({
     ...sharedOptions,

--- a/server/hocuspocus/server.ts
+++ b/server/hocuspocus/server.ts
@@ -59,6 +59,20 @@ function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * Sentinel thrown by sendJsonAndStop to halt Hocuspocus's onRequest pipeline
+ * after we've written a response ourselves.
+ *
+ * It is a named class rather than the previous `throw null` so surrounding
+ * try/catch blocks can tell "I already answered this request" apart from a
+ * genuine failure. A catch that swallowed the old null signal double-wrote
+ * the response and crashed the process with ERR_HTTP_HEADERS_SENT on every
+ * /readyz probe (2026-07-20). Any catch around a send MUST rethrow this.
+ */
+class ResponseHandled {
+  readonly handled = true;
+}
+
 function sendJsonAndStop(
   response: onRequestPayload["response"],
   status: number,
@@ -69,7 +83,7 @@ function sendJsonAndStop(
     "Cache-Control": "no-store",
   });
   response.end(JSON.stringify(payload));
-  throw null;
+  throw new ResponseHandled();
 }
 
 async function handleHealthRequest(data: onRequestPayload) {
@@ -84,20 +98,27 @@ async function handleHealthRequest(data: onRequestPayload) {
   }
 
   if (url.pathname === "/readyz") {
+    // Scope the try to the DB probe ONLY — never wrap a sendJsonAndStop call,
+    // whose ResponseHandled sentinel must reach Hocuspocus uncaught.
+    let databaseError: unknown = null;
     try {
       await prisma.$queryRaw`SELECT 1`;
+    } catch (error) {
+      databaseError = error;
+    }
+    if (!databaseError) {
       sendJsonAndStop(data.response, 200, {
         ok: true,
         service: "digital-garden-hocuspocus",
         database: "ready",
         uptimeMs: Date.now() - startedAt,
       });
-    } catch (error) {
+    } else {
       sendJsonAndStop(data.response, 503, {
         ok: false,
         service: "digital-garden-hocuspocus",
         database: "unavailable",
-        error: getErrorMessage(error),
+        error: getErrorMessage(databaseError),
       });
     }
   }


### PR DESCRIPTION
First execution session of [BROWSER-REACH-PLAN.md](docs/notes-feature/work-tracking/BROWSER-REACH-PLAN.md), the browser half of the AI Infrastructure v3 split. Two collaboration fixes rode along because smoke-testing the panel surfaced them; both matter well beyond the extension.

## Sprint 1 — Collaboration fixes (highest value, independent of the extension)

- **Failed collab connections no longer steal the caret.** `useEditor`'s deps carried transient connection flags, so the first keystroke while disconnected destroyed and rebuilt the editor mid-edit. Deps reduced to `[editorMode]`; the autosave-skip decision moved to a ref; editability was already handled by the existing `setEditable` effect. Failure now degrades to a banner, exactly as the banner text promises.
- **`/readyz` no longer kills the Hocuspocus process.** `sendJsonAndStop` halts the pipeline by throwing after writing; that call sat inside the DB-failure `try`, so the catch swallowed its own stop-signal and double-wrote the response — `ERR_HTTP_HEADERS_SENT`, uncaught, process exit. Health checks were a kill shot on local *and* production. The `try` now scopes to the DB probe only, and the sentinel is a named `ResponseHandled` class instead of `throw null` so no future catch can swallow it silently.
- **CLAUDE.md** documents the dev collaboration topology (local dev needs its own Hocuspocus now that the dev DB is local Docker Postgres) and the Cloud Build footgun (it ships the working directory — deploy only from a checkout at `origin/main`).

**Gate:** `pnpm build` exit 0 · typecheck clean · lint 0 errors / 151 warnings (ratchet held) · local collab verified end-to-end after the fixes.

## Sprint 2 — App features

- **Recents** — Obsidian-style recently-viewed list on the left rail's clock. Aggregates the existing navigation-history store (all panes merged, deduped on newest visit, relative timestamps) rather than tracking its own state, so it persists across restarts for free.
- **Clear-tabs ⊗ gains a second level** — click still clears everything; hold 250ms opens a target menu with each visible pane and its tab count, plus all panes. Single-pane layouts skip the per-pane rows. Gesture and threshold match the back button's hold-for-history so the nav bar keeps one interaction grammar.
- **Freezable overlay panels (❆)** — toggle in the toolbar and on the collapsed chip; frozen panels bypass the hostname check on restore and follow the user across sites, open or minimized, until closed or unfrozen.

**Gate:** exercised in-app across single and split layouts; overlay freeze verified across a cross-site navigation.

## Sprint 3 — Browser Reach B1: the side panel

- **Launch handle opens a Chrome side panel** hosting the embed iframe on a new `/embed/panel` route: file tree, tabbed content workspace, and the multi-conversation chat surface at panel width. The extension contributes only a thin context bar (page pill, reload) — no chat or content UI of its own.
- **Panel chrome reduced deliberately**: navigation bar suppressed, workspace chooser relocated into the collapsible Files section via the shell-slot registry, single-pane enforced through the store's own `setLayoutMode` (no app-side overrides). First-run tooltip teaches the two-surface principle.
- **Security (ShadowPrompt lesson)**: versioned message envelope with exact-origin validation both directions; env-configurable extension-origin allowlist (`NEXT_PUBLIC_EMBED_EXTENSION_IDS`) that also drives `frame-ancestors` — CSP's `*` matches network schemes only, so the panel was blocked with `ERR_BLOCKED_BY_RESPONSE` until `chrome-extension:` was named explicitly.
- Overlay stays reachable via alt/shift-click, with automatic fallback on Chromium without `sidePanel`.

**Gate:** panel opens the mini-DG shell on dev and prod embed targets; tree → tab dispatch, chat, workspace chooser, and tree collapse all exercised in Vivaldi.

## Preflight

**Gates**
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors, 151 warnings (ratchet held at 175)
- [x] `pnpm build` exit 0
- [x] `pnpm extension:build` + reload verified in browser

**Collaboration**
- [x] Caret survives a failing/absent collab connection
- [x] `/readyz` probed repeatedly without killing the process
- [ ] Reviewer: confirm local `pnpm dev:collab` flow against Docker Postgres

**Browser extension**
- [x] Side panel opens from launch handle; embed loads on localhost + prod targets
- [x] Tree single-click opens a content tab; chat surface usable
- [x] Alt/shift-click still opens the legacy overlay
- [x] Reviewer: `pnpm extension:build` then reload at `chrome://extensions`

**App features**
- [x] Recents lists and reopens recently viewed content
- [x] ⊗ click clears all; hold opens the per-pane menu
- [x] ❆ freeze persists a panel across a cross-site navigation

**Post-merge (required)**
- [ ] **Redeploy Hocuspocus from a checkout at `origin/main`** — production still crashes on every `/readyz` probe until the fix ships: `gcloud builds submit --config cloudbuild.hocuspocus.yaml .`
- [ ] Verify `/readyz` twice in a row against the new revision
- [ ] Set `NEXT_PUBLIC_EMBED_EXTENSION_IDS` in production env once the extension ID is stable

**Known follow-ups (not in this PR)**
- Panel token promotion is `?_t=` only; extending the proxy's promotion prefix to `/embed/` is queued for B2
- Overlay message path can't be origin-validated by design (content scripts post from host-page origins) — needs an extension-minted handshake nonce, queued for B2/B3
- Workspace entity shape for B4 still needs verification against what core v3 shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)