### PR TITLE
chore(dev): minimal worktree/branch banner for dev builds

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import NavBar from "@/components/client/nav/NavBar";
 import { Toaster } from "@/components/client/ui/sonner";
 import { SettingsInitializer } from "@/components/settings/SettingsInitializer";
 import { ThemeProvider, THEME_SCRIPT } from "@/lib/features/theme";
+import { DevWorktreeBanner } from "@/lib/features/dev-banner";
 
 const geistSans = localFont({
   src: "../public/fonts/liberation-sans-regular.ttf",
@@ -165,6 +166,9 @@ export default async function RootLayout({
             closeButton
           />
         </ThemeProvider>
+        {/* Dev-only: names the worktree/branch this localhost is serving.
+            Renders nothing outside `next dev`. */}
+        <DevWorktreeBanner />
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ import NavBar from "@/components/client/nav/NavBar";
 import { Toaster } from "@/components/client/ui/sonner";
 import { SettingsInitializer } from "@/components/settings/SettingsInitializer";
 import { ThemeProvider, THEME_SCRIPT } from "@/lib/features/theme";
-import { DevWorktreeBanner } from "@/lib/features/dev-banner";
+import { DevWorktreeBanner, withDevWorktreeTitle } from "@/lib/features/dev-banner";
 
 const geistSans = localFont({
   src: "../public/fonts/liberation-sans-regular.ttf",
@@ -45,7 +45,10 @@ const geminiSans = Roboto({
   display: "swap",
 });
 
-export const metadata: Metadata = {
+// Base metadata for every route. Exported through `generateMetadata` (not a
+// static `metadata` const) so the title can be prefixed with the worktree/branch
+// in dev — Next forbids exporting both from one segment.
+const baseMetadata: Metadata = {
   title: {
     default: "Digital Garden",
     template: "%s · Digital Garden",
@@ -93,6 +96,16 @@ export const metadata: Metadata = {
   },
   manifest: "/site.webmanifest",
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  // Identical to baseMetadata in production; in dev the title gains a
+  // `[worktree/branch]` prefix so tabs from different checkouts are
+  // distinguishable. See lib/features/dev-banner/title.ts.
+  return {
+    ...baseMetadata,
+    title: await withDevWorktreeTitle(baseMetadata.title),
+  };
+}
 
 export const viewport: Viewport = {
   themeColor: "#ffffff",

--- a/lib/features/dev-banner/DevWorktreeBanner.tsx
+++ b/lib/features/dev-banner/DevWorktreeBanner.tsx
@@ -1,0 +1,56 @@
+import type { CSSProperties } from "react";
+
+import { composeWorktreeLabel, getWorktreeIdentity } from "./identity";
+
+/**
+ * Styles are inline rather than Tailwind classes on purpose. This component gets
+ * cherry-picked across every active worktree, each sitting at a different commit
+ * with a potentially different Tailwind/globals.css state. Inline styles have no
+ * build-time dependency at all, so the banner renders identically everywhere it
+ * lands — including on branches predating any given design-token change.
+ *
+ * Mid-grey at low opacity reads on both the light and dark shells without the
+ * component needing to know anything about the theme.
+ */
+const BANNER_STYLE: CSSProperties = {
+  position: "fixed",
+  bottom: 0,
+  left: 0,
+  // Above every app layer (modals top out far below this) but under the
+  // 2147483647 ceiling, leaving headroom for devtools overlays.
+  zIndex: 2147483000,
+  padding: "2px 7px",
+  borderTopRightRadius: 4,
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+  fontSize: 10,
+  lineHeight: 1.5,
+  letterSpacing: "0.02em",
+  color: "rgba(128, 128, 128, 0.95)",
+  background: "rgba(128, 128, 128, 0.14)",
+  backdropFilter: "blur(4px)",
+  WebkitBackdropFilter: "blur(4px)",
+  // Never intercept a click, a drag, or a text selection — the banner sits over
+  // real UI and must be incapable of getting in the way.
+  pointerEvents: "none",
+  userSelect: "none",
+  whiteSpace: "nowrap",
+};
+
+/**
+ * Dev-only marker naming the worktree/branch this localhost is serving.
+ *
+ * Returns null before touching the filesystem in any non-development build, so
+ * production pages neither render it nor bail out of static generation.
+ */
+export async function DevWorktreeBanner() {
+  if (process.env.NODE_ENV !== "development") return null;
+
+  const identity = await getWorktreeIdentity();
+  if (!identity) return null;
+
+  return (
+    <div aria-hidden style={BANNER_STYLE}>
+      {composeWorktreeLabel(identity)}
+    </div>
+  );
+}

--- a/lib/features/dev-banner/identity.ts
+++ b/lib/features/dev-banner/identity.ts
@@ -1,0 +1,105 @@
+/**
+ * Resolves which checkout the running dev server belongs to, by reading git's
+ * on-disk plumbing directly rather than shelling out to `git`.
+ *
+ * Reading files instead of spawning a process matters here: this runs inside
+ * the root layout on every dev request, and a `child_process` spawn per render
+ * would be both slow and a nuisance under Turbopack's module graph. The two
+ * files involved (`.git` and `HEAD`) are a few dozen bytes each.
+ *
+ * Nothing here is cached across requests on purpose — switching branches in a
+ * checkout must be reflected on the next page load without restarting `next dev`.
+ * React's `cache()` only dedupes within a single render pass.
+ */
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { cache } from "react";
+
+export type WorktreeIdentity = {
+  /**
+   * Directory name of the checkout — the linked-worktree name (e.g. `browser-reach`)
+   * or the repository directory for the main checkout (e.g. `Digital-Garden`).
+   */
+  directory: string;
+  /** Branch name, or `detached@<sha>` when HEAD is not on a branch. */
+  branch: string;
+  /** True when this checkout is a linked worktree rather than the main one. */
+  isLinkedWorktree: boolean;
+};
+
+/**
+ * The main checkout has `.git` as a directory. A linked worktree has `.git` as a
+ * FILE containing `gitdir: /abs/path/to/main/.git/worktrees/<name>` — and that
+ * per-worktree directory is where its own HEAD lives. Reading the main repo's
+ * `.git/HEAD` from a worktree would report the wrong branch entirely.
+ */
+async function resolveGitDir(
+  root: string,
+): Promise<{ gitDir: string; isLinkedWorktree: boolean } | null> {
+  const dotGit = path.join(root, ".git");
+
+  let entry;
+  try {
+    entry = await stat(dotGit);
+  } catch {
+    return null; // not a git checkout — degrade to no banner
+  }
+
+  if (entry.isDirectory()) {
+    return { gitDir: dotGit, isLinkedWorktree: false };
+  }
+
+  const pointer = (await readFile(dotGit, "utf8")).trim();
+  const match = /^gitdir:\s*(.+)$/.exec(pointer);
+  if (!match) return null;
+
+  return { gitDir: path.resolve(root, match[1]), isLinkedWorktree: true };
+}
+
+async function readBranch(gitDir: string): Promise<string | null> {
+  let head: string;
+  try {
+    head = (await readFile(path.join(gitDir, "HEAD"), "utf8")).trim();
+  } catch {
+    return null;
+  }
+
+  const ref = /^ref:\s*refs\/heads\/(.+)$/.exec(head);
+  if (ref) return ref[1];
+
+  // Detached HEAD stores the raw commit sha instead of a symbolic ref.
+  return /^[0-9a-f]{40}$/.test(head) ? `detached@${head.slice(0, 7)}` : null;
+}
+
+export const getWorktreeIdentity = cache(
+  async (): Promise<WorktreeIdentity | null> => {
+    const root = process.cwd();
+    const git = await resolveGitDir(root);
+    if (!git) return null;
+
+    const branch = await readBranch(git.gitDir);
+    if (!branch) return null;
+
+    return {
+      directory: path.basename(root),
+      branch,
+      isLinkedWorktree: git.isLinkedWorktree,
+    };
+  },
+);
+
+/**
+ * Builds the single line of text the banner shows.
+ *
+ * Git guarantees one branch per worktree, so the branch alone is already a
+ * unique identifier — the directory is added only when it carries information
+ * the branch name doesn't. Hence:
+ *   - main checkout                                    → `feat/tone-system`
+ *   - worktree `folder-studio` on `worktree-folder-studio` → `worktree-folder-studio`
+ *   - worktree `browser-reach` on `chore/pin-hocuspocus`   → `browser-reach · chore/pin-hocuspocus`
+ */
+export function composeWorktreeLabel(identity: WorktreeIdentity): string {
+  if (!identity.isLinkedWorktree) return identity.branch;
+  if (identity.branch.includes(identity.directory)) return identity.branch;
+  return `${identity.directory} · ${identity.branch}`;
+}

--- a/lib/features/dev-banner/index.ts
+++ b/lib/features/dev-banner/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Server-only — reads git plumbing off disk. Do not import from a
+ * `"use client"` module.
+ */
+export { DevWorktreeBanner } from "./DevWorktreeBanner";
+export { composeWorktreeLabel, getWorktreeIdentity } from "./identity";
+export type { WorktreeIdentity } from "./identity";

--- a/lib/features/dev-banner/index.ts
+++ b/lib/features/dev-banner/index.ts
@@ -5,3 +5,4 @@
 export { DevWorktreeBanner } from "./DevWorktreeBanner";
 export { composeWorktreeLabel, getWorktreeIdentity } from "./identity";
 export type { WorktreeIdentity } from "./identity";
+export { withDevWorktreeTitle } from "./title";

--- a/lib/features/dev-banner/title.ts
+++ b/lib/features/dev-banner/title.ts
@@ -1,0 +1,44 @@
+import type { Metadata } from "next";
+
+import { composeWorktreeLabel, getWorktreeIdentity } from "./identity";
+
+type RootTitle = { default: string; template: string };
+
+function isRootTitle(title: Metadata["title"]): title is RootTitle {
+  return (
+    typeof title === "object" &&
+    title !== null &&
+    "default" in title &&
+    "template" in title
+  );
+}
+
+/**
+ * Dev-only: prefix the browser-tab title with the worktree/branch label so tabs
+ * from different checkouts are distinguishable at a glance.
+ *
+ * The root metadata title is `{ default, template }`. Both slots must be
+ * prefixed, not just `template`: `template` only wraps titles that *child*
+ * routes supply, while `default` is what renders when a route supplies none
+ * (the content IDE, for one). Prefixing both is what makes the tag appear on
+ * every route — safe precisely because nothing in the app mutates
+ * `document.title` at runtime to clobber it.
+ *
+ * Returns the title untouched outside development, or if the checkout can't be
+ * identified, so production titles are byte-for-byte unchanged.
+ */
+export async function withDevWorktreeTitle(
+  title: Metadata["title"],
+): Promise<Metadata["title"]> {
+  if (process.env.NODE_ENV !== "development") return title;
+  if (!isRootTitle(title)) return title;
+
+  const identity = await getWorktreeIdentity();
+  if (!identity) return title;
+
+  const tag = `[${composeWorktreeLabel(identity)}]`;
+  return {
+    default: `${tag} ${title.default}`,
+    template: `${tag} ${title.template}`,
+  };
+}


### PR DESCRIPTION
## Sprint — Dev worktree banner + tab-title prefix

Running several worktrees at once means several localhosts, and nothing on the page or in the tab strip says which is which. Two dev-only signals, both no-ops outside `next dev`:

### 1 — Corner banner
Grey, `pointer-events: none` marker in the bottom-left naming the checkout it serves.
- **Branch read from git plumbing**, not a spawned `git`: `.git` (dir → main checkout, file → `gitdir:` pointer → linked worktree), then that dir's `HEAD`. Reading the main repo's HEAD from a worktree would report the wrong branch — the exact confusion this fixes.
- **Uncached across requests** (`react/cache` dedupes within a render only) → branch switches show on the next page load, no `next dev` restart. Also hot-reloads into a running server.
- **Inline styles, not Tailwind** — the commit cherry-picks across ~12 branches at divergent design-token state and renders identically.

### 2 — Browser-tab title prefix
The tab title now starts with `[worktree/branch]` in dev, ahead of the usual route title, e.g. `[browser-reach · chore/pin-hocuspocus-region] Contact · Digital Garden`.
- Root `metadata` const → async `generateMetadata` (Next forbids exporting both); every other metadata field passes through untouched.
- **Both** title slots prefixed — `template` (child-route titles) and `default` (routes that set none, e.g. the content IDE) — so the tag shows on every route. Safe because nothing in the app writes `document.title` at runtime to clobber it.
- Server-rendered into the initial `<title>`, so the tab is labelled before hydration. Production titles are byte-for-byte unchanged.

**Label rule** (shared by both): branch alone when it's already unique (main checkout, or when the branch name contains the dir); `dir · branch` otherwise.

**Gate:** `pnpm typecheck` clean · `pnpm lint` 0 errors / 151 warnings (under the 159 ratchet) · both signals verified in served HTML (`<title>` on `/` and `/contact`) and screenshot-checked on white + dark shells; banner live-reloaded into a running worktree dev server with the correct linked-worktree label.

### Files
- `lib/features/dev-banner/identity.ts` — git-plumbing resolver + label composer
- `lib/features/dev-banner/DevWorktreeBanner.tsx` — server component, dev-gated
- `lib/features/dev-banner/title.ts` — dev-only title prefixer
- `lib/features/dev-banner/index.ts` — barrel (server-only)
- `app/layout.tsx` — banner mount + `generateMetadata`

### Pre-merge checklist
- [x] `pnpm typecheck`
- [x] `pnpm lint` (no new warnings)
- [x] Banner + tab title verified in browser, both themes
- [ ] No migrations / no schema changes (n/a)
- [ ] Post-merge: new branches inherit both signals; the already-cherry-picked worktrees become redundant history (harmless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)