### PR TITLE
feat(site-pages): About as a composer-editable prose page

### DIFF
--- a/app/(public)/[...path]/page.tsx
+++ b/app/(public)/[...path]/page.tsx
@@ -66,10 +66,12 @@ async function renderPublic(
     }
 
     if (joined === "about") {
-      const { AboutPage } = await import(
-        "../../../components/personal/AboutPage"
-      );
-      return <AboutPage />;
+      const [{ AboutPage }, { fetchProseData }] = await Promise.all([
+        import("../../../components/personal/AboutPage"),
+        import("@/lib/domain/page-layout/resolve"),
+      ]);
+      const data = await fetchProseData(tenant.tenantId, "about", { draft });
+      return <AboutPage data={data ?? undefined} />;
     }
     if (joined === "results") {
       const [{ WorkResultsPage }, { fetchWorkData }] = await Promise.all([

--- a/components/personal/AboutPage.tsx
+++ b/components/personal/AboutPage.tsx
@@ -9,9 +9,27 @@
  * tree during CSR; client components bypass that serialization step entirely).
  */
 
+import { Fragment } from "react";
 import Link from "next/link";
 import { PersonalHeader } from "./PersonalHeader";
+import { Emphasis } from "@/components/common/Emphasis";
+import type { ProseData } from "@/lib/domain/page-layout/resolved";
+import { DEFAULT_ABOUT_DATA } from "@/lib/domain/page-layout/about-default";
 import "./personal-pages.css";
+
+/** Render a pull-quote string, turning newlines into <br>. */
+function AsideLines({ text }: { text: string }) {
+  return (
+    <>
+      {text.split("\n").map((line, i) => (
+        <Fragment key={i}>
+          {i > 0 && <br />}
+          {line}
+        </Fragment>
+      ))}
+    </>
+  );
+}
 
 /** Sinusoidal vine with leaf/bud nodes — drawn between sections. */
 function VineDivider({ marginTop }: { marginTop?: number }) {
@@ -37,7 +55,8 @@ function VineDivider({ marginTop }: { marginTop?: number }) {
   );
 }
 
-export function AboutPage() {
+export function AboutPage({ data }: { data?: ProseData }) {
+  const sections = (data ?? DEFAULT_ABOUT_DATA).sections;
   return (
     <div className="personal-home public-route personal-page">
       <PersonalHeader crumb="about" />
@@ -70,106 +89,33 @@ export function AboutPage() {
           and the connective tissue that helps teams move with less friction.
         </p>
 
-        <VineDivider marginTop={52} />
-
-        <div className="sec">
-          <div className="sec-content">
-            <span className="sec-kicker">The work</span>
-            <h2>
-              Structure in <em>motion.</em>
-            </h2>
-            <p>
-              I&apos;m drawn to the space where{" "}
-              <b>system design meets human coordination</b> — where the question
-              is not just what to build, but how the work itself should move.
-            </p>
-            <p>
-              At Doxy.me, that meant helping scale customer and revenue
-              operations through rapid growth: support systems, Intercom
-              automation, billing workflows, lifecycle messaging, usage-based
-              revenue, help-center architecture, and cross-functional process
-              design.
-            </p>
-            <p>
-              The thread through all of it is the same:{" "}
-              <b>the map has to match the territory</b>, or the system
-              eventually becomes fiction.
-            </p>
-          </div>
-          <aside className="sec-note" aria-hidden="true">
-            <span className="note-text">
-              every system is a theory
-              <br />
-              until the work
-              <br />
-              runs through it
-            </span>
-          </aside>
-        </div>
-
-        <VineDivider />
-
-        <div className="sec">
-          <div className="sec-content">
-            <span className="sec-kicker">Outside work</span>
-            <h2>
-              Actual <em>dirt.</em>
-            </h2>
-            <p>
-              I garden in the desert Southwest, where alkaline soil, intense
-              heat, and scarce water make{" "}
-              <b>every assumption visible.</b>
-            </p>
-            <p>
-              What started as a hobby has become a discipline in constraints:
-              shade, timing, amendment, irrigation, observation, and patience.
-            </p>
-            <p>
-              That instinct follows me back into my work. Good systems are{" "}
-              <b>grown as much as they are designed.</b>
-            </p>
-          </div>
-          <aside className="sec-note" aria-hidden="true">
-            <span className="note-text">
-              constraints are the design,
-              <br />
-              not the excuse
-            </span>
-          </aside>
-        </div>
-
-        <VineDivider />
-
-        <div className="sec">
-          <div className="sec-content">
-            <span className="sec-kicker">Right now</span>
-            <h2>
-              Building the <em>garden.</em>
-            </h2>
-            <p>
-              I&apos;m building davidvalentine.org as a{" "}
-              <b>digital garden</b>: a living record of projects, notes,
-              experiments, career artifacts, and things I&apos;m learning.
-            </p>
-            <p>
-              It is part portfolio, part workshop, part memory system —
-              organized less like a filing cabinet and more like a landscape:
-              roots, paths, branches, seasons, and the occasional useful weed.
-            </p>
-            <p>
-              For the professional trail, start with the{" "}
-              <b>résumé</b>. For the thinking behind it, browse the{" "}
-              <b>field notes</b>. To wander, enter the garden.
-            </p>
-          </div>
-          <aside className="sec-note" aria-hidden="true">
-            <span className="note-text">
-              gardens grow by relation,
-              <br />
-              not by hierarchy
-            </span>
-          </aside>
-        </div>
+        {sections.map((s, i) => (
+          <Fragment key={i}>
+            <VineDivider marginTop={i === 0 ? 52 : undefined} />
+            <div className="sec">
+              <div className="sec-content">
+                <span className="sec-kicker">
+                  <Emphasis text={s.kicker} />
+                </span>
+                <h2>
+                  <Emphasis text={s.heading} />
+                </h2>
+                {s.paragraphs.map((p, j) => (
+                  <p key={j}>
+                    <Emphasis text={p} />
+                  </p>
+                ))}
+              </div>
+              {s.aside && (
+                <aside className="sec-note" aria-hidden="true">
+                  <span className="note-text">
+                    <AsideLines text={s.aside} />
+                  </span>
+                </aside>
+              )}
+            </div>
+          </Fragment>
+        ))}
 
         <div className="ab-ctas">
           <Link className="ab-cta pri" href="/resume">

--- a/components/personal/personal-pages.css
+++ b/components/personal/personal-pages.css
@@ -78,7 +78,7 @@
 .personal-home .sec h2 em { font-style:italic; color:var(--accent-warm); font-weight:500; }
 .personal-home .sec p { font-family:var(--serif); font-size:18.5px; line-height:1.72; color:var(--text-soft); max-width:50ch; }
 .personal-home .sec p + p { margin-top:18px; }
-.personal-home .sec p b { color:var(--text); font-weight:600; }
+.personal-home .sec p b, .personal-home .sec p strong { color:var(--text); font-weight:600; }
 
 .personal-home .sec-note .note-text { font-family:var(--hand); font-size:18px; font-weight:500; color:var(--accent-warm); line-height:1.4; transform:rotate(-1.2deg); display:block; }
 .personal-home .sec-note .note-arrow { font-family:var(--hand); font-size:15px; color:color-mix(in srgb,var(--accent-warm) 65%,transparent); display:block; margin-top:4px; }

--- a/components/settings/site-pages/PreviewPane.tsx
+++ b/components/settings/site-pages/PreviewPane.tsx
@@ -17,6 +17,7 @@
 const PREVIEWABLE: Record<string, string> = {
   results: "/results",
   blog: "/blog",
+  about: "/about",
 };
 
 export function PreviewPane({

--- a/components/settings/site-pages/RowEditor.tsx
+++ b/components/settings/site-pages/RowEditor.tsx
@@ -270,7 +270,8 @@ export function ItemEditor({
 
   return (
     <div className="grid grid-cols-1 gap-3 border-t border-white/5 px-3 py-3 sm:grid-cols-2">
-      <TitleField item={item} inherited={inherited} set={set} />
+      {/* Prose paragraphs have no title — the blurb IS the paragraph. */}
+      {pageKind !== "prose" && <TitleField item={item} inherited={inherited} set={set} />}
 
       {pageKind === "record" && (
         <>
@@ -340,13 +341,33 @@ export function ItemEditor({
         </>
       )}
 
-      {(pageKind === "index" || pageKind === "prose") && (
+      {pageKind === "index" && (
         <>
           <OverridableText label="Subtitle" value={item.subtitle} placeholder="Optional secondary line" onChange={(v) => set("subtitle", v)} />
           <div className="flex items-end">
             <HiddenToggle item={item} set={set} />
           </div>
           <BlurbField item={item} inherited={inherited} set={set} />
+        </>
+      )}
+
+      {pageKind === "prose" && (
+        <>
+          <div className="flex flex-col gap-1 sm:col-span-2">
+            <span className="font-mono text-[10px] uppercase tracking-wider text-white/40">
+              Paragraph — wrap a phrase in **stars** to bold it
+            </span>
+            <textarea
+              aria-label="Paragraph"
+              className={`${inputCls} min-h-[80px] font-serif`}
+              value={item.blurb ?? ""}
+              placeholder="The paragraph text."
+              onChange={(e) => set("blurb", e.target.value === "" ? undefined : e.target.value)}
+            />
+          </div>
+          <div className="flex items-end">
+            <HiddenToggle item={item} set={set} />
+          </div>
         </>
       )}
     </div>

--- a/components/settings/site-pages/SectionCard.tsx
+++ b/components/settings/site-pages/SectionCard.tsx
@@ -171,7 +171,13 @@ export function SectionCard({
           aria-label={`${sectionNoun} heading`}
           className={`${inputCls} font-mono`}
           value={section.label}
-          placeholder={pageKind === "garden" ? "Category name" : "— Section heading"}
+          placeholder={
+            pageKind === "garden"
+              ? "Category name"
+              : pageKind === "prose"
+                ? "Section kicker (e.g. The work)"
+                : "— Section heading"
+          }
           onChange={(e) => onChange({ ...section, label: e.target.value })}
         />
         <label className="ml-1 font-mono text-[10px] uppercase tracking-wider text-white/40">Order</label>
@@ -214,10 +220,34 @@ export function SectionCard({
         </div>
       )}
 
+      {pageKind === "prose" && (
+        <div className="mb-3 grid gap-2">
+          <input
+            aria-label="Section heading"
+            className={`${inputCls} w-full font-serif`}
+            value={section.heading ?? ""}
+            placeholder="Heading — wrap a word in *stars* for accent (e.g. Structure in *motion.*)"
+            onChange={(e) => onChange({ ...section, heading: e.target.value || undefined })}
+          />
+          <textarea
+            aria-label="Margin note"
+            className={`${inputCls} w-full`}
+            rows={2}
+            value={section.aside ?? ""}
+            placeholder="Margin pull-quote (optional) — one line per row"
+            onChange={(e) => onChange({ ...section, aside: e.target.value || undefined })}
+          />
+        </div>
+      )}
+
       {/* items — nested under the section to signal the parent/child relationship */}
       <div className="ml-1.5 space-y-3 border-l-2 border-white/10 pl-4">
         <span className="block font-mono text-[9px] uppercase tracking-[0.16em] text-white/30">
-          {pageKind === "garden" ? "Items in this category" : "Rows in this section"}
+          {pageKind === "garden"
+            ? "Items in this category"
+            : pageKind === "prose"
+              ? "Paragraphs in this section"
+              : "Rows in this section"}
         </span>
         <ul className="divide-y divide-white/5 rounded-md border border-white/10 bg-black/15">
         {section.items.map((item, i) => {
@@ -251,7 +281,10 @@ export function SectionCard({
             );
           }
           const inherited = inheritedFor(item.ref);
-          const shownTitle = item.title ?? inherited?.title ?? "(untitled)";
+          const shownTitle =
+            pageKind === "prose"
+              ? (item.blurb?.slice(0, 80) || "(empty paragraph)")
+              : (item.title ?? inherited?.title ?? "(untitled)");
           const open = openRow === i;
           return (
             <li key={i} className={item.hidden ? "opacity-45" : undefined}>

--- a/components/settings/site-pages/defaults.ts
+++ b/components/settings/site-pages/defaults.ts
@@ -81,6 +81,7 @@ export function slugToSegment(slug: string): string {
 const PERSONAL_ROUTES: Record<string, { kind: PageKind; label: string }> = {
   results: { kind: "record", label: "Results / Work" },
   blog: { kind: "garden", label: "Field Notes" },
+  about: { kind: "prose", label: "About" },
 };
 
 export type RouteStatus = "wired" | "wrong-kind" | "home" | "unwired";

--- a/lib/domain/page-layout/about-default.ts
+++ b/lib/domain/page-layout/about-default.ts
@@ -1,0 +1,44 @@
+/**
+ * The canonical About narrative — the single source of truth for both the
+ * AboutPage fallback (when no SitePage config exists) and the seed script that
+ * mirrors it into an editable "about" SitePage. Server-safe (plain data).
+ *
+ * `heading` uses *accent* emphasis; paragraphs use **bold**; `aside` newlines
+ * render as <br>.
+ */
+import type { ProseData } from "./resolved";
+
+export const DEFAULT_ABOUT_DATA: ProseData = {
+  sections: [
+    {
+      kicker: "The work",
+      heading: "Structure in *motion.*",
+      paragraphs: [
+        "I'm drawn to the space where **system design meets human coordination** — where the question is not just what to build, but how the work itself should move.",
+        "At Doxy.me, that meant helping scale customer and revenue operations through rapid growth: support systems, Intercom automation, billing workflows, lifecycle messaging, usage-based revenue, help-center architecture, and cross-functional process design.",
+        "The thread through all of it is the same: **the map has to match the territory**, or the system eventually becomes fiction.",
+      ],
+      aside: "every system is a theory\nuntil the work\nruns through it",
+    },
+    {
+      kicker: "Outside work",
+      heading: "Actual *dirt.*",
+      paragraphs: [
+        "I garden in the desert Southwest, where alkaline soil, intense heat, and scarce water make **every assumption visible.**",
+        "What started as a hobby has become a discipline in constraints: shade, timing, amendment, irrigation, observation, and patience.",
+        "That instinct follows me back into my work. Good systems are **grown as much as they are designed.**",
+      ],
+      aside: "constraints are the design,\nnot the excuse",
+    },
+    {
+      kicker: "Right now",
+      heading: "Building the *garden.*",
+      paragraphs: [
+        "I'm building davidvalentine.org as a **digital garden**: a living record of projects, notes, experiments, career artifacts, and things I'm learning.",
+        "It is part portfolio, part workshop, part memory system — organized less like a filing cabinet and more like a landscape: roots, paths, branches, seasons, and the occasional useful weed.",
+        "For the professional trail, start with the **résumé**. For the thinking behind it, browse the **field notes**. To wander, enter the garden.",
+      ],
+      aside: "gardens grow by relation,\nnot by hierarchy",
+    },
+  ],
+};

--- a/lib/domain/page-layout/resolve.ts
+++ b/lib/domain/page-layout/resolve.ts
@@ -28,6 +28,7 @@ import type {
   WorkData,
   GardenData,
   GardenItem,
+  ProseData,
   ResolvedRecordEntry,
   ResolvedRecordSection,
   ResolvedTimelineEntry,
@@ -306,4 +307,31 @@ export async function fetchGardenData(
     };
   }
   return cats;
+}
+
+/**
+ * Resolve a prose page's editable body (About). Each section → a narrative
+ * block: `label` is the kicker, `heading` the h2, items' `blurb`s the
+ * paragraphs, `aside` the margin pull-quote. Hero/intro/CTAs stay in the
+ * component. Null when the page has no sections (component keeps its default).
+ */
+export async function fetchProseData(
+  tenantId: string,
+  slug: string,
+  opts?: ResolveOptions,
+): Promise<ProseData | null> {
+  const loaded = await loadPage(tenantId, slug, opts);
+  if (!loaded || loaded.config.sections.length === 0) return null;
+
+  return {
+    sections: loaded.config.sections.map((section) => ({
+      kicker: section.label,
+      heading: section.heading ?? "",
+      paragraphs: section.items
+        .filter((item) => !item.hidden)
+        .map((item) => item.blurb ?? "")
+        .filter((p) => p.trim().length > 0),
+      aside: section.aside,
+    })),
+  };
 }

--- a/lib/domain/page-layout/resolved.ts
+++ b/lib/domain/page-layout/resolved.ts
@@ -82,3 +82,18 @@ export interface GardenCategory {
 
 /** The full `window.CATS` object, keyed by category. */
 export type GardenData = Record<string, GardenCategory>;
+
+// ── Prose (About narrative) ──────────────────────────────────────────────────
+// The editable body sections of a prose page. Hero / intro / CTAs stay code.
+
+export interface ProseSection {
+  kicker: string; // emphasis string — the `sec-kicker`
+  heading: string; // emphasis string — the h2, e.g. "Structure in *motion.*"
+  paragraphs: string[]; // emphasis strings, each a <p>
+  aside?: string; // margin pull-quote; newlines render as <br>
+}
+
+/** What AboutPage renders for its editable body (hero/intro/CTAs stay code). */
+export interface ProseData {
+  sections: ProseSection[];
+}

--- a/lib/domain/page-layout/schema.ts
+++ b/lib/domain/page-layout/schema.ts
@@ -83,6 +83,10 @@ const listSection = z.object({
   // Garden only: does this category's leaf grow up (shoot) or down (root)?
   // Drives the `gl--root` engine class. Absent → "shoot". Ignored by other kinds.
   growth: z.enum(["shoot", "root"]).optional(),
+  // Prose only: the section's h2 (emphasis-aware) and its margin pull-quote.
+  // `label` is the kicker; items are paragraphs (each item's `blurb`).
+  heading: emphasisString.optional(),
+  aside: z.string().optional(),
   items: z.array(listItem).default([]),
 });
 

--- a/scripts/seed-about-page.ts
+++ b/scripts/seed-about-page.ts
@@ -1,0 +1,97 @@
+/**
+ * Seed / verify the About ("about") SitePage.
+ *
+ * Mirrors the canonical About narrative (lib/domain/page-layout/about-default)
+ * into a prose SitePage so /about becomes composer-editable while rendering
+ * identically. Each ProseSection → a listSection (kicker → label, heading,
+ * aside; each paragraph → an item's blurb). Hero / intro / CTAs stay in code.
+ *
+ *   npx tsx scripts/seed-about-page.ts --verify   # DB-free: validate + round-trip fidelity
+ *   npx tsx scripts/seed-about-page.ts            # upsert the about SitePage (needs DATABASE_URL)
+ */
+import { sitePageConfig } from "../lib/domain/page-layout/schema";
+import { DEFAULT_ABOUT_DATA } from "../lib/domain/page-layout/about-default";
+import type { Prisma } from "../lib/database/generated/prisma";
+
+/** ProseData → SitePage prose config (the shape the composer edits). */
+function proseToConfig(data: typeof DEFAULT_ABOUT_DATA) {
+  return {
+    sections: data.sections.map((s) => ({
+      label: s.kicker,
+      sort: "manual" as const,
+      heading: s.heading,
+      aside: s.aside,
+      items: s.paragraphs.map((p) => ({ blurb: p })),
+    })),
+  };
+}
+
+async function main() {
+  const verify = process.argv.includes("--verify");
+  const rawConfig = proseToConfig(DEFAULT_ABOUT_DATA);
+
+  // (1) Validate through the REAL Zod schema — proves the prose shape
+  // (heading + aside + paragraph blurbs) is accepted.
+  const parsed = sitePageConfig.parse(rawConfig);
+  console.log(`✓ config parses: ${parsed.sections.length} sections`);
+
+  if (verify) {
+    // (2) Round-trip: rebuild what fetchProseData emits and compare to the
+    // canonical narrative — kicker / heading / paragraphs / aside.
+    const problems: string[] = [];
+    DEFAULT_ABOUT_DATA.sections.forEach((orig, i) => {
+      const s = parsed.sections[i];
+      const paragraphs = s.items
+        .filter((it) => !it.hidden)
+        .map((it) => it.blurb ?? "")
+        .filter((p) => p.trim().length > 0);
+      if (s.label !== orig.kicker) problems.push(`#${i} kicker ${s.label} != ${orig.kicker}`);
+      if ((s.heading ?? "") !== orig.heading) problems.push(`#${i} heading mismatch`);
+      if ((s.aside ?? undefined) !== orig.aside) problems.push(`#${i} aside mismatch`);
+      if (paragraphs.length !== orig.paragraphs.length)
+        problems.push(`#${i} paragraph count ${paragraphs.length} != ${orig.paragraphs.length}`);
+      orig.paragraphs.forEach((p, j) => {
+        if (paragraphs[j] !== p) problems.push(`#${i}.${j} paragraph text mismatch`);
+      });
+    });
+    if (problems.length) {
+      console.error("✗ fidelity problems:\n  " + problems.join("\n  "));
+      process.exit(1);
+    }
+    const paras = parsed.sections.reduce((n, s) => n + s.items.length, 0);
+    console.log(`✓ round-trip fidelity: ${parsed.sections.length} sections, ${paras} paragraphs match the narrative`);
+    console.log("VERIFY PASS");
+    return;
+  }
+
+  // Seed mode — needs a DB.
+  const { prisma } = await import("../lib/database/client");
+  const anchor = await prisma.sitePage.findFirst({ where: { slug: "results" } });
+  const tenantId =
+    anchor?.tenantId ??
+    (await prisma.tenant.findFirst({ where: { isPersonal: true } }))?.id;
+  if (!tenantId) throw new Error("No target tenant (no results page, no personal tenant)");
+
+  const config = parsed as unknown as Prisma.InputJsonValue;
+  const page = await prisma.sitePage.upsert({
+    where: { tenantId_slug: { tenantId, slug: "about" } },
+    update: { draftConfig: config },
+    create: {
+      tenantId,
+      slug: "about",
+      title: "About",
+      kind: "prose",
+      visibility: "draft",
+      config,
+      draftConfig: config,
+    },
+  });
+  console.log(`✓ seeded about SitePage ${page.id} (tenant ${tenantId}) as DRAFT`);
+  console.log("  Preview it at /about?preview=draft, then Publish in the composer.");
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Makes the **About** page (`/about`) composer-editable — its 3 narrative body sections become a prose SitePage, while the hero, intro, and CTAs stay code-driven (the "editable body sections" scope).

## Why

Unlike Results (ledger) or Field Notes (garden), `/about` was **fully static** — `<AboutPage />` took no props, no config, no resolver. This wires the parts worth editing (the narrative) without forcing the bespoke chrome (hero, vine dividers, CTAs) into a generic model.

## Changes

- **Schema** — add `heading` (emphasis) + `aside` to `listSection`. Prose-only, Zod-only, **no migration** (JSON config shape); ignored by other page kinds.
- **Resolver** — `ProseData` view-model + `fetchProseData` (kicker = `label`, `heading`, paragraphs = item `blurb`s, `aside`), draft/publish-gated like `/results` and `/blog`.
- **AboutPage** — takes `data?` and falls back to a shared `DEFAULT_ABOUT_DATA` (single source of truth, also feeds the seed); renders via `<Emphasis>`.
- **CSS** — `.sec p strong` companion so `**bold**` paragraphs keep their weight (`<Emphasis>` emits `<strong>`; the design styled bare `<b>`).
- **Mount** — `/about` calls `fetchProseData` with owner-draft gating.
- **Composer** — `about → prose` route + live preview; a prose section block (heading + aside) in `SectionCard`, a paragraph editor in `RowEditor`, and prose-aware labels/row summaries.
- **Seed** (`scripts/seed-about-page.ts`) — mirrors the static About into an editable prose page; DB-free `--verify`.

## Verification

`npx tsx scripts/seed-about-page.ts --verify`:
- ✅ config parses through the **real** Zod schema — 3 sections
- ✅ round-trip fidelity — 3 sections, 9 paragraphs match the narrative (kicker / heading / paragraphs / aside)

Plus: typecheck clean, lint 151/0, full build exit 0. `schema.prisma` untouched.

## Adoption (your step — same as Field Notes)

Seeds as a **draft**, so public `/about` keeps the current static page until you publish:

```
DATABASE_URL=<prod> npx tsx scripts/seed-about-page.ts
```

Then `/about?preview=draft`, refine kicker/heading/paragraphs/aside in the composer, **Publish**.

## Note (pre-existing, not this PR)

`tsc` twice hit a **stale committed Prisma client** on `main` (missing `SitePage`, `SearchConnection`) — the build regenerates it so runtime is fine, but the checked-in generated client under `lib/database/generated/` is out of date. Worth either regenerating+committing it or fully untracking that dir (`git rm --cached`) since it's already gitignored.

---

## Pre-merge checklist

- [x] `--verify` fidelity pass (3 sections, 9 paragraphs)
- [x] typecheck clean · lint 151/0 · build exit 0
- [x] `schema.prisma` untouched (prose fields are JSON-config only — no migration)
- [ ] Seed against prod + confirm `/about?preview=draft`, then Publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
