### PR TITLE
AI v3.2 T5 — deterministic first-message chat titles

### DIFF
--- a/app/api/conversations/[id]/auto-title/route.ts
+++ b/app/api/conversations/[id]/auto-title/route.ts
@@ -18,7 +18,6 @@ import { prisma } from "@/lib/database/client";
 import {
   resolveFeatureRoute,
   executeWithFallback,
-  NoRoutesAvailableError,
 } from "@/lib/domain/ai/features";
 import { resolveChatModelFromConnection } from "@/lib/domain/ai/providers/registry";
 import { publishConversationEvent } from "@/lib/features/conversations/events";
@@ -76,105 +75,108 @@ export async function POST(request: NextRequest, context: RouteContext) {
         });
       }
 
-      // Resolve feature route. If nothing is configured AND no default
-      // suggestion matches the user's connections, silently skip.
-      const routes = await resolveFeatureRoute(
-        session.user.id,
-        "chat-title-generation",
-      );
-      if (routes.length === 0) {
+      // Deterministic fallback (T5): a concise title from the user's first
+      // message, so a URL-opened or sidebar chat ALWAYS gets a meaningful
+      // title without a manual rename — even when no `chat-title-generation`
+      // route is configured or the model call fails.
+      const fallbackTitle = buildFirstMessageTitle(extractText(userMsgs[0].parts));
+
+      const finalize = async (title: string, source: "ai" | "first_message") => {
+        await prisma.conversation.update({ where: { id }, data: { title } });
+        // Keep the backing chat ContentNode's title in sync (file tree +
+        // workspace tabs are ContentNode-driven) when archive-linked.
+        if (conv.archivedToContentNodeId) {
+          await prisma.contentNode.updateMany({
+            where: { id: conv.archivedToContentNodeId, ownerId: session.user.id },
+            data: { title },
+          });
+        }
+        publishConversationEvent(session.user.id, {
+          type: "conversation.updated",
+          conversationId: id,
+          title,
+          at: new Date().toISOString(),
+        });
+        logger.info({
+          layer: "ai",
+          event: "conv.auto_title",
+          summary: `auto-title set for ${id} (${source})`,
+          attrs: { conversation_id: id, title_chars: title.length, source },
+        });
         return NextResponse.json({
           success: true,
-          data: { title: null, skipped: true, reason: "no_route" },
+          data: { title, skipped: false, source },
+        });
+      };
+
+      // Prefer an AI-generated title when a route is configured; fall back to
+      // the deterministic first-message summary on ANY failure (no route
+      // configured, model error, or empty response).
+      let aiTitle = "";
+      try {
+        const routes = await resolveFeatureRoute(
+          session.user.id,
+          "chat-title-generation",
+        );
+        if (routes.length > 0) {
+          // Build a compact prompt from the first ~3 messages.
+          const conversationText = conv.messages
+            .map((m) => {
+              const text = extractText(m.parts);
+              if (!text) return null;
+              return `${m.role === "user" ? "User" : "Assistant"}: ${text.slice(0, 500)}`;
+            })
+            .filter(Boolean)
+            .join("\n\n");
+
+          const systemPrompt =
+            "You generate concise chat titles. Respond with ONLY a 3-5 word title in title case. No quotes, no punctuation, no markdown, no commentary.";
+
+          const generated = await withSpan(
+            { layer: "ai", name: "auto_title" },
+            { attrs: { conversation_id: id, route_count: routes.length } },
+            async () =>
+              executeWithFallback({
+                featureId: "chat-title-generation",
+                routes,
+                attempt: async ({ route }) => {
+                  const model = await resolveChatModelFromConnection(
+                    route.connection,
+                    route.modelId,
+                  );
+                  const { text } = await generateText({
+                    model,
+                    messages: [
+                      { role: "system", content: systemPrompt },
+                      { role: "user", content: conversationText },
+                    ],
+                    maxOutputTokens: 30,
+                  });
+                  return text;
+                },
+              }),
+          );
+          aiTitle = sanitizeTitle(generated);
+        }
+      } catch (aiError) {
+        // No route, or a model/connection failure — fall through to the
+        // deterministic fallback rather than leaving the chat untitled.
+        logger.warn({
+          layer: "ai",
+          event: "auto_title:ai_unavailable",
+          summary: `AI title unavailable for ${id} — using first-message fallback`,
+          error: aiError,
         });
       }
 
-      // Build a compact prompt from the first ~3 messages.
-      const conversationText = conv.messages
-        .map((m) => {
-          const text = extractText(m.parts);
-          if (!text) return null;
-          return `${m.role === "user" ? "User" : "Assistant"}: ${text.slice(0, 500)}`;
-        })
-        .filter(Boolean)
-        .join("\n\n");
-
-      const systemPrompt =
-        "You generate concise chat titles. Respond with ONLY a 3-5 word title in title case. No quotes, no punctuation, no markdown, no commentary.";
-
-      const generated = await withSpan(
-        { layer: "ai", name: "auto_title" },
-        {
-          attrs: {
-            conversation_id: id,
-            route_count: routes.length,
-          },
-        },
-        async () =>
-          executeWithFallback({
-            featureId: "chat-title-generation",
-            routes,
-            attempt: async ({ route }) => {
-              const model = await resolveChatModelFromConnection(
-                route.connection,
-                route.modelId,
-              );
-              const { text } = await generateText({
-                model,
-                messages: [
-                  { role: "system", content: systemPrompt },
-                  { role: "user", content: conversationText },
-                ],
-                maxOutputTokens: 30,
-              });
-              return text;
-            },
-          }),
-      );
-
-      const title = sanitizeTitle(generated);
+      const title = aiTitle || fallbackTitle;
       if (!title) {
         return NextResponse.json({
           success: true,
-          data: { title: null, skipped: true, reason: "empty_response" },
+          data: { title: null, skipped: true, reason: "no_content" },
         });
       }
-
-      await prisma.conversation.update({
-        where: { id },
-        data: { title },
-      });
-
-      // Keep the backing chat ContentNode's title in sync (file tree +
-      // workspace tabs are ContentNode-driven) when archive-linked.
-      if (conv.archivedToContentNodeId) {
-        await prisma.contentNode.updateMany({
-          where: {
-            id: conv.archivedToContentNodeId,
-            ownerId: session.user.id,
-          },
-          data: { title },
-        });
-      }
-
-      publishConversationEvent(session.user.id, {
-        type: "conversation.updated",
-        conversationId: id,
-        title,
-        at: new Date().toISOString(),
-      });
-
-      logger.info({
-        layer: "ai",
-        event: "conv.auto_title",
-        summary: `auto-title set for ${id}`,
-        attrs: { conversation_id: id, title_chars: title.length },
-      });
-
-      return NextResponse.json({
-        success: true,
-        data: { title, skipped: false },
-      });
+      return finalize(title, aiTitle ? "ai" : "first_message");
     } catch (error) {
       if (
         error instanceof Error &&
@@ -184,12 +186,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
           { success: false, error: "Unauthorized" },
           { status: 401 },
         );
-      }
-      if (error instanceof NoRoutesAvailableError) {
-        return NextResponse.json({
-          success: true,
-          data: { title: null, skipped: true, reason: "no_route" },
-        });
       }
       logger.error({
         layer: "ai",
@@ -243,4 +239,29 @@ function sanitizeTitle(raw: string): string {
     t = t.slice(0, MAX_TITLE_CHARS).trim();
   }
   return t;
+}
+
+const FALLBACK_TITLE_WORDS = 8;
+const FALLBACK_TITLE_CHARS = 48;
+
+/**
+ * Deterministic first-message-summary title (T5). The AI title route is the
+ * preferred source, but a URL-opened / quick chat must still get a meaningful
+ * title with no AI config and no manual rename — so we distill the user's
+ * first message: strip markdown lead-ins + quotes, keep the first handful of
+ * words, cap the length, drop trailing punctuation, capitalize. Returns "" if
+ * there's nothing titlable.
+ */
+function buildFirstMessageTitle(text: string): string {
+  let t = text.replace(/\s+/g, " ").trim();
+  t = t.replace(/^#{1,6}\s+/, "").replace(/^[-*+]\s+/, "");
+  t = t.replace(/[`*"'“”‘’]/g, "").trim();
+  if (!t) return "";
+  let title = t.split(" ").slice(0, FALLBACK_TITLE_WORDS).join(" ");
+  if (title.length > FALLBACK_TITLE_CHARS) {
+    title = title.slice(0, FALLBACK_TITLE_CHARS).trim();
+  }
+  title = title.replace(/[.,!?:;]+$/, "").trim();
+  if (!title) return "";
+  return title.charAt(0).toUpperCase() + title.slice(1);
 }

--- a/docs/notes-feature/work-tracking/AI-V3.2-PLAN.md
+++ b/docs/notes-feature/work-tracking/AI-V3.2-PLAN.md
@@ -281,15 +281,29 @@ stream needs a resumable-stream store (Redis-class).
 - **Gate:** reload mid-stream → the SAME in-flight response continues
   rendering live, not just the completed message on next load.
 
-## T5 — Conversation title strategy for quick URL chats
+## T5 — Conversation title strategy for quick URL chats ✅ BUILT (2026-07-23)
 
 Deferred S3-time call: page title vs. first-message summary for chats
 opened from a URL.
 
-- Decide + implement the title source for quick/URL-opened chats
-  (first-message summary is the likely answer; confirm at build).
-- **Gate:** a URL-opened chat gets a meaningful title without manual
-  rename, consistent with sidebar-created chats.
+- **Decision: first-message summary** (the plan's likely answer). Root
+  cause of the gap: `POST /api/conversations/[id]/auto-title` returned
+  `title: null, skipped: true` on `no_route` / `NoRoutesAvailableError` /
+  `empty_response` — so a chat with no `chat-title-generation` feature
+  route configured (or a model failure) got NO title at all.
+- **Built:** the route now computes a deterministic `buildFirstMessageTitle`
+  (first ~8 words / 48 chars of the user's first message, markdown-stripped,
+  capitalized) and falls back to it whenever the AI path is unavailable or
+  yields nothing. The AI title stays preferred when a route is configured;
+  the response carries `source: "ai" | "first_message"`. Server-only change;
+  the existing client trigger (`use-conversation-binding.ts`, after the first
+  assistant turn) already applies whatever title comes back. Both surfaces
+  (sidebar + full-page/URL) share that binding, so titling is now consistent.
+- **Gate:** MET — a URL-opened chat gets a meaningful title without a manual
+  rename, even with zero AI config.
+- Page-title-for-page-rooted-chats (browser panel "Ask about this page") was
+  considered and left out: first-message summary is universal and simpler;
+  revisit only if page-rooted chats want the page's title specifically.
 
 ## T6 — Acquisition explainer (owner walkthrough)
 


### PR DESCRIPTION
## Sprint 1 — T5: URL/quick chats always get a meaningful title

**The gap:** `POST /api/conversations/[id]/auto-title` returned `title: null, skipped: true` whenever the AI path couldn't run — `no_route` (no `chat-title-generation` feature route configured), `NoRoutesAvailableError`, or `empty_response`. A user with no title-generation model configured therefore got **untitled** chats and had to rename by hand. This hit URL/quick-opened chats and sidebar chats alike.

**Decision (per the plan):** first-message summary over page-title — it's universal and needs no AI config.

**Built:** the route now computes a deterministic `buildFirstMessageTitle` (first ~8 words / 48 chars of the user's first message, markdown/quote-stripped, capitalized) and falls back to it on *any* AI-path failure. The AI title stays preferred when a route is configured; the response reports `source: "ai" | "first_message"`. Server-only — the existing client trigger (`use-conversation-binding.ts`, fires after the first assistant turn and is shared by the sidebar + full-page/URL surfaces) applies whatever title comes back, so titling is now consistent across every surface.

- **Gate:** MET — a URL-opened chat gets a meaningful title without a manual rename, even with zero AI config.

## Pre-merge checklist

**Gates**
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors, baseline warnings (151)
- [x] `pnpm build` — full production build green (includes `playbooks:check` / `output-targets:check` / `markdown:blocks:check`)
- [x] Deterministic-title logic verified against representative inputs (cover-letter request, `##`-prefixed playbook cue, short question, `-` bullet, `**bold**` emphasis, whitespace-only)
- [x] Migration-free (no schema change)

**Manual smoke test**
- [x] With NO `chat-title-generation` route configured: start a chat, send one message, get a reply → the chat is auto-titled from your first message (not left "Untitled"), no manual rename
- [x] With a `chat-title-generation` route configured: same flow → the AI-generated 3–5 word title still wins (fallback not used)
- [x] Open a chat from a URL/quick entry → it gets a meaningful title consistent with a sidebar-created chat
- [x] A chat that already has a title is not re-titled (idempotent)
- [x] The backing chat ContentNode's tree/tab label updates to match the new title (archive-linked case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)