### PR TITLE
fix(hocuspocus): restore the null stop-signal — production crashes on every /readyz probe

### DIFF
--- a/server/hocuspocus/server.ts
+++ b/server/hocuspocus/server.ts
@@ -60,19 +60,23 @@ function getErrorMessage(error: unknown) {
 }
 
 /**
- * Sentinel thrown by sendJsonAndStop to halt Hocuspocus's onRequest pipeline
- * after we've written a response ourselves.
+ * Writes a response and halts Hocuspocus's onRequest pipeline.
  *
- * It is a named class rather than the previous `throw null` so surrounding
- * try/catch blocks can tell "I already answered this request" apart from a
- * genuine failure. A catch that swallowed the old null signal double-wrote
- * the response and crashed the process with ERR_HTTP_HEADERS_SENT on every
- * /readyz probe (2026-07-20). Any catch around a send MUST rethrow this.
+ * `throw null` is REQUIRED here, not a shortcut. Hocuspocus's requestHandler
+ * does:
+ *
+ *     catch (error) { if (error) { throw error; } }   // Server.ts
+ *
+ * i.e. a *falsy* throw means "a hook already answered this request, stop the
+ * chain", and anything truthy is rethrown and crashes the process. Replacing
+ * this with a named sentinel class looked safer but was rethrown on every
+ * probe — do not "improve" it again.
+ *
+ * The companion rule: never wrap a call to this in a try that also handles
+ * real failures, or that catch will swallow the stop-signal and double-write
+ * the response (ERR_HTTP_HEADERS_SENT). Scope such trys to the fallible work
+ * itself — see /readyz below.
  */
-class ResponseHandled {
-  readonly handled = true;
-}
-
 function sendJsonAndStop(
   response: onRequestPayload["response"],
   status: number,
@@ -83,7 +87,7 @@ function sendJsonAndStop(
     "Cache-Control": "no-store",
   });
   response.end(JSON.stringify(payload));
-  throw new ResponseHandled();
+  throw null;
 }
 
 async function handleHealthRequest(data: onRequestPayload) {
@@ -99,7 +103,7 @@ async function handleHealthRequest(data: onRequestPayload) {
 
   if (url.pathname === "/readyz") {
     // Scope the try to the DB probe ONLY — never wrap a sendJsonAndStop call,
-    // whose ResponseHandled sentinel must reach Hocuspocus uncaught.
+    // whose null stop-signal must reach Hocuspocus uncaught.
     let databaseError: unknown = null;
     try {
       await prisma.$queryRaw`SELECT 1`;


### PR DESCRIPTION
**Production hotfix.** The `/readyz` crash fix in #115 didn't work, and made the crash unconditional. Verified against the live revision: repeated probes alternate success and empty-response with `uptimeMs` resetting each time — one process exit per probe.

## What went wrong

#115 replaced `throw null` with a named `ResponseHandled` sentinel, reasoning that a named class can't be silently swallowed by a `catch`. Hocuspocus's `requestHandler` ends with:

```js
catch (error) {
  // if a hook rejects and the error is empty, do nothing
  if (error) { throw error; }
}
```

A **falsy** throw is the documented "a hook already answered this request, stop the chain" signal. The sentinel was truthy, so every probe rethrew it, escaped `onRequest`, and exited the process — the same crash from the opposite direction.

## The fix

`throw null` restored, with the contract written down so it doesn't get "improved" again, plus the companion rule that was the *actual* original fix: never wrap a send in a `try` that also handles real failures, or that catch swallows the stop-signal and double-writes (`ERR_HTTP_HEADERS_SENT`). The `/readyz` try stays scoped to the database probe alone.

## Preflight

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors, 151 warnings (ratchet held)
- [ ] **Post-merge: redeploy Hocuspocus** from a checkout matching main — `gcloud builds submit --config cloudbuild.hocuspocus.yaml .`
- [ ] Verify with **five consecutive** `/readyz` probes: all succeed, `uptimeMs` increases monotonically (a single surviving instance)

Note for the deploy guard: `git rev-list --count HEAD..origin/main == 0` gives a false alarm on a just-merged branch (always ≥1 behind by its own merge commit). `git diff origin/main --quiet` is the check that matters for a directory-shipping build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)