### PR TITLE
feat(browser-reach): B3-B — settle-then-associate + viewership Recents

### DIFF
--- a/app/embed/panel/PanelShellClient.tsx
+++ b/app/embed/panel/PanelShellClient.tsx
@@ -16,8 +16,12 @@ import {
   requestOverlayOpen,
   requestResolvePageNode,
   requestPageCapture,
+  requestCaptureSettings,
+  requestAssociate,
   OVERLAY_CORNERS,
+  type CaptureSettings,
 } from "@/lib/domain/browser-extension/panel-bridge";
+import { shouldCapturePage } from "@/lib/domain/browser-extension/capture-policy";
 import { useContentStore, TOP_LEFT_PANE_ID } from "@/state/content-store";
 import { useRightPanelCollapseStore } from "@/state/right-panel-collapse-store";
 import { useSettingsStore } from "@/state/settings-store";
@@ -30,6 +34,10 @@ const QUICK_ACCESS_COLLAPSED_KEY = "dg-panel-quick-access-collapsed";
 // Short opener pre-filled (not sent) into the new chat when opened via "Ask AI
 // about this page" — so a user who isn't expecting to type can just hit send.
 const ASK_ABOUT_PAGE_PREFILL = "Give me a quick overview of this page.";
+// B3-B settle window: how long a page URL must hold steady before auto-linking
+// it to the open note. Long enough that flipping through tabs doesn't associate
+// every page you glance at.
+const AUTO_ASSOCIATE_DWELL_MS = 5000;
 
 /**
  * The full file-tree menu is nearly as tall as the panel itself. Trim the
@@ -231,6 +239,45 @@ export function PanelShellClient({
   const shellNavigationControls = useExtensionShellNavigationControls();
   const selectedContentId = useContentStore((s) => s.selectedContentId);
 
+  // ── B3-B settle-then-associate ────────────────────────────────────────────
+  // Capture settings (killswitch + denylist) live in the extension's
+  // chrome.storage; this partitioned iframe's own settings store is empty, so we
+  // ask the host once (the reply is handled in the message listener below).
+  const [captureSettings, setCaptureSettings] = useState<CaptureSettings | null>(
+    null
+  );
+  // (url|contentId) pairs already auto-attempted this session, so a manual unlink
+  // isn't immediately re-linked and the settle effect can't spam the host.
+  const autoLinkedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    requestCaptureSettings();
+  }, []);
+
+  // When a page holds steady for the dwell window AND a note is open AND the
+  // killswitch is on AND the page passes the capture policy (not DG's own
+  // content, not a mailbox/auth page, not denylisted), link it to the note.
+  // The note's link icon reflects it; unlinking there is the undo.
+  useEffect(() => {
+    const url = pageContext?.url;
+    if (!url || !selectedContentId) return;
+    if (!captureSettings?.autoAssociate) return;
+    const key = `${url}|${selectedContentId}`;
+    if (autoLinkedRef.current.has(key)) return;
+    const decision = shouldCapturePage(url, {
+      appOrigins: [window.location.origin],
+      userDenylist: captureSettings.denylist,
+    });
+    if (!decision.capture) return;
+    const title = pageContext?.title ?? "";
+    const timer = setTimeout(() => {
+      // Only associate while the user is actually looking at the panel.
+      if (document.visibilityState !== "visible") return;
+      autoLinkedRef.current.add(key);
+      requestAssociate({ url, contentId: selectedContentId, title });
+    }, AUTO_ASSOCIATE_DWELL_MS);
+    return () => clearTimeout(timer);
+  }, [pageContext?.url, pageContext?.title, selectedContentId, captureSettings]);
+
   // Server-resolved preference; "system" defers to the iframe's own media
   // query, subscribed through useSyncExternalStore so it stays SSR-safe and
   // needs no setState-in-effect.
@@ -369,6 +416,17 @@ export function PanelShellClient({
           faviconUrl: data.payload.faviconUrl
             ? String(data.payload.faviconUrl)
             : undefined,
+        });
+      }
+
+      // B3-B capture settings (killswitch + denylist) from chrome.storage.
+      if (data.type === "capture-settings" && data.payload) {
+        setCaptureSettings({
+          autoAssociate: data.payload.autoAssociate === true,
+          navHistory: data.payload.navHistory !== false,
+          denylist: Array.isArray(data.payload.denylist)
+            ? data.payload.denylist.map((entry: unknown) => String(entry))
+            : [],
         });
       }
 

--- a/app/embed/panel/PanelShellClient.tsx
+++ b/app/embed/panel/PanelShellClient.tsx
@@ -5,6 +5,7 @@ import { DndWrapper } from "@/components/content/DndWrapper";
 import { LeftSidebar } from "@/components/content/LeftSidebar";
 import { MainPanelWorkspace } from "@/components/content/MainPanelWorkspace";
 import { PanelQuickAccess } from "@/components/content/PanelQuickAccess";
+import { PanelPageLinkButton } from "@/components/content/PanelPageLinkButton";
 import { MultiConversationSidebar } from "@/components/content/ai/MultiConversationSidebar";
 import { ContextMenu } from "@/components/content/context-menu/ContextMenu";
 import { fileTreeActionProvider } from "@/components/content/context-menu/file-tree-actions";
@@ -651,6 +652,15 @@ export function PanelShellClient({
               flexDirection: "column",
             }}
           >
+            {/* B3-B: note↔page link toggle. Renders only in the panel embed with
+                both an open note and a current page (self-hides otherwise). */}
+            <div style={{ flexShrink: 0, display: "flex", justifyContent: "flex-end" }}>
+              <PanelPageLinkButton
+                pageUrl={pageContext?.url ?? null}
+                pageTitle={pageContext?.title ?? ""}
+                contentId={selectedContentId}
+              />
+            </div>
             <MainPanelWorkspace />
           </div>
         </>

