### PR TITLE
AI 3.6 — Lossless playbook rendering + file-tree playbook lifecycle

### DIFF
--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -153,6 +153,7 @@ import type {
   ResolvedModelRoute,
 } from "@/lib/domain/ai/model-directive";
 import { renderPlaybookSection } from "@/lib/domain/ai/playbooks/render";
+import { getServerExtensions } from "@/lib/domain/editor/extensions-server";
 import { isPlaybookMetadata } from "@/lib/domain/ai/playbooks/registry";
 import {
   configurePhaseCheckpointGate,
@@ -1138,6 +1139,9 @@ export async function POST(request: Request) {
           : null;
       if (explicitPlaybookId) {
         try {
+          // Editor extensions for LOSSLESS playbook rendering (v3.6) — built
+          // once per request, only on the playbook path.
+          const serverExtensions = getServerExtensions();
           const playbookNode = await prisma.contentNode.findFirst({
             where: {
               id: explicitPlaybookId,
@@ -1181,7 +1185,10 @@ export async function POST(request: Request) {
                 ...parsed.standingRules.references,
                 ...phase.references,
               ];
-              const phaseText = renderPlaybookSection(phase.content);
+              const phaseText = renderPlaybookSection(
+                phase.content,
+                serverExtensions,
+              );
               const referenceContext = await resolvePlaybookReferenceContext(
                 session.user.id,
                 allRefs,
@@ -1214,6 +1221,7 @@ export async function POST(request: Request) {
 
               const standingText = renderPlaybookSection(
                 parsed.standingRules.content,
+                serverExtensions,
               );
               playbookContext =
                 `\n\n## Active Playbook: "${playbookNode.title}"\n` +
@@ -1244,6 +1252,8 @@ export async function POST(request: Request) {
         }
       } else if (rootedPlaybookId) {
         try {
+          // Editor extensions for LOSSLESS playbook rendering (v3.6).
+          const serverExtensions = getServerExtensions();
           const rootedNode = await prisma.contentNode.findFirst({
             where: {
               id: rootedPlaybookId,
@@ -1268,6 +1278,7 @@ export async function POST(request: Request) {
 
             const standingText = renderPlaybookSection(
               parsed.standingRules.content,
+              serverExtensions,
             );
             const activePhase = parsed.phases[0];
             const allReferences = [
@@ -1282,7 +1293,10 @@ export async function POST(request: Request) {
             if (activePhase) {
               configurePhaseCheckpointGate(phaseCheckpointGate, {
                 phaseTitle: activePhase.title,
-                phaseText: renderPlaybookSection(activePhase.content),
+                phaseText: renderPlaybookSection(
+                  activePhase.content,
+                  serverExtensions,
+                ),
                 referenceContentIds:
                   referenceContext.activeReferenceContentIds,
                 researchToolsAvailable:
@@ -1297,7 +1311,7 @@ export async function POST(request: Request) {
             const phaseText = parsed.phases
               .map(
                 (phase, index) =>
-                  `### Phase ${index + 1}: ${phase.title}\n${renderPlaybookSection(phase.content)}`,
+                  `### Phase ${index + 1}: ${phase.title}\n${renderPlaybookSection(phase.content, serverExtensions)}`,
               )
               .join("\n\n");
             playbookContext =

--- a/app/api/content/playbooks/mark/route.ts
+++ b/app/api/content/playbooks/mark/route.ts
@@ -13,7 +13,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/infrastructure/auth";
 import { prisma } from "@/lib/database/client";
 import type { Prisma } from "@/lib/database/generated/prisma";
-import { withPlaybookMetadata } from "@/lib/domain/ai/playbooks/registry";
+import {
+  isPlaybookMetadata,
+  stripPlaybookMetadata,
+  withPlaybookMetadata,
+} from "@/lib/domain/ai/playbooks/registry";
 import { logger, withRouteTrace, withSpan } from "@/lib/core/logger";
 
 const ROUTE_PATH = "/api/content/playbooks/mark";
@@ -89,6 +93,81 @@ export async function POST(request: NextRequest) {
       });
       return NextResponse.json(
         { success: false, error: { message: "Failed to mark as playbook" } },
+        { status: 500 },
+      );
+    }
+  });
+}
+
+/**
+ * DELETE /api/content/playbooks/mark?contentId=… — the "unmark" path.
+ * Strips the playbook markers from NotePayload.metadata while preserving any
+ * other metadata. Idempotent: unmarking something that isn't a playbook (or has
+ * no payload row) succeeds with `wasPlaybook: false` rather than erroring.
+ */
+export async function DELETE(request: NextRequest) {
+  return withRouteTrace(request, { route: ROUTE_PATH }, async () => {
+    try {
+      const session = await withSpan(
+        { layer: "auth", name: "session" },
+        { summary: "session lookup" },
+        async () => requireAuth(),
+      );
+
+      const contentId = request.nextUrl.searchParams.get("contentId");
+      if (!contentId) {
+        return NextResponse.json(
+          { success: false, error: { message: "contentId is required" } },
+          { status: 400 },
+        );
+      }
+
+      const node = await prisma.contentNode.findFirst({
+        where: {
+          id: contentId,
+          ownerId: session.user.id,
+          contentType: { in: ["note", "folder"] },
+          deletedAt: null,
+        },
+        select: { id: true, notePayload: { select: { metadata: true } } },
+      });
+      if (!node) {
+        return NextResponse.json(
+          { success: false, error: { message: "Note or folder not found" } },
+          { status: 404 },
+        );
+      }
+
+      const metadata =
+        (node.notePayload?.metadata as Record<string, unknown> | null) ?? null;
+      // Nothing to strip — no payload row, or not actually marked. Idempotent success.
+      if (!node.notePayload || !isPlaybookMetadata(metadata)) {
+        return NextResponse.json({ success: true, wasPlaybook: false });
+      }
+
+      await prisma.notePayload.update({
+        where: { contentId: node.id },
+        data: {
+          metadata: stripPlaybookMetadata(metadata) as unknown as Prisma.InputJsonValue,
+        },
+      });
+
+      return NextResponse.json({ success: true, wasPlaybook: true });
+    } catch (error) {
+      if (error instanceof Error && error.message === "Authentication required") {
+        return NextResponse.json(
+          { success: false, error: { message: "Unauthorized" } },
+          { status: 401 },
+        );
+      }
+      logger.error({
+        layer: "ai",
+        event: "playbooks_unmark:caught",
+        summary: "failed to unmark playbook",
+        error,
+      });
+      return NextResponse.json(
+        { success: false, error: { message: "Failed to unmark playbook" } },
         { status: 500 },
       );
     }

--- a/components/content/FileNode.tsx
+++ b/components/content/FileNode.tsx
@@ -44,6 +44,7 @@ import {
   MessageCircle,
   User,
   Users,
+  BookMarked,
 } from "lucide-react";
 import { useLongPress } from "@/components/common/useLongPress";
 import { useContextMenuStore } from "@/state/context-menu-store";
@@ -436,6 +437,11 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
           includeReferencedContent: data.folder?.includeReferencedContent || false, // Phase 2: Folder setting
           externalUrl: data.external?.url, // Phase 2: External link URL
           file: data.file || null, // For supportsCustomIcon check
+          isPlaybook: data.note?.playbook === true, // v3.6: state-aware Mark/Unmark
+          playbookDescription:
+            typeof data.note?.playbookDescription === "string"
+              ? data.note.playbookDescription
+              : "",
         },
         // Pass callbacks to context menu
         onRename: () => {
@@ -596,10 +602,22 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     >
       <div className="flex items-center gap-1">
         {getChevron()}
-        {/* Referenced rows get the OS-alias idiom: a small link badge on
-            the icon's corner — the semantic marker that reads the same
-            nested under a note or adjacent to primaries in a folder. */}
-        {data.role === "referenced" ? (
+        {/* Corner badges use the OS-alias idiom: a small glyph on the icon's
+            corner. Playbook takes precedence over the referenced marker — a
+            note that's both is more usefully surfaced as a playbook. Both share
+            the referenced badge's formatting; only the glyph differs (v3.6). */}
+        {data.note?.playbook ? (
+          <span data-file-icon className="relative inline-flex">
+            {getIcon()}
+            <span
+              aria-hidden
+              title="Playbook"
+              className="absolute -bottom-0.5 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-white text-indigo-500 shadow-sm ring-1 ring-black/10 dark:bg-gray-800 dark:text-indigo-400 dark:ring-white/15"
+            >
+              <BookMarked className="h-2 w-2" />
+            </span>
+          </span>
+        ) : data.role === "referenced" ? (
           <span data-file-icon className="relative inline-flex">
             {getIcon()}
             <span

--- a/components/content/ResizablePanels.tsx
+++ b/components/content/ResizablePanels.tsx
@@ -20,6 +20,7 @@ import { fileTreeActionProvider } from "./context-menu/file-tree-actions";
 import { editorActionProvider } from "./context-menu/editor-actions";
 import { FolderAssistantDialog } from "./dialogs/FolderAssistantDialog";
 import { ImportSkillDialog } from "./dialogs/ImportSkillDialog";
+import { PlaybookDescriptionDialog } from "./dialogs/PlaybookDescriptionDialog";
 import { ImagePreviewHost } from "./viewer/ImagePreviewHost";
 
 interface ResizablePanelsProps {
@@ -191,6 +192,7 @@ export function ResizablePanels({ children }: ResizablePanelsProps) {
 
     {/* Import Skill as Playbook dialog (opened from the file-tree context menu) */}
     <ImportSkillDialog />
+      <PlaybookDescriptionDialog />
 
     {/* Global image preview lightbox (chat images) */}
     <ImagePreviewHost />

--- a/components/content/context-menu/editor-actions.tsx
+++ b/components/content/context-menu/editor-actions.tsx
@@ -1004,45 +1004,9 @@ export const editorActionProvider: ContextMenuActionProvider = (ctx) => {
     });
   }
 
-  // --- Mark as Playbook (AI v3.2 T3) ---
-  // Hand-authoring path: the note's `##` sections already parse as phases
-  // (lib/domain/ai/playbooks/parse.ts). This just marks it discoverable in
-  // chat's /playbook picker via NotePayload.metadata.
-  sections.push({
-    actions: [
-      {
-        id: "mark-as-playbook",
-        label: "Mark as Playbook",
-        inlineInput: {
-          placeholder: "One-line description (shown in the /playbook picker)…",
-          inputLabel: "Mark as Playbook",
-          autoFocus: true,
-          onSubmit: async (description) => {
-            const entry = Object.entries(
-              useEditorInstanceStore.getState().editorsByContentId,
-            ).find(([, ed]) => Boolean(ed));
-            const contentId = entry?.[0];
-            if (!contentId) {
-              toast.error("No note open to mark");
-              return;
-            }
-            try {
-              const res = await fetch("/api/content/playbooks/mark", {
-                method: "POST",
-                credentials: "include",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ contentId, description }),
-              });
-              if (!res.ok) throw new Error("request failed");
-              toast.success("Marked as playbook — attach it from any chat with /playbook");
-            } catch {
-              toast.error("Failed to mark as playbook");
-            }
-          },
-        },
-      },
-    ],
-  });
+  // Playbook Mark/Unmark moved to the FILE-TREE context menu in v3.6 (with a
+  // playbook badge on the tree icon + a centered description modal). It's no
+  // longer in the editor menu.
 
   // --- Dev tools (local development only) ---
   if (process.env.NODE_ENV === "development") {

--- a/components/content/context-menu/file-tree-actions.tsx
+++ b/components/content/context-menu/file-tree-actions.tsx
@@ -36,9 +36,12 @@ import {
   Captions,
   LampDesk,
   BookUp,
+  BookMarked,
+  BookMinus,
 } from "lucide-react";
 import { toast } from "sonner";
 import { useImportSkillStore } from "@/state/import-skill-store";
+import { usePlaybookDialogStore } from "@/state/playbook-dialog-store";
 import type { ContextMenuActionProvider, ContextMenuSection, ContextMenuAction } from "./types";
 import {
   getNewContentMenuItems,
@@ -81,6 +84,8 @@ export interface FileTreeContext {
     includeReferencedContent?: boolean; // Phase 2: Folder setting
     externalUrl?: string; // Phase 2: External link URL
     file?: { mimeType?: string } | null; // For supportsCustomIcon check
+    isPlaybook?: boolean; // v3.6: note/folder already marked as a playbook
+    playbookDescription?: string; // v3.6: seeds the edit-description dialog
   };
   /** Callbacks */
   onRename?: (id: string) => void; // Triggers inline edit mode
@@ -307,6 +312,70 @@ export const fileTreeActionProvider: ContextMenuActionProvider = (ctx) => {
       ],
     });
     return sections;
+  }
+
+  // --- Playbook: Mark / Edit description / Unmark (v3.6; moved off the editor
+  // context menu). Any note-bearing content — a note, or a folder with a Notes
+  // payload — can become a playbook. State-aware via clickedNode.isPlaybook so
+  // the menu shows the right verb; editing the description opens a centered
+  // modal (a modal never grows the menu past the viewport, unlike an inline
+  // input). Mark/unmark just flag NotePayload.metadata; the file's title is the
+  // playbook name and its `##` sections are the phases.
+  if (
+    isSingleSelection &&
+    clickedId &&
+    clickedNode &&
+    (clickedNode.contentType === "note" || clickedNode.contentType === "folder")
+  ) {
+    const playbookTitle = clickedNode.title;
+    const contentId = clickedId;
+    const playbookActions: ContextMenuAction[] = clickedNode.isPlaybook
+      ? [
+          {
+            id: "edit-playbook-description",
+            label: "Edit Playbook Description…",
+            icon: <BookMarked className="h-4 w-4" />,
+            onClick: () =>
+              usePlaybookDialogStore.getState().openDialog({
+                contentId,
+                title: playbookTitle,
+                description: clickedNode.playbookDescription ?? "",
+                editing: true,
+              }),
+          },
+          {
+            id: "unmark-playbook",
+            label: "Unmark Playbook",
+            icon: <BookMinus className="h-4 w-4" />,
+            onClick: async () => {
+              try {
+                const res = await fetch(
+                  `/api/content/playbooks/mark?contentId=${encodeURIComponent(contentId)}`,
+                  { method: "DELETE", credentials: "include" },
+                );
+                if (!res.ok) throw new Error("request failed");
+                window.dispatchEvent(new CustomEvent("dg:tree-refresh"));
+                toast.success("Unmarked — removed from the /playbook picker");
+              } catch {
+                toast.error("Failed to unmark playbook");
+              }
+            },
+          },
+        ]
+      : [
+          {
+            id: "mark-as-playbook",
+            label: "Mark as Playbook…",
+            icon: <BookMarked className="h-4 w-4" />,
+            onClick: () =>
+              usePlaybookDialogStore.getState().openDialog({
+                contentId,
+                title: playbookTitle,
+                editing: false,
+              }),
+          },
+        ];
+    sections.push({ title: "Playbook", actions: playbookActions });
   }
 
   // Section 2: Folder view mode (folder only, single selection)

--- a/components/content/dialogs/PlaybookDescriptionDialog.tsx
+++ b/components/content/dialogs/PlaybookDescriptionDialog.tsx
@@ -1,0 +1,188 @@
+/**
+ * PlaybookDescriptionDialog
+ *
+ * "Mark as Playbook" / "Edit Playbook Description" — a centered modal for the
+ * one-line description shown in the /playbook picker. Opened from the file-tree
+ * context menu (v3.6 moved this off the editor menu). A modal, not an inline
+ * menu input: an inline input grows the context menu past the viewport and
+ * forces a page scroll. The playbook NAME is always the file title (read-only
+ * here); marking just flags NotePayload.metadata via POST /playbooks/mark
+ * (idempotent upsert, so the same route saves an edited description).
+ *
+ * Store-driven + <Body>-mounts-while-open, mirroring ImportSkillDialog so each
+ * open starts fresh with no reset effect.
+ */
+
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/glass/dialog";
+import { Button } from "@/components/ui/glass/button";
+import { BookMarked, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { usePlaybookDialogStore } from "@/state/playbook-dialog-store";
+
+export function PlaybookDescriptionDialog() {
+  const open = usePlaybookDialogStore((s) => s.open);
+  const contentId = usePlaybookDialogStore((s) => s.contentId);
+  const title = usePlaybookDialogStore((s) => s.title);
+  const description = usePlaybookDialogStore((s) => s.description);
+  const editing = usePlaybookDialogStore((s) => s.editing);
+  const close = usePlaybookDialogStore((s) => s.close);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && close()}>
+      <DialogContent className="max-w-md">
+        {open && contentId && (
+          <Body
+            contentId={contentId}
+            title={title}
+            initialDescription={description}
+            editing={editing}
+            onClose={close}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Body({
+  contentId,
+  title,
+  initialDescription,
+  editing,
+  onClose,
+}: {
+  contentId: string;
+  title: string;
+  initialDescription: string;
+  editing: boolean;
+  onClose: () => void;
+}) {
+  const [description, setDescription] = useState(initialDescription);
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  async function handleSave() {
+    if (busy) return;
+    setBusy(true);
+    setNotice(null);
+    try {
+      const res = await fetch("/api/content/playbooks/mark", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ contentId, description: description.trim() }),
+      });
+      if (!res.ok) {
+        setBusy(false);
+        setNotice("Couldn't save — please try again.");
+        return;
+      }
+      window.dispatchEvent(new CustomEvent("dg:tree-refresh"));
+      toast.success(
+        editing
+          ? "Playbook description updated"
+          : "Marked as playbook — attach it from any chat with /playbook",
+      );
+      onClose();
+    } catch {
+      setBusy(false);
+      setNotice("Network error — please try again.");
+    }
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <BookMarked className="h-4 w-4 text-indigo-400" />
+          {editing ? "Edit Playbook Description" : "Mark as Playbook"}
+        </DialogTitle>
+      </DialogHeader>
+
+      <div className="min-w-0 space-y-3">
+        <div className="space-y-1">
+          <span className="text-[11px] uppercase tracking-wide text-gray-400">
+            Playbook
+          </span>
+          <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+            {title || "Untitled"}
+          </p>
+          <p className="text-xs text-gray-400">
+            The playbook name is the file name. Its{" "}
+            <code className="text-[11px]">##</code> sections are its phases.
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <label
+            htmlFor="playbook-description"
+            className="text-[11px] uppercase tracking-wide text-gray-400"
+          >
+            Description
+          </label>
+          <textarea
+            id="playbook-description"
+            value={description}
+            autoFocus
+            onChange={(e) => {
+              setDescription(e.target.value);
+              if (notice) setNotice(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                void handleSave();
+              }
+            }}
+            placeholder="One-line summary shown in the /playbook picker…"
+            spellCheck
+            rows={3}
+            className="w-full resize-y rounded-md border border-black/10 bg-black/[0.03] px-3 py-2 text-sm leading-relaxed text-gray-900 outline-none focus:border-indigo-400/50 dark:border-white/10 dark:bg-white/[0.04] dark:text-gray-100"
+          />
+        </div>
+
+        {notice && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">{notice}</p>
+        )}
+
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleSave}
+            disabled={busy}
+            className="gap-1.5"
+          >
+            {busy ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Saving…
+              </>
+            ) : editing ? (
+              "Save"
+            ) : (
+              "Mark as Playbook"
+            )}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/docs/notes-feature/work-tracking/AI-ROADMAP.md
+++ b/docs/notes-feature/work-tracking/AI-ROADMAP.md
@@ -16,27 +16,45 @@ the owner 2026-07-25 after AI 3.4 merged.
 | 3.2.2 | Prompt-cache foundation | #129 |
 | 3.3 | T4 resumable streams (live re-attach) | #130 |
 | 3.4 | Playbook-orchestrated model routing + catalog-drift safety net | #132 |
+| 3.5 | Registry-authoritative model population (auto-fetch on install) | #133 |
+
+**3.5 deferral (owner: "we can back log that"):** the **monthly model-category
+cron** (realtime / audio / image / reasoning / …). Categories are inferred at
+runtime today via `inferCapabilities` (id patterns); a periodically-refreshed
+authoritative category map is an enhancement, not a blocker.
 
 ## Planned (owner-ordered 2026-07-25)
 
-### 3.5 — Registry-authoritative models  ← IN PROGRESS
-Stop pre-installing model lists. On connection install (with a valid key),
-auto-fetch the model list from the provider registry and replace the
-template's seed models with it; seeds remain the fallback for
-no-model-list-API providers / fetch failures. Extends 3.4's catalog-drift
-safety net ([MODEL-CATALOG-FRESHNESS.md](../guides/ai/MODEL-CATALOG-FRESHNESS.md)).
+### 3.6 — Playbook completeness  ← BUILT (pre-PR, branch `feat/ai-v3.6-playbook-completeness`)
+Scope correction from the original T3-deferral list: the **SKILL.md import
+adapter already shipped with T3** (`playbooks/import/skill-md.ts` +
+`ImportSkillDialog`) and is **already lossless on the way in** — `markdownToTiptap`
+was rewired to `markdownToTiptapRich` in T2. So 3.6 reduced to two real items:
 
-**Deferred to backlog (owner: "we can back log that"):** the **monthly
-model-category cron** (realtime / audio / image / reasoning / …). Categories
-are inferred at runtime today via `inferCapabilities` (id patterns); a
-periodically-refreshed authoritative category map is an enhancement, not a
-blocker — revisit if runtime inference proves too brittle.
-
-### 3.6 — Playbook completeness
-The T3 deferrals as one release: SKILL.md import adapter · "unmark playbook"
-affordance · upgrade the playbook renderer (`playbooks/render.ts`) from its
-scoped temporary renderer to the **lossless T2 serializer** (the "revisit once
-T2 lands" note — T2 has landed).
+- **Lossless phase rendering (headline).** `playbooks/render.ts` no longer
+  hand-rolls plain text (which garbled tables into a cell-dump, dropped link
+  URLs, and dropped callout framing). `renderPlaybookSection(nodes, extensions)`
+  now runs the section through the **T2 self-verifying serializer**
+  (`markdown-serialize.ts`), so tables, callouts (`> [!note]`), links, and nested
+  marks reach the model intact. `[[wiki-links]]` are preserved via a ⟦⟧ sentinel
+  pre-pass (they'd otherwise serialize as raw `<span>` HTML). The old plain
+  renderer is kept as `renderPlaybookSectionPlain` for directive-scanning
+  (`output-directives.ts`) and as the serializer-failure fallback. Extensions are
+  injected (module stays `extensions-server`-free / tsx-safe); the chat route
+  passes `getServerExtensions()` into all 5 call sites.
+- **Playbook lifecycle moved to the file tree.** Mark / Edit-description /
+  Unmark now live in the **file-tree context menu** (removed from the editor
+  menu). It's **state-aware** — the tree API already ships `notePayload.metadata`
+  on each node, so the menu shows "Mark as Playbook…" vs "Edit Playbook
+  Description…" + "Unmark Playbook" per the node's real state. Available for any
+  note-bearing content (note or folder with a Notes payload). A **playbook badge**
+  (a `BookMarked` corner glyph, same formatting as the referenced-content link
+  badge) marks playbook files in the tree at a glance. The description is edited
+  in a **centered modal** (`PlaybookDescriptionDialog`) — the playbook name is the
+  file name; only the one-line description is editable — replacing the old inline
+  menu input that grew the context menu past the viewport. Server: `DELETE
+  /api/content/playbooks/mark?contentId=…` + `stripPlaybookMetadata` (idempotent,
+  preserves other metadata); mark/edit reuse the idempotent POST upsert.
 
 ### 3.7 — Resource governance
 The **enforcement** half of agentic discipline (we shipped the observability —

--- a/lib/domain/ai/playbooks/output-directives.ts
+++ b/lib/domain/ai/playbooks/output-directives.ts
@@ -1,5 +1,5 @@
 import type { ParsedPlaybook, PlaybookSection } from "./parse";
-import { renderPlaybookSection } from "./render";
+import { renderPlaybookSectionPlain } from "./render";
 
 export type RelativeOutputLocation =
   | "under_chat"
@@ -91,8 +91,10 @@ export function extractOutputDirectivesFromText(
 }
 
 function extractFromSection(section: PlaybookSection): PlaybookOutputDirective[] {
+  // Plain text is sufficient (and extension-free): directive scanning only
+  // regexes for "output … under chat/content" prose, never table/callout detail.
   return extractOutputDirectivesFromText(
-    renderPlaybookSection(section.content),
+    renderPlaybookSectionPlain(section.content),
     section.title || undefined,
   );
 }

--- a/lib/domain/ai/playbooks/registry.ts
+++ b/lib/domain/ai/playbooks/registry.ts
@@ -41,6 +41,20 @@ export function withPlaybookMetadata(
   };
 }
 
+/**
+ * Remove the playbook markers from a metadata object (the "unmark" path).
+ * Returns the remaining metadata unchanged apart from the two flag keys — any
+ * other note metadata (word counts, imports, etc.) is preserved. May be `{}`.
+ */
+export function stripPlaybookMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  const rest = { ...(metadata ?? {}) };
+  delete rest[PLAYBOOK_FLAG_KEY];
+  delete rest[PLAYBOOK_DESCRIPTION_KEY];
+  return rest;
+}
+
 /** Does this note's metadata mark it as a playbook? */
 export function isPlaybookMetadata(metadata: unknown): boolean {
   return (

--- a/lib/domain/ai/playbooks/render.ts
+++ b/lib/domain/ai/playbooks/render.ts
@@ -1,32 +1,99 @@
 /**
- * Playbook section renderer (AI v3.2 T3)
+ * Playbook section renderer (AI v3.2 T3 → v3.6 lossless upgrade)
  *
- * One-way TipTap JSON → plain text for MODEL CONTEXT ONLY — not user-facing
- * markdown, not round-trip safe, nothing writes this back into a document.
- * Preserves `[[Target]]` / `[[Target|Display]]` wiki-link syntax verbatim so
- * the model can trace references via `getCurrentNote`, plus enough block
- * structure (headings, lists, code, quotes) to stay readable.
+ * TipTap JSON → markdown for MODEL CONTEXT (the text a playbook's phases/standing
+ * rules become inside the chat system prompt). Two renderers with different jobs:
  *
- * Deliberately does NOT depend on the richer lossless markdown serializer
- * (lib/domain/content/markdown-serialize.ts, AI v3.2 T2) — that module lives
- * on an unmerged branch (PR #125) as of this writing, and wikiLink nodes
- * have no `.text`, so the existing search-text extractor silently drops
- * them. Once T2 lands, phase rendering could upgrade to
- * `tiptapToMarkdownRich` for full formatting fidelity; plain text with
- * preserved wiki-links is sufficient for traceable model context today.
+ *   renderPlaybookSection(nodes, extensions)  — the LOSSLESS path (v3.6). Runs the
+ *     section through the T2 self-verifying serializer (markdown-serialize.ts), so
+ *     tables, callouts (`> [!note]`), links, and nested marks reach the model
+ *     intact instead of being flattened or dropped. `[[wiki-links]]` are preserved
+ *     verbatim via a sentinel pre-pass (they'd otherwise serialize as raw <span>
+ *     HTML, which the model can't trace). Requires injected `extensions` — the
+ *     module stays free of `extensions-server` so it's tsx-safe, exactly like the
+ *     serializer it wraps.
+ *
+ *   renderPlaybookSectionPlain(nodes)  — the dependency-free path. A hand-rolled
+ *     plain-text walk that preserves `[[wiki-links]]` and basic block structure.
+ *     Used where rich fidelity is irrelevant and injecting extensions is undesirable
+ *     (output-directive SCANNING, which only regexes for "output under chat" prose;
+ *     and as the safety-net fallback if the rich serializer throws).
+ *
+ * Why v3.6 replaced the old sole plain renderer: it silently GARBLED tables into a
+ * flat cell-dump, DROPPED link URLs, and DROPPED callout framing — real fidelity
+ * loss the model paid for. See docs/notes-feature/work-tracking/AI-ROADMAP.md 3.6.
  */
 
-import type { JSONContent } from "@tiptap/core";
+import type { JSONContent, Extensions } from "@tiptap/core";
+import {
+  tiptapToMarkdownRich,
+  type HtmlBridge,
+} from "@/lib/domain/content/markdown-serialize";
+
+// ── Wiki-link preservation ───────────────────────────────────────────────────
+// ServerWikiLink renders as `<span data-type="wiki-link" data-target-title=…>`,
+// which turndown degrades to a raw HTML span (lossless but un-traceable) in the
+// rich path. To keep the model-facing `[[Target]]` syntax, we flatten wikiLink
+// nodes to a sentinel-wrapped text run BEFORE serializing, then restore `[[ ]]`
+// after. The sentinels (mathematical white square brackets, U+27E6/U+27E7) are
+// not markdown metacharacters, so turndown passes them through un-escaped and
+// they round-trip as plain text — verified against the real serializer.
+const WL_OPEN = "⟦⟦";
+const WL_CLOSE = "⟧⟧";
+
+function wikiLinkSyntax(node: JSONContent): string {
+  const targetTitle =
+    typeof node.attrs?.targetTitle === "string" ? node.attrs.targetTitle : "";
+  const displayText =
+    typeof node.attrs?.displayText === "string" && node.attrs.displayText
+      ? node.attrs.displayText
+      : undefined;
+  return displayText ? `${targetTitle}|${displayText}` : targetTitle;
+}
+
+/** Replace wikiLink inline nodes with sentinel-wrapped text so they survive serialization. */
+function flattenWikiLinks(node: JSONContent): JSONContent {
+  if (node.type === "wikiLink") {
+    return { type: "text", text: `${WL_OPEN}${wikiLinkSyntax(node)}${WL_CLOSE}` };
+  }
+  if (Array.isArray(node.content)) {
+    return { ...node, content: node.content.map(flattenWikiLinks) };
+  }
+  return node;
+}
+
+function restoreWikiLinks(markdown: string): string {
+  return markdown.split(WL_OPEN).join("[[").split(WL_CLOSE).join("]]");
+}
+
+/**
+ * Render a playbook section's top-level nodes to LOSSLESS model-context markdown.
+ *
+ * @param extensions injected editor extensions (runtime: `getServerExtensions()`).
+ * @param bridge optional HTML (de)serialization bridge — runtime omits it (the
+ *   serializer's env-split default is correct in the Next server); tsx callers
+ *   inject a `@tiptap/html/server` bridge.
+ */
+export function renderPlaybookSection(
+  nodes: JSONContent[],
+  extensions: Extensions,
+  bridge?: HtmlBridge,
+): string {
+  if (!nodes.length) return "";
+  try {
+    const doc: JSONContent = { type: "doc", content: nodes.map(flattenWikiLinks) };
+    return restoreWikiLinks(tiptapToMarkdownRich(doc, extensions, bridge)).trim();
+  } catch {
+    // Never let a serializer edge case blank out a phase — degrade to plain text.
+    return renderPlaybookSectionPlain(nodes);
+  }
+}
+
+// ── Plain-text path (dependency-free) ────────────────────────────────────────
 
 function renderInline(node: JSONContent): string {
   if (node.type === "wikiLink") {
-    const targetTitle =
-      typeof node.attrs?.targetTitle === "string" ? node.attrs.targetTitle : "";
-    const displayText =
-      typeof node.attrs?.displayText === "string" && node.attrs.displayText
-        ? node.attrs.displayText
-        : undefined;
-    return displayText ? `[[${targetTitle}|${displayText}]]` : `[[${targetTitle}]]`;
+    return `[[${wikiLinkSyntax(node)}]]`;
   }
   if (typeof node.text === "string") {
     let text = node.text;
@@ -87,8 +154,13 @@ function renderBlock(node: JSONContent, listDepth = 0): string {
   }
 }
 
-/** Render a playbook section's top-level nodes to model-readable text, preserving `[[wiki-links]]`. */
-export function renderPlaybookSection(nodes: JSONContent[]): string {
+/**
+ * Render a section's top-level nodes to readable PLAIN TEXT, preserving
+ * `[[wiki-links]]`. No editor extensions required — safe under tsx and cheap for
+ * directive scanning. Lossy for tables/callouts/links (use `renderPlaybookSection`
+ * when the model needs those).
+ */
+export function renderPlaybookSectionPlain(nodes: JSONContent[]): string {
   return nodes
     .map((n) => renderBlock(n))
     .filter((s) => s.trim().length > 0)

--- a/lib/domain/content/types.ts
+++ b/lib/domain/content/types.ts
@@ -65,11 +65,17 @@ export interface TreeNode {
     personId?: string;
   };
 
-  // Optional payload summaries
+  // Optional payload summaries. The tree API assigns the note's full
+  // `NotePayload.metadata` here, so playbook markers ride along (v3.6) — the
+  // file-tree badge + Mark/Unmark menu read them without an extra fetch.
   note?: {
     wordCount?: number;
     characterCount?: number;
     readingTime?: number;
+    /** Marked as a playbook (metadata.playbook). */
+    playbook?: boolean;
+    /** One-line description shown in the /playbook picker. */
+    playbookDescription?: string;
   };
   folder?: {
     viewMode: string;

--- a/scripts/validate-playbook-parser.ts
+++ b/scripts/validate-playbook-parser.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import type { JSONContent } from "@tiptap/core";
 
 import { parsePlaybook } from "@/lib/domain/ai/playbooks/parse";
-import { renderPlaybookSection } from "@/lib/domain/ai/playbooks/render";
+import { renderPlaybookSectionPlain } from "@/lib/domain/ai/playbooks/render";
 import {
   bindPlaybookToLatestUserMessage,
   createPlaybookMessageAttachmentPart,
@@ -56,7 +56,7 @@ assert.deepEqual(
   ["Surface facts", "Read between the lines"],
 );
 assert.equal(
-  renderPlaybookSection(structured.standingRules.content),
+  renderPlaybookSectionPlain(structured.standingRules.content),
   "Use current sources.",
 );
 assert.deepEqual(structured.phases[1].references, [
@@ -85,9 +85,9 @@ assert.deepEqual(
   pastedSkill.phases.map((phase) => phase.title),
   ["Phase A: Surface facts", "Phase B: Read between the lines"],
 );
-assert.equal(renderPlaybookSection(pastedSkill.standingRules.content), "");
+assert.equal(renderPlaybookSectionPlain(pastedSkill.standingRules.content), "");
 assert.equal(
-  renderPlaybookSection(pastedSkill.phases[0].content),
+  renderPlaybookSectionPlain(pastedSkill.phases[0].content),
   "Find the product and funding.\nDone when: both are answered.",
 );
 assert.deepEqual(pastedSkill.phases[1].references, [
@@ -102,7 +102,7 @@ assert.equal(unsectioned.phaseLevel, null);
 assert.equal(unsectioned.phases.length, 1);
 assert.equal(unsectioned.phases[0].title, "Instructions");
 assert.equal(
-  renderPlaybookSection(unsectioned.phases[0].content),
+  renderPlaybookSectionPlain(unsectioned.phases[0].content),
   "Research the subject, then summarize the evidence.",
 );
 

--- a/state/playbook-dialog-store.ts
+++ b/state/playbook-dialog-store.ts
@@ -1,0 +1,42 @@
+/**
+ * Playbook-description dialog state (transient — not persisted).
+ *
+ * Opened from the file-tree context menu ("Mark as Playbook…" / "Edit Playbook
+ * Description…"). A centered modal (see PlaybookDescriptionDialog) rather than an
+ * inline menu input — an inline input grows the context menu past the viewport
+ * and forces a page scroll (v3.6 UX fix). The playbook's NAME is always the
+ * file's title; only the one-line description is editable here.
+ */
+
+import { create } from "zustand";
+
+interface PlaybookDialogState {
+  open: boolean;
+  /** Content node being marked / edited. */
+  contentId: string | null;
+  /** File title — shown read-only; it IS the playbook name. */
+  title: string;
+  /** Seed description (edit mode) or "" (fresh mark). */
+  description: string;
+  /** true = the note is already a playbook and we're editing its description. */
+  editing: boolean;
+  openDialog: (args: {
+    contentId: string;
+    title: string;
+    description?: string;
+    editing?: boolean;
+  }) => void;
+  close: () => void;
+}
+
+export const usePlaybookDialogStore = create<PlaybookDialogState>((set) => ({
+  open: false,
+  contentId: null,
+  title: "",
+  description: "",
+  editing: false,
+  openDialog: ({ contentId, title, description = "", editing = false }) =>
+    set({ open: true, contentId, title, description, editing }),
+  close: () =>
+    set({ open: false, contentId: null, title: "", description: "", editing: false }),
+}));


### PR DESCRIPTION
AI **3.6 — Playbook completeness**. Two sprints: make a playbook's phases reach the model **losslessly**, and move the playbook **lifecycle** (mark / edit / unmark) into the file tree with a visible badge and a clean modal.

**Data-model note (no migration):** a playbook *is* a note — the "playbook-ness" is two flags on the note's existing `NotePayload.metadata` (`playbook`, `playbookDescription`), and the runnable content is parsed **live** from that same `tiptapJson` every chat turn. Editing the source note edits the playbook. Migration-free (reuses the JSON column).

**Scope correction:** the roadmap listed a "SKILL.md import adapter" as unbuilt — it **already shipped with T3** and is **already lossless on the way in** (`markdownToTiptap` was rewired to `markdownToTiptapRich` in T2). So 3.6 reduced to the two sprints below.

---

## Sprint 1 — Lossless phase rendering

The old `renderPlaybookSection` hand-rolled plain text: it **garbled tables into a flat cell-dump, dropped link URLs, and dropped callout framing** — fidelity the model silently paid for.

- `renderPlaybookSection(nodes, extensions)` now runs each section through the **T2 self-verifying serializer** (`tiptapToMarkdownRich`), so tables, callouts (`> [!note]`), links, and nested marks reach the model intact.
- `[[wiki-links]]` preserved as clean `[[Target]]` via a `⟦⟧` sentinel pre-pass (they'd otherwise serialize as raw `<span>` HTML the model can't trace).
- Old plain renderer kept as `renderPlaybookSectionPlain` for output-directive scanning (which only regexes for "output under chat" prose) and as the serializer-failure fallback.
- Extensions **injected** so the module stays `extensions-server`-free / `tsx`-safe (same pattern as the serializer it wraps); the chat route passes `getServerExtensions()` into all 5 call sites.

**Gate:** `pnpm typecheck` + `pnpm lint` + `pnpm build` (incl. `collab:schema:check`) + `validate-playbook-parser.ts` — all green.

## Sprint 2 — Playbook lifecycle in the file tree

- Mark / Edit-description / Unmark **moved off the editor context menu** into the **file-tree context menu**, and made **state-aware** (the tree API already ships `notePayload.metadata` per node): a non-playbook shows "Mark as Playbook…"; a playbook shows "Edit Playbook Description…" + "Unmark Playbook".
- **Playbook badge** — a `BookMarked` corner glyph on playbook files in the tree, reusing the referenced-content link-badge formatting (different glyph).
- **Centered modal** (`PlaybookDescriptionDialog`) for the description — replaces the inline menu input that grew the context menu past the viewport and forced a page scroll. Playbook name = file name (read-only); only the description is editable.
- Works for **any note-bearing content** (note, or folder with a Notes payload).
- Server: `DELETE /api/content/playbooks/mark?contentId=…` + `stripPlaybookMetadata` (idempotent, preserves other metadata); mark/edit reuse the idempotent POST upsert.

**Gate:** `pnpm typecheck` + `pnpm lint` (0 errors, 151 warnings — under the 175 ratchet, all pre-existing) + `pnpm build` — all green.

---

## Pre-merge checklist

**Gates**
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors, no new warnings (151, under ratchet)
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm build` green
- [x] `npx tsx scripts/validate-playbook-parser.ts` passes

**Migrations**
- [x] None — playbook flags reuse the existing `NotePayload.metadata` JSON column

**Smoke test (owner)**
- [x] Right-click a note in the tree → **Mark as Playbook…** → centered modal (no page scroll) → Save → `BookMarked` badge appears on the tree icon
- [x] Right-click it again → state-aware **Edit Playbook Description…** + **Unmark Playbook**
- [x] Edit description → modal pre-filled → Save → `/playbook` picker shows the new text
- [x] **Unmark** → badge disappears, gone from `/playbook` picker
- [x] Same flow on a **folder** with Notes content
- [x] Right-click *inside* a note editor → no Mark/Unmark entries (removed)
- [x] Lossless: mark a note with a table + callout + `[[wiki-link]]` + link, `/playbook`-attach it, ask the model to restate the phase → table/callout/link all survive
- [ ] Regression: multi-phase playbook still advances through checkpoints (progressive disclosure); `model:` phase directive still routes (3.4)

**Post-merge**
- [x] No Hocuspocus redeploy needed (no new TipTap block/node types; render changes are chat-route model-context only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