--- a/components/content/PanelPageLinkButton.tsx
+++ b/components/content/PanelPageLinkButton.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+/**
+ * Panel note ↔ page link toggle (BROWSER-REACH B3-B).
+ *
+ * A small link affordance shown on the note open in the side panel. It reflects
+ * whether the page you're currently viewing is linked to that note, and clicking
+ * it links/unlinks — the manual, always-available control (auto-associate on
+ * settle is a separate, opt-in accelerator). The click always acts on the CURRENT
+ * page URL passed in, never a stale one.
+ *
+ * The association itself is a WebResourceContentLink, created/deleted through the
+ * extension (the embed runs on session auth and relays via the panel host, which
+ * resolves the URL → webResourceId and calls the existing background handlers).
+ * Off-panel this renders nothing.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { Link2, Link2Off, Loader2 } from "lucide-react";
+import {
+  requestAssociate,
+  requestUnassociate,
+  isPanelEmbedSurface,
+} from "@/lib/domain/browser-extension/panel-bridge";
+import { isAllowedEmbedMessageOrigin } from "@/lib/domain/browser-extension/embed-message-origins";
+
+/** Loose page identity: host + pathname, case-insensitive, no trailing slash. */
+function samePage(a: string, b: string): boolean {
+  try {
+    const ua = new URL(a);
+    const ub = new URL(b);
+    const norm = (u: URL) =>
+      `${u.host.toLowerCase()}${u.pathname.replace(/\/+$/, "")}`;
+    return norm(ua) === norm(ub);
+  } catch {
+    return false;
+  }
+}
+
+export function PanelPageLinkButton({
+  pageUrl,
+  pageTitle,
+  contentId,
+}: {
+  pageUrl: string | null;
+  pageTitle: string;
+  contentId: string | null;
+}) {
+  // null = unknown/loading; true/false = resolved link state for the current page.
+  const [linked, setLinked] = useState<boolean | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Resolve the current link state: does the open note already associate this
+  // page? Reads the note's links (session-authed; does NOT create a WebResource,
+  // unlike resource-context) and matches the current page URL against them.
+  useEffect(() => {
+    if (!pageUrl || !contentId) {
+      setLinked(null);
+      return;
+    }
+    let cancelled = false;
+    setLinked(null);
+    setError(null);
+    void (async () => {
+      try {
+        const res = await fetch(`/api/content/links/${contentId}`, {
+          credentials: "include",
+        });
+        if (!res.ok) throw new Error("links fetch failed");
+        const body = await res.json();
+        const resources: Array<{ normalizedUrl?: string; canonicalUrl?: string }> =
+          body?.data?.associatedWebResources ?? [];
+        const isLinked = resources.some(
+          (r) =>
+            (r.normalizedUrl && samePage(r.normalizedUrl, pageUrl)) ||
+            (r.canonicalUrl && samePage(r.canonicalUrl, pageUrl))
+        );
+        if (!cancelled) setLinked(isLinked);
+      } catch {
+        // Non-fatal — leave state unknown; the toggle still works (upsert/delete).
+        if (!cancelled) setLinked(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [pageUrl, contentId]);
+
+  // Ack from the host after a link/unlink relay resolves.
+  useEffect(() => {
+    function handle(event: MessageEvent) {
+      if (!isAllowedEmbedMessageOrigin(event.origin)) return;
+      const data = event.data;
+      if (!data || typeof data !== "object") return;
+      if (data.v !== 1 || data.source !== "dg-panel-host") return;
+      if (data.type === "association-changed" && data.payload?.contentId === contentId) {
+        setBusy(false);
+        setError(null);
+        if (typeof data.payload.linked === "boolean") setLinked(data.payload.linked);
+      }
+      if (data.type === "association-error" && data.payload?.contentId === contentId) {
+        setBusy(false);
+        setError(
+          typeof data.payload?.message === "string"
+            ? data.payload.message
+            : "Couldn't update the link"
+        );
+      }
+    }
+    window.addEventListener("message", handle);
+    return () => window.removeEventListener("message", handle);
+  }, [contentId]);
+
+  const toggle = useCallback(() => {
+    if (!pageUrl || !contentId || busy) return;
+    setBusy(true);
+    setError(null);
+    if (linked) {
+      requestUnassociate({ url: pageUrl, contentId });
+    } else {
+      requestAssociate({ url: pageUrl, contentId, title: pageTitle });
+    }
+  }, [pageUrl, contentId, busy, linked, pageTitle]);
+
+  // Only meaningful in the panel embed, with both a page and an open note.
+  if (!isPanelEmbedSurface() || !pageUrl || !contentId) return null;
+
+  const label = error
+    ? error
+    : linked
+      ? "Linked to this page — click to unlink"
+      : "Link this page to the note";
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      disabled={busy}
+      title={label}
+      aria-label={label}
+      aria-pressed={linked === true}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 5,
+        padding: "3px 8px",
+        fontSize: 11,
+        border: 0,
+        background: "transparent",
+        cursor: busy ? "default" : "pointer",
+        color: error
+          ? "var(--intent-danger, #e5695f)"
+          : linked
+            ? "var(--gold-primary, #c8a04f)"
+            : "var(--text-secondary, #9a9a9a)",
+      }}
+    >
+      {busy ? (
+        <Loader2 size={13} className="animate-spin" />
+      ) : linked ? (
+        <Link2 size={13} />
+      ) : (
+        <Link2Off size={13} />
+      )}
+      <span style={{ maxWidth: 180, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {linked ? "Linked" : "Link page"}
+      </span>
+    </button>
+  );
+}

--- a/components/content/RecentsPanel.tsx
+++ b/components/content/RecentsPanel.tsx
@@ -27,7 +27,35 @@ import {
 import { shouldCapturePage } from "@/lib/domain/browser-extension/capture-policy";
 import { isAllowedEmbedMessageOrigin } from "@/lib/domain/browser-extension/embed-message-origins";
 
-const HISTORY_FILTER_KEY = "dg-panel-recents-show-history";
+// 3-state filter for the panel Recents: everything mixed, notes/files only, or
+// browser history only. Cycles on click. Defaults to "all" (mixed).
+type RecentsFilter = "all" | "recents" | "history";
+const RECENTS_FILTER_ORDER: RecentsFilter[] = ["all", "recents", "history"];
+const RECENTS_FILTER_LABEL: Record<RecentsFilter, string> = {
+  all: "All",
+  recents: "Notes & files",
+  history: "Browser history",
+};
+const RECENTS_FILTER_KEY = "dg-panel-recents-filter";
+
+// Unified list item so notes/files and browser pages can interleave by recency.
+type RecentsListItem =
+  | {
+      kind: "content";
+      key: string;
+      timestamp: number;
+      contentId: string;
+      title: string;
+      contentType?: string;
+    }
+  | {
+      kind: "history";
+      key: string;
+      timestamp: number;
+      url: string;
+      title: string;
+      favIconUrl: string | null;
+    };
 
 const TYPE_ICONS: Record<string, string> = {
   folder: "M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z",
@@ -77,7 +105,7 @@ export function RecentsPanel() {
   const inPanel = isPanelEmbedSurface();
 
   const [browserHistory, setBrowserHistory] = useState<PageHistoryEntry[]>([]);
-  const [showBrowserHistory, setShowBrowserHistory] = useState(true);
+  const [filterMode, setFilterMode] = useState<RecentsFilter>("all");
   const [failedFavicons, setFailedFavicons] = useState<Set<string>>(new Set());
 
   const recents = useMemo(() => {
@@ -107,10 +135,13 @@ export function RecentsPanel() {
   useEffect(() => {
     if (!inPanel) return;
     try {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time localStorage hydration
-      setShowBrowserHistory(localStorage.getItem(HISTORY_FILTER_KEY) !== "false");
+      const stored = localStorage.getItem(RECENTS_FILTER_KEY);
+      if (stored === "all" || stored === "recents" || stored === "history") {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time localStorage hydration
+        setFilterMode(stored);
+      }
     } catch {
-      // Storage unavailable — keep the shown-by-default.
+      // Storage unavailable — keep the "all" default.
     }
     function onMessage(event: MessageEvent) {
       if (!isAllowedEmbedMessageOrigin(event.origin)) return;
@@ -128,20 +159,54 @@ export function RecentsPanel() {
 
   // Defense-in-depth: even though the extension already filters at record time,
   // re-apply the full capture policy at display (adds mailbox/auth-suffix guards).
-  const visibleHistory = useMemo(() => {
-    if (!inPanel || !showBrowserHistory) return [] as PageHistoryEntry[];
+  const filteredHistory = useMemo(() => {
+    if (!inPanel) return [] as PageHistoryEntry[];
     const origin = typeof window !== "undefined" ? window.location.origin : "";
     return browserHistory.filter(
       (entry) =>
         shouldCapturePage(entry.url, { appOrigins: origin ? [origin] : [] }).capture
     );
-  }, [inPanel, showBrowserHistory, browserHistory]);
+  }, [inPanel, browserHistory]);
 
-  function toggleShowHistory() {
-    setShowBrowserHistory((prev) => {
-      const next = !prev;
+  // Notes/files and browser pages merged into one recency-sorted list. The
+  // active filter decides which kinds are eligible before the sort.
+  const mergedItems = useMemo(() => {
+    const items: RecentsListItem[] = [];
+    if (filterMode !== "history") {
+      for (const item of recents) {
+        items.push({
+          kind: "content",
+          key: `c:${item.contentId}`,
+          timestamp: item.timestamp,
+          contentId: item.contentId,
+          title: item.title ?? "Untitled",
+          contentType: item.contentType,
+        });
+      }
+    }
+    if (filterMode !== "recents") {
+      for (const entry of filteredHistory) {
+        items.push({
+          kind: "history",
+          key: `h:${entry.normalizedUrl}`,
+          timestamp: new Date(entry.lastViewedAt).getTime(),
+          url: entry.url,
+          title: entry.title?.trim() || hostnameOf(entry.url),
+          favIconUrl: entry.favIconUrl,
+        });
+      }
+    }
+    return items.sort((a, b) => b.timestamp - a.timestamp);
+  }, [filterMode, recents, filteredHistory]);
+
+  function cycleFilter() {
+    setFilterMode((prev) => {
+      const next =
+        RECENTS_FILTER_ORDER[
+          (RECENTS_FILTER_ORDER.indexOf(prev) + 1) % RECENTS_FILTER_ORDER.length
+        ];
       try {
-        localStorage.setItem(HISTORY_FILTER_KEY, String(next));
+        localStorage.setItem(RECENTS_FILTER_KEY, next);
       } catch {
         // Non-fatal.
       }
@@ -192,31 +257,47 @@ export function RecentsPanel() {
     );
   }
 
-  // ── Panel embed: content recents + browser history + filter ────────────────
-  const isEmpty = recents.length === 0 && visibleHistory.length === 0;
+  // ── Panel embed: notes/files + browser history, mixed, with a cycling filter ─
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex items-center justify-between px-3 py-1.5 text-[11px] uppercase tracking-wide text-gray-400 dark:text-gray-500">
         <span>Recents</span>
         <button
           type="button"
-          onClick={toggleShowHistory}
-          aria-pressed={showBrowserHistory}
-          className="rounded px-1.5 py-0.5 text-[11px] normal-case tracking-normal text-gray-500 transition-colors hover:bg-black/5 dark:text-gray-400 dark:hover:bg-white/5"
+          onClick={cycleFilter}
+          title="Filter: All → Notes & files → Browser history"
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] normal-case tracking-normal text-gray-500 transition-colors hover:bg-black/5 dark:text-gray-400 dark:hover:bg-white/5"
         >
-          {showBrowserHistory ? "Hide history" : "Show history"}
+          <svg
+            className="h-3 w-3 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 4h18M6 8h12M9 12h6M11 16h2"
+            />
+          </svg>
+          {RECENTS_FILTER_LABEL[filterMode]}
         </button>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto py-1">
-        {isEmpty ? (
+        {mergedItems.length === 0 ? (
           <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-gray-500 dark:text-gray-400">
-            Recently viewed notes, files, and pages will appear here.
+            {filterMode === "history"
+              ? "Pages you visit will appear here."
+              : filterMode === "recents"
+                ? "Recently viewed notes and files will appear here."
+                : "Recently viewed notes, files, and pages will appear here."}
           </div>
         ) : (
-          <>
-            {recents.map((item) => (
+          mergedItems.map((item) =>
+            item.kind === "content" ? (
               <button
-                key={item.contentId}
+                key={item.key}
                 type="button"
                 onClick={() => setSelectedContentId(item.contentId)}
                 className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
@@ -235,71 +316,58 @@ export function RecentsPanel() {
                   />
                 </svg>
                 <span className="min-w-0 flex-1 truncate text-sm text-gray-800 dark:text-gray-200">
-                  {item.title ?? "Untitled"}
+                  {item.title}
                 </span>
                 <span className="shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
                   {formatRelativeTime(item.timestamp)}
                 </span>
               </button>
-            ))}
-
-            {visibleHistory.length > 0 && (
-              <>
-                <div className="px-3 pb-1 pt-2 text-[11px] uppercase tracking-wide text-gray-400 dark:text-gray-500">
-                  Browser history
-                </div>
-                {visibleHistory.map((entry) => {
-                  const showFavicon =
-                    entry.favIconUrl && !failedFavicons.has(entry.url);
-                  return (
-                    <button
-                      key={entry.normalizedUrl}
-                      type="button"
-                      onClick={() => requestOpenUrl(entry.url)}
-                      title={entry.url}
-                      className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
-                    >
-                      {showFavicon ? (
-                        // eslint-disable-next-line @next/next/no-img-element -- arbitrary external favicon, not a project asset
-                        <img
-                          src={entry.favIconUrl ?? undefined}
-                          alt=""
-                          className="h-4 w-4 shrink-0 rounded-sm"
-                          onError={() =>
-                            setFailedFavicons((prev) => {
-                              const next = new Set(prev);
-                              next.add(entry.url);
-                              return next;
-                            })
-                          }
-                        />
-                      ) : (
-                        <svg
-                          className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d={GLOBE_ICON}
-                          />
-                        </svg>
-                      )}
-                      <span className="min-w-0 flex-1 truncate text-sm text-gray-800 dark:text-gray-200">
-                        {entry.title?.trim() || hostnameOf(entry.url)}
-                      </span>
-                      <span className="shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
-                        {formatRelativeTime(new Date(entry.lastViewedAt).getTime())}
-                      </span>
-                    </button>
-                  );
-                })}
-              </>
-            )}
-          </>
+            ) : (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => requestOpenUrl(item.url)}
+                title={item.url}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+              >
+                {item.favIconUrl && !failedFavicons.has(item.url) ? (
+                  // eslint-disable-next-line @next/next/no-img-element -- arbitrary external favicon, not a project asset
+                  <img
+                    src={item.favIconUrl}
+                    alt=""
+                    className="h-4 w-4 shrink-0 rounded-sm"
+                    onError={() =>
+                      setFailedFavicons((prev) => {
+                        const next = new Set(prev);
+                        next.add(item.url);
+                        return next;
+                      })
+                    }
+                  />
+                ) : (
+                  <svg
+                    className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d={GLOBE_ICON}
+                    />
+                  </svg>
+                )}
+                <span className="min-w-0 flex-1 truncate text-sm text-gray-800 dark:text-gray-200">
+                  {item.title}
+                </span>
+                <span className="shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+                  {formatRelativeTime(item.timestamp)}
+                </span>
+              </button>
+            )
+          )
         )}
       </div>
     </div>

--- a/components/content/RecentsPanel.tsx
+++ b/components/content/RecentsPanel.tsx
@@ -3,15 +3,31 @@
 /**
  * Recents Panel — Obsidian-style recently-viewed list for the left sidebar.
  *
- * Reuses the navigation-history store (the back/forward stacks): entries from
- * every pane are merged, deduped by contentId (keeping the newest timestamp),
- * and sorted most-recent-first. Clicking an item opens it in the active pane —
- * the same path the back-history dropdown uses.
+ * App side: merges the navigation-history store (the back/forward stacks) across
+ * panes, deduped by contentId (newest timestamp wins), sorted most-recent-first.
+ * Clicking an item opens it in the active pane — the same path the back-history
+ * dropdown uses.
+ *
+ * Panel embed (BROWSER-REACH B3-B): additionally surfaces the browser
+ * page-history the extension recorded ("pages you visited"), behind a filter
+ * that DEFAULTS TO SHOWN here and is absent in the standalone app. That history
+ * lives only in the browser (never the server), which is exactly why it can only
+ * appear in the panel — clicking an entry re-opens the URL in a new tab.
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigationHistoryStore } from "@/state/navigation-history-store";
 import { useContentStore } from "@/state/content-store";
+import {
+  isPanelEmbedSurface,
+  requestPageHistory,
+  requestOpenUrl,
+  type PageHistoryEntry,
+} from "@/lib/domain/browser-extension/panel-bridge";
+import { shouldCapturePage } from "@/lib/domain/browser-extension/capture-policy";
+import { isAllowedEmbedMessageOrigin } from "@/lib/domain/browser-extension/embed-message-origins";
+
+const HISTORY_FILTER_KEY = "dg-panel-recents-show-history";
 
 const TYPE_ICONS: Record<string, string> = {
   folder: "M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z",
@@ -22,6 +38,9 @@ const TYPE_ICONS: Record<string, string> = {
 
 const DEFAULT_ICON =
   "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z";
+
+const GLOBE_ICON =
+  "M21 12a9 9 0 11-18 0 9 9 0 0118 0zM3.6 9h16.8M3.6 15h16.8M12 3a15 15 0 010 18M12 3a15 15 0 000 18";
 
 function formatRelativeTime(timestamp: number): string {
   const deltaSeconds = Math.round((timestamp - Date.now()) / 1000);
@@ -42,11 +61,24 @@ function formatRelativeTime(timestamp: number): string {
   return "just now";
 }
 
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
 export function RecentsPanel() {
   const byPaneId = useNavigationHistoryStore((state) => state.byPaneId);
   const setSelectedContentId = useContentStore(
     (state) => state.setSelectedContentId
   );
+  const inPanel = isPanelEmbedSurface();
+
+  const [browserHistory, setBrowserHistory] = useState<PageHistoryEntry[]>([]);
+  const [showBrowserHistory, setShowBrowserHistory] = useState(true);
+  const [failedFavicons, setFailedFavicons] = useState<Set<string>>(new Set());
 
   const recents = useMemo(() => {
     const newestById = new Map<
@@ -70,44 +102,206 @@ export function RecentsPanel() {
     return [...newestById.values()].sort((a, b) => b.timestamp - a.timestamp);
   }, [byPaneId]);
 
-  if (recents.length === 0) {
+  // Panel-only: hydrate the filter preference and pull the browser page-history
+  // from the extension (via the host bridge). No-ops entirely in the app.
+  useEffect(() => {
+    if (!inPanel) return;
+    try {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time localStorage hydration
+      setShowBrowserHistory(localStorage.getItem(HISTORY_FILTER_KEY) !== "false");
+    } catch {
+      // Storage unavailable — keep the shown-by-default.
+    }
+    function onMessage(event: MessageEvent) {
+      if (!isAllowedEmbedMessageOrigin(event.origin)) return;
+      const data = event.data;
+      if (!data || typeof data !== "object") return;
+      if (data.v !== 1 || data.source !== "dg-panel-host") return;
+      if (data.type === "page-history" && Array.isArray(data.payload?.history)) {
+        setBrowserHistory(data.payload.history as PageHistoryEntry[]);
+      }
+    }
+    window.addEventListener("message", onMessage);
+    requestPageHistory();
+    return () => window.removeEventListener("message", onMessage);
+  }, [inPanel]);
+
+  // Defense-in-depth: even though the extension already filters at record time,
+  // re-apply the full capture policy at display (adds mailbox/auth-suffix guards).
+  const visibleHistory = useMemo(() => {
+    if (!inPanel || !showBrowserHistory) return [] as PageHistoryEntry[];
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    return browserHistory.filter(
+      (entry) =>
+        shouldCapturePage(entry.url, { appOrigins: origin ? [origin] : [] }).capture
+    );
+  }, [inPanel, showBrowserHistory, browserHistory]);
+
+  function toggleShowHistory() {
+    setShowBrowserHistory((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(HISTORY_FILTER_KEY, String(next));
+      } catch {
+        // Non-fatal.
+      }
+      return next;
+    });
+  }
+
+  // ── App side: original rendering, untouched (zero regression) ──────────────
+  if (!inPanel) {
+    if (recents.length === 0) {
+      return (
+        <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-gray-500 dark:text-gray-400">
+          Recently viewed notes and files will appear here.
+        </div>
+      );
+    }
     return (
-      <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-gray-500 dark:text-gray-400">
-        Recently viewed notes and files will appear here.
+      <div className="min-h-0 flex-1 overflow-y-auto py-1">
+        {recents.map((item) => (
+          <button
+            key={item.contentId}
+            type="button"
+            onClick={() => setSelectedContentId(item.contentId)}
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+          >
+            <svg
+              className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d={TYPE_ICONS[item.contentType ?? ""] ?? DEFAULT_ICON}
+              />
+            </svg>
+            <span className="min-w-0 flex-1 truncate text-sm text-gray-800 dark:text-gray-200">
+              {item.title ?? "Untitled"}
+            </span>
+            <span className="shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+              {formatRelativeTime(item.timestamp)}
+            </span>
+          </button>
+        ))}
       </div>
     );
   }
 
+  // ── Panel embed: content recents + browser history + filter ────────────────
+  const isEmpty = recents.length === 0 && visibleHistory.length === 0;
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto py-1">
-      {recents.map((item) => (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center justify-between px-3 py-1.5 text-[11px] uppercase tracking-wide text-gray-400 dark:text-gray-500">
+        <span>Recents</span>
         <button
-          key={item.contentId}
           type="button"
-          onClick={() => setSelectedContentId(item.contentId)}
-          className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+          onClick={toggleShowHistory}
+          aria-pressed={showBrowserHistory}
+          className="rounded px-1.5 py-0.5 text-[11px] normal-case tracking-normal text-gray-500 transition-colors hover:bg-black/5 dark:text-gray-400 dark:hover:bg-white/5"
         >
-          <svg
-            className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d={TYPE_ICONS[item.contentType ?? ""] ?? DEFAULT_ICON}
-            />
-          </svg>
-          <span className="min-w-0 flex-1 truncate text-sm text-gray-800 dark:text-gray-200">
-            {item.title ?? "Untitled"}
-          </span>
-          <span className="shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
-            {formatRelativeTime(item.timestamp)}
-          </span>
+          {showBrowserHistory ? "Hide history" : "Show history"}
         </button>
-      ))}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto py-1">
+        {isEmpty ? (
+          <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-gray-500 dark:text-gray-400">
+            Recently viewed notes, files, and pages will appear here.
+          </div>
+        ) : (
+          <>
+            {recents.map((item) => (
+              <button
+                key={item.contentId}
+                type="button"
+                onClick={() => setSelectedContentId(item.contentId)}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+              >
+                <svg
+                  className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d={TYPE_ICONS[item.contentType ?? ""] ?? DEFAULT_ICON}
+                  />
+                </svg>
+                <span className="min-w-0 flex-1 truncate text-sm text-gray-800 dark:text-gray-200">
+                  {item.title ?? "Untitled"}
+                </span>
+                <span className="shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+                  {formatRelativeTime(item.timestamp)}
+                </span>
+              </button>
+            ))}
+
+            {visibleHistory.length > 0 && (
+              <>
+                <div className="px-3 pb-1 pt-2 text-[11px] uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  Browser history
+                </div>
+                {visibleHistory.map((entry) => {
+                  const showFavicon =
+                    entry.favIconUrl && !failedFavicons.has(entry.url);
+                  return (
+                    <button
+                      key={entry.normalizedUrl}
+                      type="button"
+                      onClick={() => requestOpenUrl(entry.url)}
+                      title={entry.url}
+                      className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
+                    >
+                      {showFavicon ? (
+                        // eslint-disable-next-line @next/next/no-img-element -- arbitrary external favicon, not a project asset
+                        <img
+                          src={entry.favIconUrl ?? undefined}
+                          alt=""
+                          className="h-4 w-4 shrink-0 rounded-sm"
+                          onError={() =>
+                            setFailedFavicons((prev) => {
+                              const next = new Set(prev);
+                              next.add(entry.url);
+                              return next;
+                            })
+                          }
+                        />
+                      ) : (
+                        <svg
+                          className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d={GLOBE_ICON}
+                          />
+                        </svg>
+                      )}
+                      <span className="min-w-0 flex-1 truncate text-sm text-gray-800 dark:text-gray-200">
+                        {entry.title?.trim() || hostnameOf(entry.url)}
+                      </span>
+                      <span className="shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+                        {formatRelativeTime(new Date(entry.lastViewedAt).getTime())}
+                      </span>
+                    </button>
+                  );
+                })}
+              </>
+            )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/docs/notes-feature/work-tracking/BACKLOG.md
+++ b/docs/notes-feature/work-tracking/BACKLOG.md
@@ -81,6 +81,23 @@ Dropped from the active B-series (owner call): the existing workspaces infra + `
 - [ ] "Browser Sessions" as workspace items — auto-created, date/time-named, most-recent-active first; per-workspace target folder rides the `settings` JSON column (no schema change per C3).
 - [ ] Per-window active-workspace pointer (browser-side, keyed by `windowId`; app renders what the API returns).
 
+## Browser Reach B3-B — settle-then-associate + viewership (BUILT 2026-07-23, awaiting smoke test)
+
+Branch `feat/browser-reach-b3b-associations`. Gates green (typecheck + lint 0-err + full build + `pnpm extension:build`). NOT yet smoke-tested (owner deferred to after all building). Requires `pnpm extension:build` + reload the extension before testing.
+
+Shipped:
+- **Capture policy** (`lib/domain/browser-extension/capture-policy.ts`) — pure `shouldCapturePage()` shared safety gate: blocks non-web schemes, browser-internal (Web Store), Digital Garden's own origins, mailboxes/auth/password-managers, and a user denylist. Applied at record time (extension) and display time (panel).
+- **Phase B — settle-then-associate** (`PanelShellClient`): a page that holds steady 5s while a note is open auto-links to it, gated by the killswitch + policy + panel visibility + a per-session dedup (so a manual unlink isn't re-linked). The Phase A link icon reflects/undoes it.
+- **Phase C — viewership → Recents**: the background records a capped, deduped page-history ring buffer to `chrome.storage.local` (record-time guards: navHistory on, not DG-origin, not denylisted). `RecentsPanel` gains a panel-only browser-history section behind a "Show/Hide history" filter (default shown in panel, absent in the app); clicking re-opens the URL in a new tab. Also fixed a dormant background bug: the catch-all `sendResponse` sat above `get-recent-viewed-tabs`/`send-note-to-tabs`, making both unreachable.
+- **Settings** — a "Capture & privacy" card in the browser-bookmarks extension settings page (killswitch, nav-history toggle, denylist editor, clear-history), stored in `chrome.storage` via the app↔extension bridge.
+
+⚠ **Deviation to confirm with owner**: browsing history lives in `chrome.storage` (never the server), because adding a server-side `PageView` table is blocked by the repo's schema guardrail (denied `Edit`/`Write` to `prisma/**` + `prisma` CLI) *and* the local DB's post-squash migration drift. Consequence: browser history is **panel-only** (not visible in the standalone app's Recents), and its toggle/filter live with the extension settings rather than general app settings. If owner wants app-side history visibility, that's the server-`PageView` follow-up — needs the schema guardrail lifted + the `MIGRATION-BASELINE-SQUASH.md` reconciliation.
+
+Followups:
+- [ ] Server-side `PageView` table (opt-in) for app-side Recents history visibility + cross-device sync. Needs schema change (guardrailed) + DB baseline reconciliation.
+- [ ] Refresh panel browser-history on visibility change (today it loads once per panel mount).
+- [ ] "a browser extension setting allows this default to be ON" — the killswitch default is currently a fixed OFF; a chrome.storage/popup override to flip the *default* is not yet wired.
+
 ---
 
 ## Extension Workflows Followups (2026-07-16, branch `feature/workflows-extension`, PR #111)

--- a/docs/notes-feature/work-tracking/BACKLOG.md
+++ b/docs/notes-feature/work-tracking/BACKLOG.md
@@ -73,6 +73,16 @@ P1–P4 (parser, registry, `/playbook` picker, progressive-disclosure injection)
 
 ---
 
+## Browser Reach B3-A — workspaces in the panel (DEPRIORITIZED 2026-07-22)
+
+Dropped from the active B-series (owner call): the existing workspaces infra + `extensions/workplaces/` (WorkspaceSelector, workspace-store, ContentWorkspace API) already do the job, and users create sessions via existing affordances. The browser-specific value from the original 3.4/3.5 was pulled out into **B3-B** (settle-then-associate link affordance + browser-history-in-recents). Revisit only if browser-specific workspace UX becomes necessary.
+
+- [ ] Wire the panel's workspace chooser to list/switch real `ContentWorkspace`s (full-swap semantics). WorkspaceSelector already exists.
+- [ ] "Browser Sessions" as workspace items — auto-created, date/time-named, most-recent-active first; per-workspace target folder rides the `settings` JSON column (no schema change per C3).
+- [ ] Per-window active-workspace pointer (browser-side, keyed by `windowId`; app renders what the API returns).
+
+---
+
 ## Extension Workflows Followups (2026-07-16, branch `feature/workflows-extension`, PR #111)
 
 Phases 0–4 built (see `EXTENSION-WORKFLOWS-PLAN.md`); P0–P2 smoke-passed live; n8n spoke merged in mid-build (browser dispatch of n8n workflows is live). Deferred by design:

--- a/extensions/browser-bookmarks/browser-extension/src/background/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/background/index.js
@@ -6,6 +6,10 @@ const STORAGE_KEYS = {
   install: "dgBrowserBookmarksInstall",
   quickSaveDrafts: "dgBrowserBookmarksQuickSaveDrafts",
   strategyOverrides: "dgUrlStrategyOverrides",
+  // BROWSER-REACH B3-B: persisted "pages you visited" ring buffer (viewership →
+  // Recents). Kept OUT of config so it can't bloat the settings blob or ride an
+  // export. Never leaves the browser — no server row is ever created for it.
+  pageHistory: "dgBrowserPageHistory",
 };
 
 const DEFAULT_CONFIG = {
@@ -19,6 +23,14 @@ const DEFAULT_CONFIG = {
     domainIntelligenceEnabled: true,
   },
   rules: [],
+  // BROWSER-REACH B3-B capture controls. Deliberately conservative defaults:
+  // auto-association is OFF until the user opts in (killswitch); navigation
+  // history capture is ON but user-disableable and never creates content.
+  capture: {
+    autoAssociate: false,
+    navHistory: true,
+    denylist: [],
+  },
 };
 
 async function getConfig() {
@@ -1965,11 +1977,80 @@ function pruneMruTab(tabId) {
   if (idx !== -1) mruTabs.splice(idx, 1);
 }
 
+// ── Persisted page history (BROWSER-REACH B3-B, Phase C) ─────────────────────
+// A capped, deduped "pages you visited" log that SURVIVES service-worker
+// restarts (unlike mruTabs). Stored only in chrome.storage.local — it never
+// reaches the server and never becomes a ContentNode. Gated by the navHistory
+// killswitch and the same record-time safety guards as auto-associate, so a
+// page the user has blacklisted is never even written to disk.
+const PAGE_HISTORY_MAX = 250;
+
+function safeOrigin(url) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+// Cheap substring denylist check — the extension can't import the shared TS
+// capture-policy module (the build is walled off), so record-time keeps the
+// structural guards here and the panel applies the full policy at display.
+function matchesCaptureDenylist(url, denylist) {
+  if (!Array.isArray(denylist) || denylist.length === 0) return false;
+  const lower = String(url).toLowerCase();
+  return denylist.some((raw) => {
+    const entry = String(raw).trim().toLowerCase();
+    return entry.length > 0 && lower.includes(entry);
+  });
+}
+
+async function getPageHistory() {
+  const result = await chrome.storage.local.get(STORAGE_KEYS.pageHistory);
+  const stored = result[STORAGE_KEYS.pageHistory];
+  return Array.isArray(stored) ? stored : [];
+}
+
+async function recordPageView(tab) {
+  if (!tab?.url || isIneligibleMruUrl(tab.url)) return;
+  const config = await getConfig();
+  const capture = config.capture || {};
+  if (capture.navHistory === false) return; // user turned history off
+  // Never record Digital Garden's own pages as "external" viewership.
+  const appOrigin = safeOrigin(config.appBaseUrl);
+  if (appOrigin && safeOrigin(tab.url) === appOrigin) return;
+  // Honor the user denylist at record time — blacklisted pages never touch disk.
+  if (matchesCaptureDenylist(tab.url, capture.denylist)) return;
+
+  const normalizedUrl = normalizeComparableUrl(tab.url);
+  if (!normalizedUrl) return;
+
+  const history = await getPageHistory();
+  const existingIdx = history.findIndex((h) => h.normalizedUrl === normalizedUrl);
+  const firstViewedAt =
+    existingIdx !== -1 ? history[existingIdx].firstViewedAt : new Date().toISOString();
+  const viewCount =
+    existingIdx !== -1 ? (history[existingIdx].viewCount || 1) + 1 : 1;
+  if (existingIdx !== -1) history.splice(existingIdx, 1);
+  history.unshift({
+    url: tab.url,
+    normalizedUrl,
+    title: tab.title || "",
+    favIconUrl: tab.favIconUrl || null,
+    firstViewedAt,
+    lastViewedAt: new Date().toISOString(),
+    viewCount,
+  });
+  if (history.length > PAGE_HISTORY_MAX) history.length = PAGE_HISTORY_MAX;
+  await chrome.storage.local.set({ [STORAGE_KEYS.pageHistory]: history });
+}
+
 chrome.tabs.onActivated.addListener(({ tabId }) => {
   chrome.tabs.get(tabId, (tab) => {
     if (chrome.runtime.lastError || !tab?.url) return;
     void updateTabBadge(tabId, tab.url);
     updateMruTab(tabId, tab);
+    void recordPageView(tab);
   });
 });
 
@@ -1978,12 +2059,16 @@ chrome.windows.onFocusChanged.addListener((windowId) => {
   chrome.tabs.query({ active: true, windowId }, ([tab]) => {
     if (chrome.runtime.lastError || !tab) return;
     updateMruTab(tab.id, tab);
+    void recordPageView(tab);
   });
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab?.url) {
     void updateTabBadge(tabId, tab.url);
+    // Only the tab the user is actually looking at counts as a page view;
+    // background tabs finishing their load do not.
+    if (tab.active) void recordPageView(tab);
   }
 });
 
@@ -2277,7 +2362,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       sendResponse({ ok: true, data: result });
       return;
     }
-    sendResponse({ ok: false, error: "Unknown message type" });
     if (message.type === "get-recent-viewed-tabs") {
       const config = await getConfig();
       const appOrigin = config.appBaseUrl
@@ -2327,6 +2411,58 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       return;
     }
 
+    // ── BROWSER-REACH B3-B capture controls (read/write chrome.storage) ──────
+    if (message.type === "get-capture-settings") {
+      const config = await getConfig();
+      const capture = config.capture || {};
+      sendResponse({
+        ok: true,
+        data: {
+          autoAssociate: capture.autoAssociate === true,
+          navHistory: capture.navHistory !== false,
+          denylist: Array.isArray(capture.denylist) ? capture.denylist : [],
+        },
+      });
+      return;
+    }
+    if (message.type === "set-capture-settings") {
+      const config = await getConfig();
+      const prev = config.capture || {};
+      const patch = message.payload || {};
+      const next = {
+        ...config,
+        capture: {
+          autoAssociate:
+            typeof patch.autoAssociate === "boolean"
+              ? patch.autoAssociate
+              : prev.autoAssociate === true,
+          navHistory:
+            typeof patch.navHistory === "boolean"
+              ? patch.navHistory
+              : prev.navHistory !== false,
+          denylist: Array.isArray(patch.denylist)
+            ? patch.denylist.map((entry) => String(entry).trim()).filter(Boolean)
+            : Array.isArray(prev.denylist)
+              ? prev.denylist
+              : [],
+        },
+      };
+      await saveConfig(next);
+      sendResponse({ ok: true, data: next.capture });
+      return;
+    }
+    if (message.type === "get-page-history") {
+      sendResponse({ ok: true, data: await getPageHistory() });
+      return;
+    }
+    if (message.type === "clear-page-history") {
+      await chrome.storage.local.remove(STORAGE_KEYS.pageHistory);
+      sendResponse({ ok: true, data: [] });
+      return;
+    }
+
+    // Catch-all — MUST stay last so every real handler above gets first refusal.
+    sendResponse({ ok: false, error: "Unknown message type" });
   })().catch((error) => {
     sendResponse({ ok: false, error: error.message || "Unknown error" });
   });

--- a/extensions/browser-bookmarks/browser-extension/src/page-bridge.js
+++ b/extensions/browser-bookmarks/browser-extension/src/page-bridge.js
@@ -285,6 +285,31 @@ document.addEventListener("dg-browser-bookmarks-request", async (event) => {
       await dispatchResponseEvent("send-note-to-tabs-result", { results });
       return;
     }
+
+    // ── BROWSER-REACH B3-B capture controls (settings page ↔ chrome.storage) ──
+    if (detail.type === "get-capture-settings") {
+      const settings = await sendRuntimeMessage({ type: "get-capture-settings" });
+      await postMessageToPage("capture-settings", settings);
+      await dispatchResponseEvent("capture-settings", settings);
+      return;
+    }
+
+    if (detail.type === "set-capture-settings") {
+      const settings = await sendRuntimeMessage({
+        type: "set-capture-settings",
+        payload: detail.payload,
+      });
+      await postMessageToPage("capture-settings-saved", settings);
+      await dispatchResponseEvent("capture-settings-saved", settings);
+      return;
+    }
+
+    if (detail.type === "clear-page-history") {
+      await sendRuntimeMessage({ type: "clear-page-history" });
+      await postMessageToPage("page-history-cleared", {});
+      await dispatchResponseEvent("page-history-cleared", {});
+      return;
+    }
   } catch (error) {
     await postMessageToPage("bridge-error", {
       message: error?.message || "Bridge request failed",

--- a/extensions/browser-bookmarks/browser-extension/src/panel/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/panel/index.js
@@ -286,6 +286,48 @@ window.addEventListener("message", (event) => {
     return;
   }
 
+  // Link / unlink a page to a content note (B3-B). Resolve the URL to a
+  // webResourceId (resource-context) first, then call the existing background
+  // association handlers. Ack as `association-changed` so the note's link icon
+  // updates. `linked` = the resulting state.
+  if (
+    (data.type === "associate-page" || data.type === "unassociate-page") &&
+    data.payload?.url &&
+    data.payload?.contentId
+  ) {
+    const payload = data.payload;
+    const linking = data.type === "associate-page";
+    void (async () => {
+      try {
+        const context = await sendRuntimeMessage({
+          type: "fetch-resource-context",
+          payload: { url: payload.url, title: payload.title || "" },
+        });
+        const webResourceId = context?.resource?.id;
+        if (!webResourceId) throw new Error("Couldn't resolve this page");
+        await sendRuntimeMessage({
+          type: linking
+            ? "create-resource-association"
+            : "delete-resource-association",
+          payload: { webResourceId, contentId: payload.contentId },
+        });
+        postToEmbed("association-changed", {
+          url: payload.url,
+          contentId: payload.contentId,
+          linked: linking,
+        });
+      } catch (error) {
+        postToEmbed("association-error", {
+          url: payload.url,
+          contentId: payload.contentId,
+          message:
+            error instanceof Error ? error.message : "Couldn't update the link",
+        });
+      }
+    })();
+    return;
+  }
+
   // "More from {hostname}" lazy expansion. The background handler reads `url`
   // and `excludeResourceId` off the message itself (not a payload wrapper).
   if (data.type === "fetch-domain-associations" && data.payload?.url) {

--- a/extensions/browser-bookmarks/browser-extension/src/panel/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/panel/index.js
@@ -351,6 +351,51 @@ window.addEventListener("message", (event) => {
     return;
   }
 
+  // Capture settings (B3-B): the embed reads the auto-associate killswitch +
+  // denylist from chrome.storage (via the background). Replied as
+  // `capture-settings`. The panel gates its settle-then-associate on these.
+  if (data.type === "get-capture-settings") {
+    void (async () => {
+      try {
+        const settings = await sendRuntimeMessage({ type: "get-capture-settings" });
+        postToEmbed("capture-settings", settings);
+      } catch (error) {
+        postToEmbed("capture-settings-error", {
+          message: error instanceof Error ? error.message : "Couldn't load settings",
+        });
+      }
+    })();
+    return;
+  }
+
+  // Browser page history (B3-B, Phase C): the embed reads the persisted
+  // "pages you visited" log for the Recents browser-history source. Replied as
+  // `page-history`. This never leaves the browser.
+  if (data.type === "get-page-history") {
+    void (async () => {
+      try {
+        const history = await sendRuntimeMessage({ type: "get-page-history" });
+        postToEmbed("page-history", { history });
+      } catch (error) {
+        postToEmbed("page-history-error", {
+          message: error instanceof Error ? error.message : "Couldn't load history",
+        });
+      }
+    })();
+    return;
+  }
+
+  // Open a URL in a new browser tab — Recents browser-history items are pages,
+  // not content nodes, so clicking one re-opens it rather than selecting in a pane.
+  if (data.type === "open-url" && data.payload?.url) {
+    try {
+      chrome.tabs.create({ url: data.payload.url });
+    } catch {
+      // Non-fatal — restricted URL scheme, etc.
+    }
+    return;
+  }
+
   // Pop-out: the panel asks for content to open as an overlay on the page.
   // A drag can't cross from this document into the page, so the panel offers
   // four quadrants instead and tells us which corner the user chose.

--- a/extensions/browser-bookmarks/settings/BrowserBookmarksSettingsPage.tsx
+++ b/extensions/browser-bookmarks/settings/BrowserBookmarksSettingsPage.tsx
@@ -223,6 +223,14 @@ export default function BrowserBookmarksSettingsPage() {
   const [selectedInstallIds, setSelectedInstallIds] = useState<string[]>([]);
   const [bridgeState, setBridgeState] = useState<ExtensionBridgeState>({ status: "checking" });
   const [expandedBrowserFolderIds, setExpandedBrowserFolderIds] = useState<Set<string>>(new Set());
+  // B3-B capture controls (killswitch + nav-history + denylist), stored in the
+  // extension's chrome.storage and reached through the app↔extension bridge.
+  const [capture, setCapture] = useState<{
+    autoAssociate: boolean;
+    navHistory: boolean;
+    denylist: string[];
+  }>({ autoAssociate: false, navHistory: true, denylist: [] });
+  const [newDenylistEntry, setNewDenylistEntry] = useState("");
   const hasShownLoadError = useRef(false);
   const hasShownBridgeError = useRef(false);
   const hasAttemptedBridgeRepair = useRef<string | null>(null);
@@ -562,6 +570,70 @@ export default function BrowserBookmarksSettingsPage() {
     hasAttemptedBridgeRepair.current = currentTrustedInstall.id;
     void handleRefreshTrustedInstall(currentTrustedInstall.id, { silentSuccess: true });
   }, [currentInstallNeedsBridgeRepair, currentTrustedInstall]);
+
+  // Load B3-B capture settings once the extension bridge is live.
+  useEffect(() => {
+    if (bridgeState.status !== "installed") return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const settings = await requestBridgeResponse<{
+          autoAssociate?: boolean;
+          navHistory?: boolean;
+          denylist?: string[];
+        }>("get-capture-settings", "capture-settings");
+        if (cancelled) return;
+        setCapture({
+          autoAssociate: settings?.autoAssociate === true,
+          navHistory: settings?.navHistory !== false,
+          denylist: Array.isArray(settings?.denylist) ? settings.denylist : [],
+        });
+      } catch {
+        // Bridge not ready — leave conservative defaults; the card is disabled.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [bridgeState.status]);
+
+  async function persistCapture(
+    patch: Partial<{ autoAssociate: boolean; navHistory: boolean; denylist: string[] }>
+  ) {
+    const next = { ...capture, ...patch };
+    setCapture(next); // optimistic — settings edits are human-paced and sequential
+    try {
+      await requestBridgeResponse("set-capture-settings", "capture-settings-saved", next);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Couldn't save capture settings"
+      );
+    }
+  }
+
+  function handleAddDenylistEntry(event: React.FormEvent) {
+    event.preventDefault();
+    const entry = newDenylistEntry.trim();
+    if (!entry || capture.denylist.includes(entry)) {
+      setNewDenylistEntry("");
+      return;
+    }
+    void persistCapture({ denylist: [...capture.denylist, entry] });
+    setNewDenylistEntry("");
+  }
+
+  function handleRemoveDenylistEntry(entry: string) {
+    void persistCapture({ denylist: capture.denylist.filter((e) => e !== entry) });
+  }
+
+  async function handleClearPageHistory() {
+    try {
+      await requestBridgeResponse("clear-page-history", "page-history-cleared");
+      toast.success("Browsing history cleared");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Couldn't clear history");
+    }
+  }
 
   async function handleTrustCurrentInstall() {
     if (bridgeState.status !== "installed") return;
@@ -996,6 +1068,122 @@ export default function BrowserBookmarksSettingsPage() {
             </div>
           ) : null}
         </div>
+      </section>
+
+      <section
+        className="space-y-4 rounded-xl border border-white/10 p-6"
+        style={{ background: glass0.background, backdropFilter: glass0.backdropFilter }}
+      >
+        <div>
+          <h2 className="text-xl font-semibold">Capture &amp; privacy</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            What the extension captures as you browse. Auto-linking is off until you
+            turn it on; navigation history stays in this browser and never creates notes.
+          </p>
+        </div>
+
+        <div
+          className={`space-y-4 ${bridgeState.status !== "installed" ? "pointer-events-none opacity-55" : ""}`}
+        >
+          <label className="flex items-start gap-3 rounded-lg border border-white/10 bg-black/5 px-3 py-3 text-sm">
+            <input
+              type="checkbox"
+              checked={capture.autoAssociate}
+              onChange={(event) => void persistCapture({ autoAssociate: event.target.checked })}
+              className="mt-1"
+            />
+            <div className="min-w-0">
+              <div className="font-medium">Auto-link pages to the open note</div>
+              <div className="text-xs text-muted-foreground">
+                When a page settles while a note is open in the side panel, link it
+                automatically. Off by default — the note&apos;s link icon still lets you
+                link or unlink any page by hand.
+              </div>
+            </div>
+          </label>
+
+          <label className="flex items-start gap-3 rounded-lg border border-white/10 bg-black/5 px-3 py-3 text-sm">
+            <input
+              type="checkbox"
+              checked={capture.navHistory}
+              onChange={(event) => void persistCapture({ navHistory: event.target.checked })}
+              className="mt-1"
+            />
+            <div className="min-w-0">
+              <div className="font-medium">Remember pages I visit (browser history)</div>
+              <div className="text-xs text-muted-foreground">
+                Powers the Recents browser-history list in the side panel. Stored only in
+                this browser; it never reaches Digital Garden&apos;s servers and never
+                becomes a note.
+              </div>
+            </div>
+          </label>
+
+          <div className="rounded-lg border border-white/10 bg-black/5 px-3 py-3">
+            <div className="text-sm font-medium">Never capture these sites</div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              Pages matching any entry (hostname or any part of the URL) are never
+              auto-linked or added to history. Mailboxes and sign-in pages are already
+              excluded automatically.
+            </div>
+            <form onSubmit={handleAddDenylistEntry} className="mt-3 flex gap-2">
+              <input
+                value={newDenylistEntry}
+                onChange={(event) => setNewDenylistEntry(event.target.value)}
+                placeholder="e.g. bank.com or /admin"
+                className="flex-1 rounded-lg border border-white/10 bg-black/10 px-3 py-2 text-sm"
+              />
+              <button
+                type="submit"
+                className="rounded-lg border border-white/10 bg-black/10 px-3 py-2 text-sm"
+              >
+                Add
+              </button>
+            </form>
+            {capture.denylist.length > 0 ? (
+              <ul className="mt-3 space-y-2">
+                {capture.denylist.map((entry) => (
+                  <li
+                    key={entry}
+                    className="flex items-center justify-between rounded-lg border border-white/10 bg-black/10 px-3 py-2 text-sm"
+                  >
+                    <span className="truncate font-mono text-xs">{entry}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveDenylistEntry(entry)}
+                      className="rounded-md border border-red-500/30 px-2 py-1 text-xs text-red-400"
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="mt-3 text-xs text-muted-foreground">No blocked sites yet.</div>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border border-white/10 bg-black/5 px-3 py-3">
+            <div className="text-sm">
+              <div className="font-medium">Browsing history</div>
+              <div className="text-xs text-muted-foreground">
+                Clear the pages remembered in this browser.
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleClearPageHistory()}
+              className="rounded-lg border border-white/10 bg-black/10 px-3 py-1.5 text-sm"
+            >
+              Clear history
+            </button>
+          </div>
+        </div>
+        {bridgeState.status !== "installed" ? (
+          <div className="text-xs text-muted-foreground">
+            Connect the browser extension to manage capture settings.
+          </div>
+        ) : null}
       </section>
 
       <section

--- a/lib/domain/browser-extension/capture-policy.ts
+++ b/lib/domain/browser-extension/capture-policy.ts
@@ -1,0 +1,217 @@
+/**
+ * Capture policy (BROWSER-REACH B3-B) — the safety gate shared by every
+ * automatic capture path: settle-then-associate (Phase B) and the
+ * browser-history page-view log (Phase C).
+ *
+ * Pure and dependency-free on purpose, so the *exact same* decision runs in the
+ * extension service worker, in the panel embed, and again server-side before
+ * anything is persisted. Client-side gating is a courtesy (fewer requests); the
+ * server call is the authority — never trust a client that says "safe."
+ *
+ * Design intent (owner, 2026-07-23):
+ *  - Auto-capture is conservative by default; this module is what makes it so.
+ *  - We must NEVER capture Digital Garden's own pages as "external" content.
+ *  - Blatantly sensitive surfaces (mailboxes, auth/login, password managers)
+ *    are blocked outright, on top of a user-editable denylist.
+ */
+
+/** Why a page was rejected. `undefined` reason ⇒ the page is allowed. */
+export type CaptureRejectionReason =
+  | "invalid-url"
+  | "non-web-scheme"
+  | "browser-internal"
+  | "digital-garden"
+  | "sensitive"
+  | "denylisted";
+
+export interface CaptureDecision {
+  capture: boolean;
+  reason?: CaptureRejectionReason;
+}
+
+export interface CapturePolicyOptions {
+  /**
+   * Origins (or bare hostnames) that ARE Digital Garden itself. A page on any
+   * of these is our own content and must never be captured as external.
+   * Pass the app base URL(s) — dev (`http://localhost:3017`) and prod
+   * (`https://davidvalentine.org`) — plus any custom tenant hosts.
+   */
+  appOrigins?: string[];
+  /**
+   * User-authored denylist. Each entry matches if it appears as a substring of
+   * the page's hostname OR of the full lowercased URL. Empty/whitespace entries
+   * are ignored so a stray blank line can't blackhole every page.
+   */
+  userDenylist?: string[];
+}
+
+/**
+ * Hosts we always treat as sensitive mailboxes. Matched as a hostname suffix so
+ * `mail.google.com` also covers regional variants that end the same way.
+ */
+const WEBMAIL_HOST_SUFFIXES: readonly string[] = [
+  "mail.google.com",
+  "outlook.live.com",
+  "outlook.office.com",
+  "outlook.office365.com",
+  "mail.yahoo.com",
+  "mail.proton.me",
+  "mail.aol.com",
+  "mail.fastmail.com",
+  "mail.zoho.com",
+  "mail.tutanota.com",
+];
+
+/** Dedicated identity / auth / password-manager hosts. Suffix-matched. */
+const SENSITIVE_HOST_SUFFIXES: readonly string[] = [
+  "accounts.google.com",
+  "login.microsoftonline.com",
+  "login.live.com",
+  "appleid.apple.com",
+  "id.apple.com",
+  "signin.aws.amazon.com",
+  "1password.com",
+  "bitwarden.com",
+  "lastpass.com",
+  "dashlane.com",
+];
+
+/**
+ * Hostname *prefixes* that reliably indicate an auth surface. Kept deliberately
+ * narrow (leading label only) so we don't nuke pages like `author.example.com`.
+ */
+const SENSITIVE_HOST_PREFIXES: readonly string[] = [
+  "accounts.",
+  "login.",
+  "signin.",
+  "sso.",
+  "auth.",
+  "id.",
+  "oauth.",
+];
+
+/**
+ * First path segment values that indicate an auth flow. Matched on the leading
+ * segment only (e.g. `/login`, `/oauth2/...`) to avoid false hits on content
+ * like `/blog/how-i-login`.
+ */
+const SENSITIVE_FIRST_PATH_SEGMENTS: readonly string[] = [
+  "login",
+  "signin",
+  "sign-in",
+  "oauth",
+  "oauth2",
+  "sso",
+  "logout",
+  "session",
+];
+
+/** Chrome Web Store etc. — http(s) pages that are still "browser chrome." */
+const BROWSER_INTERNAL_HOST_SUFFIXES: readonly string[] = [
+  "chromewebstore.google.com",
+  "chrome.google.com", // /webstore
+  "addons.mozilla.org",
+  "microsoftedge.microsoft.com", // /addons
+];
+
+function safeParseUrl(rawUrl: string): URL | null {
+  try {
+    return new URL(rawUrl);
+  } catch {
+    return null;
+  }
+}
+
+/** Normalize an origin/host input into a comparable lowercase hostname. */
+function toHostname(originOrHost: string): string | null {
+  const trimmed = originOrHost.trim().toLowerCase();
+  if (!trimmed) return null;
+  // Already a bare host (no scheme, no slash)?
+  if (!trimmed.includes("://") && !trimmed.includes("/")) return trimmed;
+  const parsed = safeParseUrl(trimmed);
+  return parsed?.hostname ?? null;
+}
+
+function hostMatchesSuffix(hostname: string, suffix: string): boolean {
+  return hostname === suffix || hostname.endsWith("." + suffix);
+}
+
+/** True for anything that isn't a normal fetchable web page. */
+export function isNonWebScheme(url: URL): boolean {
+  return url.protocol !== "http:" && url.protocol !== "https:";
+}
+
+/** Chrome Web Store / add-on gallery pages — real http, but off-limits. */
+export function isBrowserInternalUrl(url: URL): boolean {
+  const host = url.hostname.toLowerCase();
+  if (
+    host === "chrome.google.com" &&
+    !url.pathname.toLowerCase().startsWith("/webstore")
+  ) {
+    // Google Sites etc. also live on chrome.google.com — only the store is out.
+    return false;
+  }
+  return BROWSER_INTERNAL_HOST_SUFFIXES.some((s) => hostMatchesSuffix(host, s));
+}
+
+/** Mailboxes, auth/login surfaces, password managers. */
+export function isSensitiveUrl(url: URL): boolean {
+  const host = url.hostname.toLowerCase();
+
+  if (WEBMAIL_HOST_SUFFIXES.some((s) => hostMatchesSuffix(host, s))) return true;
+  if (SENSITIVE_HOST_SUFFIXES.some((s) => hostMatchesSuffix(host, s)))
+    return true;
+  if (SENSITIVE_HOST_PREFIXES.some((p) => host.startsWith(p))) return true;
+
+  const firstSegment = url.pathname.toLowerCase().split("/").filter(Boolean)[0];
+  if (firstSegment && SENSITIVE_FIRST_PATH_SEGMENTS.includes(firstSegment))
+    return true;
+
+  return false;
+}
+
+/** True when the page belongs to Digital Garden itself. */
+export function isDigitalGardenUrl(url: URL, appOrigins: string[]): boolean {
+  const host = url.hostname.toLowerCase();
+  for (const origin of appOrigins) {
+    const appHost = toHostname(origin);
+    if (appHost && (host === appHost || hostMatchesSuffix(host, appHost))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Substring match of a user denylist entry against hostname or full URL. */
+export function matchesUserDenylist(url: URL, userDenylist: string[]): boolean {
+  const host = url.hostname.toLowerCase();
+  const href = url.href.toLowerCase();
+  for (const raw of userDenylist) {
+    const entry = raw.trim().toLowerCase();
+    if (!entry) continue; // ignore blanks — never let one blackhole everything
+    if (host.includes(entry) || href.includes(entry)) return true;
+  }
+  return false;
+}
+
+/**
+ * The single decision every automatic capture path must call. Order matters:
+ * structural rejections (bad/non-web/browser-internal) first, then the
+ * "our own content" guard, then sensitivity, then the user's denylist.
+ */
+export function shouldCapturePage(
+  rawUrl: string,
+  options: CapturePolicyOptions = {}
+): CaptureDecision {
+  const url = safeParseUrl(rawUrl);
+  if (!url) return { capture: false, reason: "invalid-url" };
+  if (isNonWebScheme(url)) return { capture: false, reason: "non-web-scheme" };
+  if (isBrowserInternalUrl(url))
+    return { capture: false, reason: "browser-internal" };
+  if (isDigitalGardenUrl(url, options.appOrigins ?? []))
+    return { capture: false, reason: "digital-garden" };
+  if (isSensitiveUrl(url)) return { capture: false, reason: "sensitive" };
+  if (matchesUserDenylist(url, options.userDenylist ?? []))
+    return { capture: false, reason: "denylisted" };
+  return { capture: true };
+}

--- a/lib/domain/browser-extension/panel-bridge.ts
+++ b/lib/domain/browser-extension/panel-bridge.ts
@@ -128,6 +128,37 @@ export function requestResolvePageNode(payload: {
   );
 }
 
+/**
+ * Link the given page (by URL) to a content note (B3-B). The host resolves the
+ * URL to a webResourceId (via resource-context) then creates the association;
+ * the result comes back as an `association-changed` message. Also used as the
+ * manual "associate the page I'm viewing right now" action from the note's link
+ * icon — the caller passes its current (live) page URL.
+ */
+export function requestAssociate(payload: {
+  url: string;
+  contentId: string;
+  title?: string;
+}): void {
+  if (!isPanelEmbedSurface()) return;
+  window.parent.postMessage(
+    { v: 1, source: "dg-panel-embed", type: "associate-page", payload },
+    "*"
+  );
+}
+
+/** Unlink a page from a content note (B3-B). Replies `association-changed`. */
+export function requestUnassociate(payload: {
+  url: string;
+  contentId: string;
+}): void {
+  if (!isPanelEmbedSurface()) return;
+  window.parent.postMessage(
+    { v: 1, source: "dg-panel-embed", type: "unassociate-page", payload },
+    "*"
+  );
+}
+
 /** Decode a data: URL into a File for the chat's attachment path. */
 export function dataUrlToFile(dataUrl: string, filename: string): File | null {
   try {

--- a/lib/domain/browser-extension/panel-bridge.ts
+++ b/lib/domain/browser-extension/panel-bridge.ts
@@ -159,6 +159,63 @@ export function requestUnassociate(payload: {
   );
 }
 
+/**
+ * Auto-capture controls (B3-B), stored in the extension's chrome.storage.
+ * `autoAssociate` defaults OFF (settle-then-associate is opt-in); `navHistory`
+ * defaults ON (viewership log, user-disableable); `denylist` is user-authored.
+ */
+export interface CaptureSettings {
+  autoAssociate: boolean;
+  navHistory: boolean;
+  denylist: string[];
+}
+
+/** One "page you visited" entry from the persisted browser-history log. */
+export interface PageHistoryEntry {
+  url: string;
+  normalizedUrl: string;
+  title: string;
+  favIconUrl: string | null;
+  firstViewedAt: string;
+  lastViewedAt: string;
+  viewCount: number;
+}
+
+/**
+ * Ask the host for the capture settings (killswitch + denylist). The reply
+ * arrives as a `capture-settings` host→embed message. Used to gate the panel's
+ * settle-then-associate and to seed the Recents browser-history filter.
+ */
+export function requestCaptureSettings(): void {
+  if (!isPanelEmbedSurface()) return;
+  window.parent.postMessage(
+    { v: 1, source: "dg-panel-embed", type: "get-capture-settings" },
+    "*"
+  );
+}
+
+/**
+ * Ask the host for the persisted browser page-history (Phase C viewership).
+ * The reply arrives as a `page-history` host→embed message. Browser-only —
+ * this data never left the browser, so it's absent in the standalone app.
+ */
+export function requestPageHistory(): void {
+  if (!isPanelEmbedSurface()) return;
+  window.parent.postMessage(
+    { v: 1, source: "dg-panel-embed", type: "get-page-history" },
+    "*"
+  );
+}
+
+/** Ask the host to open a URL in a new browser tab (Recents history click). */
+export function requestOpenUrl(url: string): void {
+  if (!isPanelEmbedSurface()) return;
+  window.parent.postMessage(
+    { v: 1, source: "dg-panel-embed", type: "open-url", payload: { url } },
+    "*"
+  );
+}
+
 /** Decode a data: URL into a File for the chat's attachment path. */
 export function dataUrlToFile(dataUrl: string, filename: string): File | null {
   try {


### PR DESCRIPTION
Browser Reach **B3-B** — the browser-specific slice pulled out of the deprioritized B3-A (workspaces). Two capabilities, wrapped in a conservative, user-controlled safety layer: **settle-then-associate** (a page you dwell on auto-links to the open note) and **viewership → Recents** (the pages you visit surface in a filterable browser-history list).

Built to be **conservative by default**: auto-association is OFF until you turn it on, and every automatic capture path passes a shared policy gate that refuses Digital Garden's own pages, mailboxes/auth surfaces, and your denylist.

---

## Sprint 1 — Phase A: manual page↔note link toggle

- `PanelPageLinkButton` on the open note reflects whether the current page is linked; click to link/unlink the page you're viewing right now (nothing stale).
- Association relay through the panel host (`associate-page`/`unassociate-page` → resolve `webResourceId` → existing background association handlers).

**Gate:** typecheck ✓ (shipped in commit `5d737743`, rebased cleanly onto `main`).

## Sprint 2 — Capture policy (shared safety gate)

- `lib/domain/browser-extension/capture-policy.ts` — pure `shouldCapturePage(url, { appOrigins, userDenylist })`. Blocks non-web schemes, browser-internal (Web Store), **Digital Garden's own origins**, mailboxes / auth / password-managers, and the user denylist.
- Dependency-free so the *same* decision runs in the extension (record-time), the panel (display-time), and any future server route. The extension build is walled off from the app module graph, so the service worker inlines the cheap structural guards while the panel imports the full module.

**Gate:** typecheck ✓ + lint ✓.

## Sprint 3 — Phase B: settle-then-associate

- In `PanelShellClient`: a page held steady for 5s while a note is open auto-links to it. Fires only when **all** hold — killswitch on, a note open, URL settled 5s, panel visible, passes `shouldCapturePage`, and not already auto-attempted this session (so a manual unlink isn't re-linked).
- Killswitch + denylist read from the extension via a new `requestCaptureSettings()` bridge (the panel's own settings store is empty in the partitioned iframe).

**Gate:** typecheck ✓.

## Sprint 4 — Phase C: viewership → Recents

- Background records a capped (250), deduped page-history ring buffer to `chrome.storage.local`, gated at record time by the nav-history toggle + DG-origin + denylist guards.
- `RecentsPanel` grows a **panel-only** browser-history section behind a "Show/Hide history" filter (default shown in the panel, entirely absent in the standalone app); clicking re-opens the URL in a new tab. App-side rendering is byte-for-byte unchanged.
- **Bug fix:** the background's catch-all `sendResponse({ok:false})` sat *above* `get-recent-viewed-tabs` and `send-note-to-tabs`, making both handlers unreachable (Chrome honors the first response). Moved it last.

**Gate:** typecheck ✓ + `pnpm extension:build` ✓.

## Sprint 5 — Capture & privacy settings

- A "Capture & privacy" card in the browser-bookmarks extension settings page: killswitch (**off by default**), nav-history toggle (on), denylist editor, clear-history. Stored in `chrome.storage` via the app↔extension bridge (added `get/set-capture-settings` + `clear-page-history` to the `page-bridge.js` allowlist).

**Gate:** typecheck ✓ + lint ✓ + full build ✓.

---

## ⚠ Architecture decision & deviations (please weigh)

Viewership is stored in **`chrome.storage`, not a server `PageView` table**. The repo hard-guardrails schema work (`.claude/settings.json` denies edits to `prisma/**` + the `prisma` CLI), and the local DB is in post-squash migration drift — a server table was impossible without owner involvement. `chrome.storage` is schema-free and more private (history never leaves the browser). **Consequences:**

1. Browser history is **panel-only** — not visible in the standalone app's Recents (the spec's "default off in the app" implied it *could* be on there, which needs server persistence).
2. The nav-history toggle + Recents filter live with the **extension** settings, not general app settings.

If app-side history visibility is wanted, that's the follow-up server-`PageView` (needs the schema guardrail lifted + `MIGRATION-BASELINE-SQUASH.md` reconciliation).

---

## Pre-merge checklist

**Gates (green locally)**
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors, 151/175 warnings — none in new files)
- [x] `NODE_OPTIONS='--max-old-space-size=8192' pnpm build` ("Compiled successfully in 34.1s", 223/223 pages)
- [x] `pnpm extension:build`
- [x] No `prisma/schema.prisma` change (regen noise discarded; no migration needed)

**Smoke tests (do before merge — reload the extension first: `pnpm extension:build` → `chrome://extensions` reload → reload page tabs)**
- [x] Settings → browser-bookmarks → "Capture & privacy" card renders; toggles + denylist persist across reload
- [x] Killswitch OFF (default): browsing pages with a note open does **not** auto-link
- [x] Killswitch ON: dwell ~5s on a page with a note open → it auto-links; the note's link icon flips; unlink there does not re-link
- [x] Auto-associate refuses a Digital Garden page, a mailbox (mail.google.com), and a denylisted host
- [x] Recents (in panel) shows a "Browser history" section; Show/Hide filter works; clicking an entry opens it in a new tab
- [x] Recents in the standalone app is unchanged (no browser-history section)
- [ ] Clear-history empties the browser-history list

**Post-merge**
- [x] No Hocuspocus redeploy needed (no publishing blocks / TipTap schema changes)

**Follow-ups (tracked in BACKLOG)**
- [ ] Server-side `PageView` for app-side history visibility + cross-device sync
- [ ] Refresh panel browser-history on visibility change (loads once per mount today)
- [ ] chrome.storage/popup override to flip the killswitch *default* to ON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
