### PR TITLE
feat(browser-reach): B5 — browser acquisition providers (P2/P3) + quick-pick

### DIFF
--- a/app/api/ai/acquisition/route.ts
+++ b/app/api/ai/acquisition/route.ts
@@ -1,0 +1,97 @@
+/**
+ * Acquisition API (BROWSER-REACH B5).
+ *
+ * POST /api/ai/acquisition
+ *   { url }                    → P1 server-fetch (in-process). The client calls
+ *                                this first; a bot-hostile page fails here.
+ *   { url, remote: {...} }     → finalize extension-fetched material (P2/P3):
+ *                                the client, after P1 fails, asks the extension
+ *                                to fetch with the user's session and posts the
+ *                                raw material here to be turned into a trusted
+ *                                envelope. This is the client-mediated P1→P3
+ *                                escalation (the server can't reach the browser).
+ *
+ * Both paths re-run the server acquisition policy (defense-in-depth). A policy
+ * denial or a fetch failure is returned as `success:false` with a reason (HTTP
+ * 200) — a normal outcome the client acts on, not a transport error.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/infrastructure/auth/middleware";
+import { logger, withRouteTrace } from "@/lib/core/logger";
+import { acquire, createAcquisitionBudget } from "@/lib/domain/ai/acquisition";
+import {
+  finalizeRemoteAcquire,
+  type RemoteAcquireMaterial,
+} from "@/lib/domain/ai/acquisition/remote-acquire";
+
+const ROUTE_PATH = "/api/ai/acquisition";
+
+export async function POST(request: NextRequest) {
+  return withRouteTrace(request, { route: ROUTE_PATH }, async () => {
+    try {
+      const session = await requireAuth();
+      const body = await request.json();
+      const url = typeof body?.url === "string" ? body.url : "";
+      if (!url) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: { code: "INVALID_REQUEST", message: "url is required" },
+          },
+          { status: 400 },
+        );
+      }
+
+      const ctx = {
+        userId: session.user.id,
+        budget: createAcquisitionBudget(),
+      };
+
+      const remote = body?.remote as RemoteAcquireMaterial | undefined;
+      const isRemote =
+        remote &&
+        (remote.mode === "sw-fetch" || remote.mode === "session-tab");
+
+      const result = isRemote
+        ? await finalizeRemoteAcquire(url, remote, ctx)
+        : await acquire({ url }, ctx);
+
+      if (!result.ok) {
+        // Expected negative outcome (blocked/denied/thin) — 200 so the client
+        // can read the reason and escalate P1 → P3 rather than treating it as
+        // a transport failure.
+        return NextResponse.json(
+          {
+            success: false,
+            error: {
+              code: "ACQUIRE_FAILED",
+              message: result.reason ?? "acquisition failed",
+            },
+          },
+          { status: 200 },
+        );
+      }
+
+      return NextResponse.json({ success: true, data: result.content });
+    } catch (error) {
+      logger.error({
+        layer: "ai",
+        event: "acquisition:route:caught",
+        summary: "acquisition route failed — 500",
+        error,
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "INTERNAL_ERROR",
+            message:
+              error instanceof Error ? error.message : "Internal server error",
+          },
+        },
+        { status: 500 },
+      );
+    }
+  });
+}

--- a/components/content/ConfirmDialog.tsx
+++ b/components/content/ConfirmDialog.tsx
@@ -94,11 +94,11 @@ export function ConfirmDialog({
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         {/* Overlay */}
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Overlay className="fixed inset-0 z-[200] bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
 
         {/* Content */}
         <Dialog.Content
-          className="fixed left-[50%] top-[50%] z-50 w-full max-w-md translate-x-[-50%] translate-y-[-50%] rounded-lg border border-black/10 dark:border-white/10 bg-[#1a1a1a] p-6 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
+          className="fixed left-[50%] top-[50%] z-[200] w-full max-w-md translate-x-[-50%] translate-y-[-50%] rounded-lg border border-black/10 dark:border-white/10 bg-[#1a1a1a] p-6 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
           onOpenAutoFocus={(e) => {
             // Focus the cancel button by default (safer)
             e.preventDefault();

--- a/components/content/blocks/SavedBlockPicker.tsx
+++ b/components/content/blocks/SavedBlockPicker.tsx
@@ -136,7 +136,7 @@ export function SavedBlockPicker({ onInsert }: SavedBlockPickerProps) {
   );
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40 backdrop-blur-sm">
       <div className="w-full max-w-md rounded-xl border border-white/10 bg-gray-900/95 shadow-2xl">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">

--- a/components/content/dialogs/FileUploadDialog.tsx
+++ b/components/content/dialogs/FileUploadDialog.tsx
@@ -444,7 +444,7 @@ export function FileUploadDialog({
 
   return (
     <div
-      className="fixed inset-0 bg-black/50 backdrop-blur-[1px] flex items-center justify-center z-50 p-4"
+      className="fixed inset-0 bg-black/50 backdrop-blur-[1px] flex items-center justify-center z-[200] p-4"
       onClick={(e) => {
         // Close dialog when clicking backdrop (not when uploading)
         if (e.target === e.currentTarget && !isUploading) {

--- a/components/content/dialogs/PageTemplateEditorDialog.tsx
+++ b/components/content/dialogs/PageTemplateEditorDialog.tsx
@@ -220,7 +220,7 @@ export function PageTemplateEditorDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm"
       onClick={(event) => {
         if (event.target === event.currentTarget) handleClose();
       }}

--- a/components/content/dialogs/SaveAsTemplateDialog.tsx
+++ b/components/content/dialogs/SaveAsTemplateDialog.tsx
@@ -133,7 +133,7 @@ export function SaveAsTemplateDialog({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-[200] flex items-center justify-center">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"

--- a/components/content/editor/SnippetEditorDialog.tsx
+++ b/components/content/editor/SnippetEditorDialog.tsx
@@ -151,7 +151,7 @@ export function SnippetEditorDialog() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm"
       onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
     >
       <div className="w-full max-w-lg rounded-xl border border-white/15 bg-white dark:bg-gray-900/95 shadow-2xl backdrop-blur-md flex flex-col max-h-[80vh]">

--- a/components/content/editor/SnippetPicker.tsx
+++ b/components/content/editor/SnippetPicker.tsx
@@ -124,7 +124,7 @@ export function SnippetPicker() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm"
       onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
     >
       <div className="w-full max-w-md rounded-xl border border-white/15 bg-gray-900/95 shadow-2xl backdrop-blur-md">

--- a/components/content/editor/TemplateEditorDialog.tsx
+++ b/components/content/editor/TemplateEditorDialog.tsx
@@ -187,7 +187,7 @@ export function TemplateEditorDialog() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm"
       onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
     >
       <div className="w-full max-w-lg rounded-xl border border-white/15 bg-white dark:bg-gray-900/95 shadow-2xl backdrop-blur-md flex flex-col max-h-[80vh]">

--- a/components/content/editor/TemplatePicker.tsx
+++ b/components/content/editor/TemplatePicker.tsx
@@ -131,7 +131,7 @@ export function TemplatePicker() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm"
       onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
     >
       <div className="w-full max-w-md rounded-xl border border-white/15 bg-gray-900/95 shadow-2xl backdrop-blur-md">

--- a/components/content/external/ExternalLinkDialog.tsx
+++ b/components/content/external/ExternalLinkDialog.tsx
@@ -119,12 +119,12 @@ export function ExternalLinkDialog({
     <>
       {/* Backdrop - lighter and more transparent */}
       <div
-        className="fixed inset-0 z-50 bg-black/5 backdrop-blur-sm"
+        className="fixed inset-0 z-[200] bg-black/5 backdrop-blur-sm"
         onClick={() => onOpenChange(false)}
       />
 
       {/* Dialog */}
-      <div className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2">
+      <div className="fixed left-1/2 top-1/2 z-[200] w-full max-w-md -translate-x-1/2 -translate-y-1/2">
         <div
           className="border border-white/10 rounded-lg shadow-2xl"
           style={{

--- a/components/content/external/ExternalLinkViewer.tsx
+++ b/components/content/external/ExternalLinkViewer.tsx
@@ -8,10 +8,21 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { ExternalLink, RefreshCw } from "lucide-react";
+import { ExternalLink, RefreshCw, BookOpen } from "lucide-react";
 import { toast } from "sonner";
 import { getSurfaceStyles } from "@/lib/design/system";
 import { clientLogger } from "@/lib/core/logger/client";
+import {
+  acquireUrlWithFallback,
+  type AcquireVia,
+} from "@/lib/domain/browser-extension/acquire-url";
+import type { AcquiredContent } from "@/lib/domain/ai/acquisition/types";
+
+const ACQUIRE_VIA_LABEL: Record<AcquireVia, string> = {
+  "server-fetch": "server fetch",
+  "sw-fetch": "your browser session",
+  "session-tab": "a background tab in your session",
+};
 
 interface ExternalLinkViewerProps {
   contentId: string;
@@ -61,6 +72,14 @@ export function ExternalLinkViewer({
   const [previewData, setPreviewData] = useState(preview.cached || null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
+  // B5: full-content acquisition (P1 server-fetch → P2/P3 via the extension).
+  const [isAcquiring, setIsAcquiring] = useState(false);
+  const [acquired, setAcquired] = useState<{
+    content: AcquiredContent;
+    via: AcquireVia;
+    usedExtension: boolean;
+  } | null>(null);
+  const [acquireError, setAcquireError] = useState<string | null>(null);
   const screenshotDataUrl =
     typeof captureMetadata?.screenshotDataUrl === "string"
       ? captureMetadata.screenshotDataUrl
@@ -79,6 +98,8 @@ export function ExternalLinkViewer({
   useEffect(() => {
     setPreviewData(preview.cached || null);
     setPreviewError(null);
+    setAcquired(null);
+    setAcquireError(null);
   }, [url, preview.cached]);
 
   const handleRefreshPreview = useCallback(
@@ -154,6 +175,34 @@ export function ExternalLinkViewer({
   const handleOpenLink = () => {
     window.open(url, "_blank", "noopener,noreferrer");
   };
+
+  // B5: read the full page. Tries a server fetch first, then — if the extension
+  // is installed — escalates to a credentialed fetch / a background session tab
+  // in the user's own browser (the bot-hostile-page path). Works without the
+  // extension too; it just can't get past pages that block server fetches.
+  const handleAcquireContent = useCallback(async () => {
+    setIsAcquiring(true);
+    setAcquireError(null);
+    try {
+      const outcome = await acquireUrlWithFallback(url);
+      if (outcome.ok && outcome.content) {
+        const via = outcome.via ?? "server-fetch";
+        setAcquired({ content: outcome.content, via, usedExtension: outcome.usedExtension });
+        toast.success(`Read via ${ACQUIRE_VIA_LABEL[via]}`);
+      } else {
+        setAcquired(null);
+        const message = outcome.reason ?? "Couldn't read this page";
+        setAcquireError(message);
+        toast.error(message);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Couldn't read this page";
+      setAcquireError(message);
+      toast.error(message);
+    } finally {
+      setIsAcquiring(false);
+    }
+  }, [url]);
 
   // Check if we have any metadata at all
   const hasAnyMetadata = Boolean(
@@ -349,7 +398,7 @@ export function ExternalLinkViewer({
       </div>
 
       {/* Action Buttons */}
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <button
           onClick={handleOpenLink}
           className="flex items-center gap-2 px-4 py-2 bg-primary/20 hover:bg-primary/30 border border-primary/30 rounded-lg text-sm font-medium text-primary transition-colors"
@@ -367,7 +416,50 @@ export function ExternalLinkViewer({
           />
           {isRefreshing ? "Refreshing..." : "Refresh Preview"}
         </button>
+        <button
+          onClick={handleAcquireContent}
+          disabled={isAcquiring}
+          className="flex items-center gap-2 px-4 py-2 bg-gray-900/10 hover:bg-gray-900/20 dark:bg-white/10 dark:hover:bg-white/15 border border-gray-900/20 dark:border-white/15 rounded-lg text-sm font-medium text-gray-900 dark:text-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          title="Read the full page text — falls back to your browser session for pages that block server fetches"
+        >
+          <BookOpen className={`h-4 w-4 ${isAcquiring ? "animate-pulse" : ""}`} />
+          {isAcquiring ? "Reading..." : "Read full content"}
+        </button>
       </div>
+
+      {/* Acquire error (B5) */}
+      {acquireError && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+          <p className="text-sm text-red-400">{acquireError}</p>
+        </div>
+      )}
+
+      {/* Acquired full content (B5) */}
+      {acquired && (
+        <div
+          className="border border-white/10 rounded-lg p-4"
+          style={{
+            background: glass0.background,
+            backdropFilter: glass0.backdropFilter,
+          }}
+        >
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <h3 className="truncate text-base font-semibold text-gray-900 dark:text-gray-100">
+              {acquired.content.title || "Extracted content"}
+            </h3>
+            <span className="inline-block shrink-0 rounded-full bg-blue-500/15 px-2 py-0.5 text-xs text-blue-500">
+              via {ACQUIRE_VIA_LABEL[acquired.via]}
+            </span>
+          </div>
+          <div className="mb-3 text-xs text-gray-500 dark:text-gray-400">
+            Web content — informational only. ~{acquired.content.tokenEstimate} tokens
+            {acquired.content.truncated ? " · truncated" : ""}
+          </div>
+          <div className="max-h-96 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+            {acquired.content.content}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/content/external/ExternalLinkViewer.tsx
+++ b/components/content/external/ExternalLinkViewer.tsx
@@ -8,14 +8,32 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { ExternalLink, RefreshCw, BookOpen } from "lucide-react";
+import { ExternalLink, RefreshCw, BookOpen, ChevronDown } from "lucide-react";
 import { toast } from "sonner";
 import { getSurfaceStyles } from "@/lib/design/system";
 import { clientLogger } from "@/lib/core/logger/client";
 import {
   acquireUrlWithFallback,
+  acquireUrlVia,
+  isExtensionAcquireAvailable,
   type AcquireVia,
 } from "@/lib/domain/browser-extension/acquire-url";
+
+// Press-and-hold quick-pick options. `needsExtension` ones (P2/P3) are disabled
+// when no extension is reachable — a server fetch is always available.
+const FETCH_OPTIONS: ReadonlyArray<{
+  key: "auto" | AcquireVia;
+  label: string;
+  hint: string;
+  needsExtension: boolean;
+}> = [
+  { key: "auto", label: "Auto", hint: "Fastest that works", needsExtension: false },
+  { key: "server-fetch", label: "Server fetch", hint: "No cookies · fastest", needsExtension: false },
+  { key: "sw-fetch", label: "Browser session", hint: "Your cookies", needsExtension: true },
+  { key: "session-tab", label: "Background tab", hint: "Full JS render", needsExtension: true },
+];
+
+const ACQUIRE_HOLD_MS = 450;
 import type { AcquiredContent } from "@/lib/domain/ai/acquisition/types";
 
 const ACQUIRE_VIA_LABEL: Record<AcquireVia, string> = {
@@ -80,6 +98,12 @@ export function ExternalLinkViewer({
     usedExtension: boolean;
   } | null>(null);
   const [acquireError, setAcquireError] = useState<string | null>(null);
+  // Press-and-hold quick-pick for "Read full content".
+  const [fetchMenuOpen, setFetchMenuOpen] = useState(false);
+  const holdTimerRef = useRef<number | null>(null);
+  const longPressFiredRef = useRef(false);
+  const fetchMenuRef = useRef<HTMLDivElement | null>(null);
+  const extensionAvailable = isExtensionAcquireAvailable();
   const screenshotDataUrl =
     typeof captureMetadata?.screenshotDataUrl === "string"
       ? captureMetadata.screenshotDataUrl
@@ -176,33 +200,76 @@ export function ExternalLinkViewer({
     window.open(url, "_blank", "noopener,noreferrer");
   };
 
-  // B5: read the full page. Tries a server fetch first, then — if the extension
-  // is installed — escalates to a credentialed fetch / a background session tab
-  // in the user's own browser (the bot-hostile-page path). Works without the
-  // extension too; it just can't get past pages that block server fetches.
-  const handleAcquireContent = useCallback(async () => {
-    setIsAcquiring(true);
-    setAcquireError(null);
-    try {
-      const outcome = await acquireUrlWithFallback(url);
-      if (outcome.ok && outcome.content) {
-        const via = outcome.via ?? "server-fetch";
-        setAcquired({ content: outcome.content, via, usedExtension: outcome.usedExtension });
-        toast.success(`Read via ${ACQUIRE_VIA_LABEL[via]}`);
-      } else {
-        setAcquired(null);
-        const message = outcome.reason ?? "Couldn't read this page";
+  // B5: read the full page. A short click runs the auto ladder (server fetch →
+  // credentialed fetch → background session tab, escalating past bot-hostile
+  // pages); press-and-hold (or the caret) opens a quick-pick to force one
+  // provider. Works without the extension too — server fetch only.
+  const runAcquire = useCallback(
+    async (choice: "auto" | AcquireVia) => {
+      setFetchMenuOpen(false);
+      setIsAcquiring(true);
+      setAcquireError(null);
+      try {
+        const outcome =
+          choice === "auto"
+            ? await acquireUrlWithFallback(url)
+            : await acquireUrlVia(url, choice);
+        if (outcome.ok && outcome.content) {
+          const via = outcome.via ?? "server-fetch";
+          setAcquired({ content: outcome.content, via, usedExtension: outcome.usedExtension });
+          toast.success(`Read via ${ACQUIRE_VIA_LABEL[via]}`);
+        } else {
+          setAcquired(null);
+          const message = outcome.reason ?? "Couldn't read this page";
+          setAcquireError(message);
+          toast.error(message);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Couldn't read this page";
         setAcquireError(message);
         toast.error(message);
+      } finally {
+        setIsAcquiring(false);
       }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Couldn't read this page";
-      setAcquireError(message);
-      toast.error(message);
-    } finally {
-      setIsAcquiring(false);
+    },
+    [url],
+  );
+
+  // Distinguish a tap (→ auto) from a hold (→ quick-pick menu).
+  const handleAcquirePointerDown = useCallback(() => {
+    longPressFiredRef.current = false;
+    if (holdTimerRef.current) window.clearTimeout(holdTimerRef.current);
+    holdTimerRef.current = window.setTimeout(() => {
+      longPressFiredRef.current = true;
+      setFetchMenuOpen(true);
+    }, ACQUIRE_HOLD_MS);
+  }, []);
+
+  const handleAcquirePointerUp = useCallback(() => {
+    if (holdTimerRef.current) {
+      window.clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
     }
-  }, [url]);
+    // Released before the hold threshold → treat as a tap.
+    if (!longPressFiredRef.current && !isAcquiring) void runAcquire("auto");
+  }, [runAcquire, isAcquiring]);
+
+  const handleAcquirePointerCancel = useCallback(() => {
+    if (holdTimerRef.current) {
+      window.clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+  }, []);
+
+  // Close the quick-pick on an outside click.
+  useEffect(() => {
+    if (!fetchMenuOpen) return;
+    const onDocPointerDown = (event: MouseEvent) => {
+      if (!fetchMenuRef.current?.contains(event.target as Node)) setFetchMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDocPointerDown);
+    return () => document.removeEventListener("mousedown", onDocPointerDown);
+  }, [fetchMenuOpen]);
 
   // Check if we have any metadata at all
   const hasAnyMetadata = Boolean(
@@ -416,15 +483,68 @@ export function ExternalLinkViewer({
           />
           {isRefreshing ? "Refreshing..." : "Refresh Preview"}
         </button>
-        <button
-          onClick={handleAcquireContent}
-          disabled={isAcquiring}
-          className="flex items-center gap-2 px-4 py-2 bg-gray-900/10 hover:bg-gray-900/20 dark:bg-white/10 dark:hover:bg-white/15 border border-gray-900/20 dark:border-white/15 rounded-lg text-sm font-medium text-gray-900 dark:text-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          title="Read the full page text — falls back to your browser session for pages that block server fetches"
-        >
-          <BookOpen className={`h-4 w-4 ${isAcquiring ? "animate-pulse" : ""}`} />
-          {isAcquiring ? "Reading..." : "Read full content"}
-        </button>
+        <div ref={fetchMenuRef} className="relative inline-flex">
+          <button
+            type="button"
+            onPointerDown={handleAcquirePointerDown}
+            onPointerUp={handleAcquirePointerUp}
+            onPointerLeave={handleAcquirePointerCancel}
+            onContextMenu={(e) => e.preventDefault()}
+            onKeyDown={(e) => {
+              if ((e.key === "Enter" || e.key === " ") && !isAcquiring) {
+                e.preventDefault();
+                void runAcquire("auto");
+              }
+            }}
+            disabled={isAcquiring}
+            className="flex select-none items-center gap-2 rounded-l-lg border border-gray-900/20 dark:border-white/15 bg-gray-900/10 hover:bg-gray-900/20 dark:bg-white/10 dark:hover:bg-white/15 px-4 py-2 text-sm font-medium text-gray-900 dark:text-gray-100 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            title="Read the full page — click for auto (server → your session), press and hold for options"
+          >
+            <BookOpen className={`h-4 w-4 ${isAcquiring ? "animate-pulse" : ""}`} />
+            {isAcquiring ? "Reading..." : "Read full content"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setFetchMenuOpen((open) => !open)}
+            disabled={isAcquiring}
+            aria-label="Fetch options"
+            aria-haspopup="menu"
+            aria-expanded={fetchMenuOpen}
+            className="flex items-center rounded-r-lg border border-l-0 border-gray-900/20 dark:border-white/15 bg-gray-900/10 hover:bg-gray-900/20 dark:bg-white/10 dark:hover:bg-white/15 px-2 py-2 text-gray-900 dark:text-gray-100 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <ChevronDown className="h-4 w-4" />
+          </button>
+
+          {fetchMenuOpen && (
+            <div
+              role="menu"
+              className="absolute left-0 top-full z-[60] mt-1 w-60 overflow-hidden rounded-lg border border-white/10 shadow-xl"
+              style={{
+                background: glass0.background,
+                backdropFilter: glass0.backdropFilter,
+              }}
+            >
+              {FETCH_OPTIONS.map((option) => {
+                const disabled = option.needsExtension && !extensionAvailable;
+                return (
+                  <button
+                    key={option.key}
+                    type="button"
+                    role="menuitem"
+                    disabled={disabled}
+                    onClick={() => void runAcquire(option.key)}
+                    className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-800 transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-200 dark:hover:bg-white/10"
+                  >
+                    <span className="font-medium">{option.label}</span>
+                    <span className="text-[11px] text-gray-500 dark:text-gray-400">
+                      {disabled ? "needs extension" : option.hint}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Acquire error (B5) */}

--- a/docs/notes-feature/work-tracking/BACKLOG.md
+++ b/docs/notes-feature/work-tracking/BACKLOG.md
@@ -116,6 +116,17 @@ Followups:
 
 ---
 
+## Browser Reach B5 followups (2026-07-25, branch `feat/browser-reach-b5-acquisition`)
+
+B5 (acquisition providers) shipped in that PR: P2 sw-fetch + P3 session-tab as remote providers, client-orchestrated P1→P2→P3 ladder, server builds the trusted envelope, "Read full content" on external-link nodes (with a press-and-hold quick-pick to force a provider), working in both the main app (page-bridge) and the side panel (panel-host channel). Two panel dialog-stacking fixes bundled.
+
+- [ ] **AI browser-acquisition tool (client-side, conditionally registered).** Let the chat AI read a bot-hostile page via the extension. Must be a *client-side* tool — the server chat route can't reach the extension: the client sends a `browserExtensionAvailable` flag per turn → the server registers `read_page_in_browser` ONLY when true; the tool has no server `execute`, so the AI SDK routes the call to the browser via `onToolCall` → run `acquireUrlVia(url, "session-tab")` → `addToolResult`. When the flag is false the tool is absent and the AI should decline with a CTA to reconnect the extension. Net-new client-tool plumbing (chat route flag + tool registry conditional + `use-conversation-engine.ts` `onToolCall` + system prompt). This is the "mid-stream chat escalation" deferred from B5's scope question.
+- [ ] Clearer quick-pick labels: "Browser session" → "Signed-in fetch" (P2), "Background tab" → "Signed-in tab" (P3) — the current labels don't convey the cookies-vs-JS distinction.
+- [ ] Cache acquired content onto the external node's payload so "Read full content" doesn't re-fetch each view (today `hydrateExternalPayload` caches garden-side, but the viewer re-fetches per open).
+- [ ] Quick-pick menu positioning in a short panel — the non-portaled dropdown may clip near the bottom; portal + flip if it surfaces.
+
+---
+
 ## Extension Workflows Followups (2026-07-16, branch `feature/workflows-extension`, PR #111)
 
 Phases 0–4 built (see `EXTENSION-WORKFLOWS-PLAN.md`); P0–P2 smoke-passed live; n8n spoke merged in mid-build (browser dispatch of n8n workflows is live). Deferred by design:

--- a/docs/notes-feature/work-tracking/BACKLOG.md
+++ b/docs/notes-feature/work-tracking/BACKLOG.md
@@ -97,17 +97,9 @@ P1–P4 (parser, registry, `/playbook` picker, progressive-disclosure injection)
 
 ---
 
-## Browser Reach B3-A — workspaces in the panel (DEPRIORITIZED 2026-07-22)
+## Browser Reach B3-B — settle-then-associate + viewership (SHIPPED, PR #131, 2026-07-25)
 
-Dropped from the active B-series (owner call): the existing workspaces infra + `extensions/workplaces/` (WorkspaceSelector, workspace-store, ContentWorkspace API) already do the job, and users create sessions via existing affordances. The browser-specific value from the original 3.4/3.5 was pulled out into **B3-B** (settle-then-associate link affordance + browser-history-in-recents). Revisit only if browser-specific workspace UX becomes necessary.
-
-- [ ] Wire the panel's workspace chooser to list/switch real `ContentWorkspace`s (full-swap semantics). WorkspaceSelector already exists.
-- [ ] "Browser Sessions" as workspace items — auto-created, date/time-named, most-recent-active first; per-workspace target folder rides the `settings` JSON column (no schema change per C3).
-- [ ] Per-window active-workspace pointer (browser-side, keyed by `windowId`; app renders what the API returns).
-
-## Browser Reach B3-B — settle-then-associate + viewership (BUILT 2026-07-23, awaiting smoke test)
-
-Branch `feat/browser-reach-b3b-associations`. Gates green (typecheck + lint 0-err + full build + `pnpm extension:build`). NOT yet smoke-tested (owner deferred to after all building). Requires `pnpm extension:build` + reload the extension before testing.
+Merged via PR #131 (2026-07-25) and smoke-tested (settings card, browser-history capture, filter). Follow-on shipped in the same PR: Recents now interleaves notes/files + browser history under a **3-state cycling filter** (All / Notes & files / Browser history), replacing the earlier two-section Show/Hide toggle.
 
 Shipped:
 - **Capture policy** (`lib/domain/browser-extension/capture-policy.ts`) — pure `shouldCapturePage()` shared safety gate: blocks non-web schemes, browser-internal (Web Store), Digital Garden's own origins, mailboxes/auth/password-managers, and a user denylist. Applied at record time (extension) and display time (panel).
@@ -115,12 +107,12 @@ Shipped:
 - **Phase C — viewership → Recents**: the background records a capped, deduped page-history ring buffer to `chrome.storage.local` (record-time guards: navHistory on, not DG-origin, not denylisted). `RecentsPanel` gains a panel-only browser-history section behind a "Show/Hide history" filter (default shown in panel, absent in the app); clicking re-opens the URL in a new tab. Also fixed a dormant background bug: the catch-all `sendResponse` sat above `get-recent-viewed-tabs`/`send-note-to-tabs`, making both unreachable.
 - **Settings** — a "Capture & privacy" card in the browser-bookmarks extension settings page (killswitch, nav-history toggle, denylist editor, clear-history), stored in `chrome.storage` via the app↔extension bridge.
 
-⚠ **Deviation to confirm with owner**: browsing history lives in `chrome.storage` (never the server), because adding a server-side `PageView` table is blocked by the repo's schema guardrail (denied `Edit`/`Write` to `prisma/**` + `prisma` CLI) *and* the local DB's post-squash migration drift. Consequence: browser history is **panel-only** (not visible in the standalone app's Recents), and its toggle/filter live with the extension settings rather than general app settings. If owner wants app-side history visibility, that's the server-`PageView` follow-up — needs the schema guardrail lifted + the `MIGRATION-BASELINE-SQUASH.md` reconciliation.
+**Storage note**: browsing history lives in `chrome.storage` (never the server), so today it's panel-only and its controls sit with the extension settings. The schema guardrail that forced this has since been **lifted** (2026-07-25); owner scheduled the server-side unification as the FIRST task of B6 hardening (see followups).
 
 Followups:
-- [ ] Server-side `PageView` table (opt-in) for app-side Recents history visibility + cross-device sync. Needs schema change (guardrailed) + DB baseline reconciliation.
-- [ ] Refresh panel browser-history on visibility change (today it loads once per panel mount).
-- [ ] "a browser extension setting allows this default to be ON" — the killswitch default is currently a fixed OFF; a chrome.storage/popup override to flip the *default* is not yet wired.
+- [ ] **[B6 — first task, before other hardening] Server-side `PageView` → unify Recents across app + panel.** A server-persisted, opt-in page-view log gives the *standalone app's* Recents the same browser-history source the panel has today (plus cross-device sync). When it lands, apply the SAME mixed-list + 3-state cycling filter to the main-app Recents and **delete the `isPanelEmbedSurface()` isolation branch in `components/content/RecentsPanel.tsx`** — the app/panel fork collapses into one code path, and the panel's bridge-fetch (`requestPageHistory` + `page-history` message) becomes a normal authed API read. This is a net *removal* of access-code. Guardrail now lifted; still run the `MIGRATION-BASELINE-SQUASH.md` reconciliation and pick the app-side filter default (spec: browser-history OFF by default in the app, shown by default in the panel).
+- [ ] Refresh panel browser-history on visibility change (today it loads once per panel mount). Likely subsumed by the API-read above once history is server-side.
+- [ ] "a browser extension setting allows this default to be ON" — the killswitch default is a fixed OFF; a chrome.storage/popup override to flip the *default* is not yet wired.
 
 ---
 

--- a/extensions/browser-bookmarks/browser-extension/src/background/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/background/index.js
@@ -2079,6 +2079,280 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   pruneMruTab(tabId);
 });
 
+// ── Acquisition providers (BROWSER-REACH B5) ─────────────────────────────────
+// The extension is a *remote provider* for the app-side Acquisition Service: it
+// fetches a URL with the user's own session (cookies / JS rendering) that a
+// server-side fetch can't reach, and returns RAW material only. The server
+// builds the trusted AcquiredContent envelope — the extension never asserts
+// trust or provenance (it's untrusted input).
+//   P2 sw-fetch    — credentialed background fetch → raw HTML (server extracts).
+//   P3 session-tab — inactive tab + injected reader → readable extraction.
+// Every request clears a local policy gate first (SSRF/private-network block is
+// non-negotiable; the app-issued deny list + a per-window budget ride on top)
+// and shows a brief activity badge, so an automated fetch is never silent.
+
+const ACQUISITION_WINDOW_MS = 5 * 60 * 1000;
+const ACQUISITION_DEFAULT_MAX_PAGES = 10;
+const ACQUISITION_MAX_HTML_CHARS = 1_500_000;
+const ACQUISITION_TAB_LOAD_TIMEOUT_MS = 20_000;
+const ACQUISITION_TAB_SETTLE_MS = 1_500;
+const ACQUISITION_EXTRACT_TIMEOUT_MS = 12_000;
+const ACCEPTED_ACQUISITION_CONTENT_TYPES = [
+  "text/html",
+  "application/xhtml",
+  "text/plain",
+];
+
+// Rolling per-window budget (rate etiquette). Not persisted — a fresh SW starts
+// with a clean allowance; the app-issued `maxPages` caps it per 5-min window.
+let acquisitionBudget = { used: 0, windowStart: 0 };
+
+function isBlockedAcquisitionHost(hostname) {
+  if (!hostname) return true;
+  const host = hostname.toLowerCase();
+  if (host === "localhost" || host === "0.0.0.0" || host === "::1" || host === "[::1]")
+    return true;
+  if (
+    host.endsWith(".local") ||
+    host.endsWith(".internal") ||
+    host.endsWith(".localdomain")
+  )
+    return true;
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const a = Number(ipv4[1]);
+    const b = Number(ipv4[2]);
+    if (a === 0 || a === 10 || a === 127) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 169 && b === 254) return true;
+  }
+  const v6 = host.replace(/^\[|\]$/g, "");
+  if (v6 === "::1") return true;
+  if (/^f[cd]/.test(v6)) return true; // fc00::/7 unique-local
+  if (/^fe[89ab]/.test(v6)) return true; // fe80::/10 link-local
+  return false;
+}
+
+// Local mirror of the server acquisition policy. The private-network block is
+// non-negotiable (no config re-enables it). The deny list + budget are the
+// app-issued policy passed on the request.
+function evaluateAcquisitionPolicy(url, policy, configDeny) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { allowed: false, reason: "invalid URL" };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { allowed: false, reason: "only http/https URLs can be acquired" };
+  }
+  if (isBlockedAcquisitionHost(parsed.hostname)) {
+    return { allowed: false, reason: "blocked host (private network)" };
+  }
+  const requestDeny = policy && Array.isArray(policy.deny) ? policy.deny : [];
+  // An app-issued deny list wins; otherwise fall back to the user's own capture
+  // denylist (B3-B "Never capture these sites") so it governs acquisition too.
+  const deny =
+    requestDeny.length > 0
+      ? requestDeny
+      : Array.isArray(configDeny)
+        ? configDeny
+        : [];
+  if (matchesCaptureDenylist(url, deny)) {
+    return { allowed: false, reason: "this domain is on your deny list" };
+  }
+  const maxPages =
+    policy && typeof policy.maxPages === "number"
+      ? policy.maxPages
+      : ACQUISITION_DEFAULT_MAX_PAGES;
+  const now = Date.now();
+  if (now - acquisitionBudget.windowStart > ACQUISITION_WINDOW_MS) {
+    acquisitionBudget = { used: 0, windowStart: now };
+  }
+  if (acquisitionBudget.used >= maxPages) {
+    return {
+      allowed: false,
+      reason: `acquisition budget reached (${maxPages} per 5 min)`,
+    };
+  }
+  acquisitionBudget.used += 1;
+  return { allowed: true };
+}
+
+function setAcquisitionBadge(active) {
+  try {
+    if (active) {
+      void chrome.action.setBadgeBackgroundColor({ color: "#2563eb" });
+      void chrome.action.setBadgeText({ text: "…" });
+    } else {
+      void chrome.action.setBadgeText({ text: "" });
+    }
+  } catch {
+    // Badge is best-effort.
+  }
+}
+
+async function acquireViaSwFetch(url) {
+  let response;
+  try {
+    response = await fetch(url, { credentials: "include", redirect: "follow" });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : "fetch failed",
+    };
+  }
+  if (!response.ok) {
+    return { ok: false, reason: `fetch failed (${response.status})` };
+  }
+  const contentType = (response.headers.get("content-type") || "").toLowerCase();
+  if (!ACCEPTED_ACQUISITION_CONTENT_TYPES.some((t) => contentType.includes(t))) {
+    return {
+      ok: false,
+      reason: `unsupported content type: ${contentType || "unknown"}`,
+    };
+  }
+  const rawHtml = (await response.text()).slice(0, ACQUISITION_MAX_HTML_CHARS);
+  return { ok: true, mode: "sw-fetch", url, finalUrl: response.url || url, rawHtml };
+}
+
+function waitForTabComplete(tabId, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let done = false;
+    const finish = (fn) => {
+      if (done) return;
+      done = true;
+      chrome.tabs.onUpdated.removeListener(onUpdated);
+      clearTimeout(timer);
+      fn();
+    };
+    const onUpdated = (updatedTabId, changeInfo) => {
+      if (updatedTabId === tabId && changeInfo.status === "complete") {
+        finish(resolve);
+      }
+    };
+    const timer = setTimeout(
+      () => finish(() => reject(new Error("page load timed out"))),
+      timeoutMs
+    );
+    chrome.tabs.onUpdated.addListener(onUpdated);
+    // Guard: the tab may already be "complete" before the listener attached.
+    chrome.tabs.get(tabId, (tab) => {
+      if (chrome.runtime.lastError) return;
+      if (tab && tab.status === "complete") finish(resolve);
+    });
+  });
+}
+
+function sendTabExtract(tabId, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let done = false;
+    const timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      reject(new Error("extraction timed out"));
+    }, timeoutMs);
+    chrome.tabs.sendMessage(
+      tabId,
+      { type: "dg-extract-content", scope: "full" },
+      (response) => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message));
+        } else if (!response || !response.ok) {
+          reject(new Error(response?.error || "extraction failed"));
+        } else {
+          resolve(response.data);
+        }
+      }
+    );
+  });
+}
+
+// Extract from a tab, injecting the lightweight reader on demand if nothing is
+// listening yet (mirrors the panel host's sendExtractWithInjectFallback). Avoids
+// a redundant listener when the overlay content script already handles it.
+async function extractFromTabWithInjectFallback(tabId) {
+  try {
+    return await sendTabExtract(tabId, ACQUISITION_EXTRACT_TIMEOUT_MS);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "";
+    if (
+      /receiving end does not exist|could not establish connection/i.test(msg) &&
+      chrome.scripting
+    ) {
+      await chrome.scripting.executeScript({
+        target: { tabId },
+        files: ["dist/reader.js"],
+      });
+      return await sendTabExtract(tabId, ACQUISITION_EXTRACT_TIMEOUT_MS);
+    }
+    throw error;
+  }
+}
+
+async function acquireViaSessionTab(url) {
+  let tab;
+  try {
+    tab = await chrome.tabs.create({ url, active: false });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : "couldn't open a tab",
+    };
+  }
+  const tabId = tab.id;
+  try {
+    await waitForTabComplete(tabId, ACQUISITION_TAB_LOAD_TIMEOUT_MS);
+    // Give client-rendered pages a moment to settle before extracting.
+    await new Promise((r) => setTimeout(r, ACQUISITION_TAB_SETTLE_MS));
+    const extracted = await extractFromTabWithInjectFallback(tabId);
+    let finalUrl = url;
+    try {
+      const current = await chrome.tabs.get(tabId);
+      if (current && current.url) finalUrl = current.url;
+    } catch {
+      // keep the request URL
+    }
+    return { ok: true, mode: "session-tab", url, finalUrl, extracted };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : "session extraction failed",
+    };
+  } finally {
+    try {
+      await chrome.tabs.remove(tabId);
+    } catch {
+      // tab may already be gone
+    }
+  }
+}
+
+async function handleAcquireUrl(payload) {
+  const url = payload && payload.url;
+  const mode = payload && payload.mode === "sw-fetch" ? "sw-fetch" : "session-tab";
+  if (!url) return { ok: false, reason: "no url provided" };
+  const config = await getConfig();
+  const configDeny =
+    config.capture && Array.isArray(config.capture.denylist)
+      ? config.capture.denylist
+      : [];
+  const decision = evaluateAcquisitionPolicy(url, payload && payload.policy, configDeny);
+  if (!decision.allowed) return { ok: false, reason: decision.reason };
+  setAcquisitionBadge(true);
+  try {
+    return mode === "sw-fetch"
+      ? await acquireViaSwFetch(url)
+      : await acquireViaSessionTab(url);
+  } finally {
+    setAcquisitionBadge(false);
+  }
+}
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // sidePanel.open() must run before any await or the user-gesture context
   // that authorized it (launcher click → this message) is lost. Handle it
@@ -2458,6 +2732,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.type === "clear-page-history") {
       await chrome.storage.local.remove(STORAGE_KEYS.pageHistory);
       sendResponse({ ok: true, data: [] });
+      return;
+    }
+    if (message.type === "acquire-url") {
+      // The inner result carries its own ok/reason (policy denials, budget,
+      // fetch failures); the outer envelope reports message-handling success.
+      sendResponse({ ok: true, data: await handleAcquireUrl(message.payload || {}) });
       return;
     }
 

--- a/extensions/browser-bookmarks/browser-extension/src/page-bridge.js
+++ b/extensions/browser-bookmarks/browser-extension/src/page-bridge.js
@@ -310,6 +310,19 @@ document.addEventListener("dg-browser-bookmarks-request", async (event) => {
       await dispatchResponseEvent("page-history-cleared", {});
       return;
     }
+
+    // Acquisition (B5): the app asks the extension to fetch a URL with the
+    // user's session (P2 sw-fetch / P3 session-tab). The result is raw material
+    // only — the server builds the trusted envelope. Long timeout on the app side.
+    if (detail.type === "acquire-url") {
+      const result = await sendRuntimeMessage({
+        type: "acquire-url",
+        payload: detail.payload,
+      });
+      await postMessageToPage("acquire-url-result", result);
+      await dispatchResponseEvent("acquire-url-result", result);
+      return;
+    }
   } catch (error) {
     await postMessageToPage("bridge-error", {
       message: error?.message || "Bridge request failed",

--- a/extensions/browser-bookmarks/browser-extension/src/panel/index.js
+++ b/extensions/browser-bookmarks/browser-extension/src/panel/index.js
@@ -396,6 +396,28 @@ window.addEventListener("message", (event) => {
     return;
   }
 
+  // Acquisition (B5): the page-bridge content script doesn't run inside this
+  // iframe, so the panel embed can't reach the background directly — it asks the
+  // host to run the acquisition provider (P2 sw-fetch / P3 session-tab) and
+  // relays the raw result back as `acquire-url-result`.
+  if (data.type === "acquire-url" && data.payload?.url) {
+    void (async () => {
+      try {
+        const result = await sendRuntimeMessage({
+          type: "acquire-url",
+          payload: data.payload,
+        });
+        postToEmbed("acquire-url-result", result);
+      } catch (error) {
+        postToEmbed("acquire-url-result", {
+          ok: false,
+          reason: error instanceof Error ? error.message : "acquisition failed",
+        });
+      }
+    })();
+    return;
+  }
+
   // Pop-out: the panel asks for content to open as an overlay on the page.
   // A drag can't cross from this document into the page, so the panel offers
   // four quadrants instead and tells us which corner the user chose.

--- a/lib/domain/ai/acquisition/remote-acquire.ts
+++ b/lib/domain/ai/acquisition/remote-acquire.ts
@@ -1,0 +1,138 @@
+/**
+ * Remote acquisition providers — server half (BROWSER-REACH B5).
+ *
+ * P2 (sw-fetch) and P3 (session-tab) run in the user's browser and hand back
+ * RAW material over the page-bridge. This module turns that raw material into a
+ * trusted `AcquiredContent` envelope — server-side, so provenance and trust
+ * tiering stay authoritative and the untrusted extension can't forge them.
+ *
+ *   P2 sw-fetch    → returns raw HTML; the server extracts it (reusing the P1
+ *                    `extractReadableContent` path — identical to P1 except who
+ *                    did the credentialed fetch).
+ *   P3 session-tab → the injected reader already ran Readability in a live DOM,
+ *                    so it returns extracted fields; the server just wraps them.
+ *
+ * Policy is re-checked here (defense-in-depth): the extension enforces its own
+ * local policy, but the server never trusts a client that says "allowed."
+ */
+
+import { extractReadableContent } from "./extract";
+import { hydrateExternalPayload } from "./hydrate";
+import { evaluateAcquirePolicy } from "./policy";
+import type {
+  AcquireContext,
+  AcquiredContent,
+  AcquireResult,
+  AcquisitionMode,
+  ExtractionQuality,
+} from "./types";
+
+/** Cap on returned content characters — mirrors server-fetch's default. */
+const REMOTE_MAX_CONTENT_CHARS = 16_000;
+
+/** Which browser-side provider produced the material. */
+export type RemoteProvider = "sw-fetch" | "session-tab";
+
+/** Raw material handed back by the extension (never a full envelope). */
+export interface RemoteAcquireMaterial {
+  mode: RemoteProvider;
+  /** P2 sw-fetch: the credentialed raw HTML. */
+  rawHtml?: string;
+  /** P3 session-tab: Readability output from the live DOM. */
+  extracted?: {
+    title?: string;
+    byline?: string;
+    siteName?: string;
+    excerpt?: string;
+    content: string;
+    quality: "readable" | "raw" | "empty";
+  };
+  /** Final URL after redirects, if the extension observed one. */
+  finalUrl?: string;
+}
+
+function isNonEmpty(value: string | undefined | null): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Build the trusted envelope from extension-returned material. Returns the same
+ * `AcquireResult` shape as `acquire()` so callers are provider-agnostic.
+ */
+export async function finalizeRemoteAcquire(
+  url: string,
+  material: RemoteAcquireMaterial,
+  ctx: AcquireContext,
+): Promise<AcquireResult> {
+  const decision = evaluateAcquirePolicy(url, ctx);
+  if (!decision.allowed) {
+    return { ok: false, reason: decision.reason ?? "blocked by acquisition policy" };
+  }
+
+  let title: string | undefined;
+  let byline: string | undefined;
+  let siteName: string | undefined;
+  let excerpt: string | undefined;
+  let publishedAt: string | undefined;
+  let body: string;
+  let quality: ExtractionQuality;
+
+  if (material.mode === "sw-fetch") {
+    if (!isNonEmpty(material.rawHtml)) {
+      return { ok: false, reason: "the extension returned no content" };
+    }
+    const extracted = await extractReadableContent(material.rawHtml, url);
+    title = extracted.title;
+    byline = extracted.byline;
+    siteName = extracted.siteName;
+    excerpt = extracted.excerpt;
+    publishedAt = extracted.publishedTime;
+    body = extracted.content;
+    quality = extracted.quality;
+  } else {
+    const ex = material.extracted;
+    if (!ex || !isNonEmpty(ex.content)) {
+      return { ok: false, reason: "the extension returned no content" };
+    }
+    title = ex.title;
+    byline = ex.byline;
+    siteName = ex.siteName;
+    excerpt = ex.excerpt;
+    body = ex.content;
+    // The reader reports "empty" for no-article pages; treat anything but a
+    // clean article as "raw" so consumers don't over-trust the extraction.
+    quality = ex.quality === "readable" ? "readable" : "raw";
+  }
+
+  const truncated = body.length > REMOTE_MAX_CONTENT_CHARS;
+  const content = truncated ? body.slice(0, REMOTE_MAX_CONTENT_CHARS) : body;
+  const canonicalUrl =
+    isNonEmpty(material.finalUrl) && material.finalUrl !== url
+      ? material.finalUrl
+      : undefined;
+  // sw-fetch is a (credentialed) static fetch; session-tab is a live session render.
+  const mode: AcquisitionMode = material.mode === "session-tab" ? "session" : "static";
+
+  const acquired: AcquiredContent = {
+    content,
+    url,
+    canonicalUrl,
+    title,
+    siteName,
+    byline,
+    publishedAt,
+    excerpt,
+    retrievedAt: new Date().toISOString(),
+    provider: material.mode,
+    mode,
+    trustTier: "untrusted-web",
+    extraction: quality,
+    tokenEstimate: Math.ceil(content.length / 4),
+    truncated,
+  };
+
+  // Garden-as-corpus caching, fire-and-forget by contract (same as P1).
+  void hydrateExternalPayload(ctx.userId, acquired);
+
+  return { ok: true, content: acquired };
+}

--- a/lib/domain/ai/tools/registry.ts
+++ b/lib/domain/ai/tools/registry.ts
@@ -96,7 +96,12 @@ export function createBaseTools(ctx: ToolExecuteContext) {
         if (!result.ok || !result.content) {
           // String result (not a throw) so the model relays the refusal
           // gracefully — registry convention (see notify_user).
-          return `Could not read the page: ${result.reason ?? "unknown error"}.`;
+          return (
+            `Could not read the page: ${result.reason ?? "unknown error"}. ` +
+            `If the user has the browser extension installed, they can open this ` +
+            `link in the app and click "Read full content" to fetch it with their ` +
+            `own browser session (which gets past pages that block server fetches).`
+          );
         }
         const c = result.content;
         // Bot-walled sites (Indeed, LinkedIn, …) return a challenge page —
@@ -106,8 +111,10 @@ export function createBaseTools(ctx: ToolExecuteContext) {
           return (
             `The page returned almost no readable content (${c.content.length} chars) — ` +
             `this site likely blocks automated access. Ask the user to either paste the ` +
-            `content directly, or try a direct/public version of the page (e.g. the ` +
-            `company's own careers page instead of a job-board aggregator).`
+            `content directly, open this link in the app and click "Read full content" ` +
+            `(which fetches it with their own browser session via the extension), or try ` +
+            `a direct/public version of the page (e.g. the company's own careers page ` +
+            `instead of a job-board aggregator).`
           );
         }
         // Settle-then-associate (AI v3 core S3, umbrella #14): a successful

--- a/lib/domain/browser-extension/acquire-url.ts
+++ b/lib/domain/browser-extension/acquire-url.ts
@@ -20,6 +20,7 @@ import {
   requestExtensionAcquire,
   type ExtensionAcquireMode,
 } from "./page-bridge-client";
+import { isPanelEmbedSurface, requestPanelAcquire } from "./panel-bridge";
 import type { AcquiredContent } from "@/lib/domain/ai/acquisition/types";
 
 /** Below this, an extraction is treated as a failed rung and escalates. */
@@ -67,12 +68,27 @@ async function callAcquireApi(
   }
 }
 
-/** One extension rung: ask the extension for material, then finalize server-side. */
+/**
+ * True when the extension is reachable — via the page-bridge (a tab's top
+ * frame) OR the panel-host channel (the side-panel iframe, where the page-bridge
+ * content script can't run).
+ */
+function extensionAvailable(): boolean {
+  return isPanelEmbedSurface() || isExtensionInstalled();
+}
+
+/**
+ * One extension rung: ask the extension for material, then finalize server-side.
+ * In the panel embed the page-bridge isn't present, so route through the panel
+ * host instead — same background provider, different channel.
+ */
 async function extensionRung(
   url: string,
   mode: ExtensionAcquireMode,
 ): Promise<{ ok: boolean; content?: AcquiredContent; reason?: string }> {
-  const material = await requestExtensionAcquire(url, { mode });
+  const material = isPanelEmbedSurface()
+    ? await requestPanelAcquire(url, mode)
+    : await requestExtensionAcquire(url, { mode });
   if (!material.ok) {
     return { ok: false, reason: material.reason ?? "extension could not fetch this page" };
   }
@@ -91,8 +107,8 @@ export async function acquireUrlWithFallback(url: string): Promise<AcquireOutcom
   }
   const p1Reason = p1.ok ? "the site returned little readable content" : p1.reason;
 
-  // No extension → return the best P1 had (content if any, else the reason).
-  if (!isExtensionInstalled()) {
+  // No extension reachable → return the best P1 had (content if any, else reason).
+  if (!extensionAvailable()) {
     return {
       ok: Boolean(p1.content),
       content: p1.content,

--- a/lib/domain/browser-extension/acquire-url.ts
+++ b/lib/domain/browser-extension/acquire-url.ts
@@ -71,9 +71,10 @@ async function callAcquireApi(
 /**
  * True when the extension is reachable — via the page-bridge (a tab's top
  * frame) OR the panel-host channel (the side-panel iframe, where the page-bridge
- * content script can't run).
+ * content script can't run). Exported so UIs can hide extension-only fetch
+ * options (P2/P3) when there's no extension.
  */
-function extensionAvailable(): boolean {
+export function isExtensionAcquireAvailable(): boolean {
   return isPanelEmbedSurface() || isExtensionInstalled();
 }
 
@@ -108,7 +109,7 @@ export async function acquireUrlWithFallback(url: string): Promise<AcquireOutcom
   const p1Reason = p1.ok ? "the site returned little readable content" : p1.reason;
 
   // No extension reachable → return the best P1 had (content if any, else reason).
-  if (!extensionAvailable()) {
+  if (!isExtensionAcquireAvailable()) {
     return {
       ok: Boolean(p1.content),
       content: p1.content,
@@ -135,6 +136,44 @@ export async function acquireUrlWithFallback(url: string): Promise<AcquireOutcom
     ok: false,
     reason: p3.reason ?? p2.reason ?? p1Reason ?? "couldn't acquire this page",
     via: "session-tab",
+    usedExtension: true,
+  };
+}
+
+/**
+ * Run ONE specific provider, no escalation — powers the "Read full content"
+ * press-and-hold quick-pick so the user can force server-fetch / sw-fetch /
+ * session-tab directly. `server-fetch` never needs the extension; the other two
+ * short-circuit with a clear reason when it isn't reachable.
+ */
+export async function acquireUrlVia(
+  url: string,
+  via: AcquireVia
+): Promise<AcquireOutcome> {
+  if (via === "server-fetch") {
+    const p1 = await callAcquireApi({ url });
+    return {
+      ok: p1.ok,
+      content: p1.content,
+      reason: p1.ok ? undefined : p1.reason,
+      via: "server-fetch",
+      usedExtension: false,
+    };
+  }
+  if (!isExtensionAcquireAvailable()) {
+    return {
+      ok: false,
+      reason: "the browser extension isn't available on this surface",
+      via,
+      usedExtension: false,
+    };
+  }
+  const rung = await extensionRung(url, via === "sw-fetch" ? "sw-fetch" : "session-tab");
+  return {
+    ok: rung.ok,
+    content: rung.content,
+    reason: rung.ok ? undefined : rung.reason,
+    via,
     usedExtension: true,
   };
 }

--- a/lib/domain/browser-extension/acquire-url.ts
+++ b/lib/domain/browser-extension/acquire-url.ts
@@ -1,0 +1,124 @@
+/**
+ * Client-mediated URL acquisition (BROWSER-REACH B5).
+ *
+ * The Acquisition Service runs server-side, but P2/P3 execute in the user's
+ * browser — the server can't reach the extension. So the escalation ladder is
+ * orchestrated here, on the client:
+ *
+ *   P1 server-fetch  → POST /api/ai/acquisition { url }
+ *   P2 sw-fetch       → extension credentialed fetch → POST finalize { url, remote }
+ *   P3 session-tab    → extension session render     → POST finalize { url, remote }
+ *
+ * Each rung escalates when the previous one FAILS or comes back too thin to be
+ * useful (a bot-hostile page often 200s with a challenge/JS-required stub). The
+ * extension steps are skipped entirely when it isn't installed. The server
+ * always builds the trusted envelope — the extension only supplies raw material.
+ */
+
+import {
+  isExtensionInstalled,
+  requestExtensionAcquire,
+  type ExtensionAcquireMode,
+} from "./page-bridge-client";
+import type { AcquiredContent } from "@/lib/domain/ai/acquisition/types";
+
+/** Below this, an extraction is treated as a failed rung and escalates. */
+const THIN_CONTENT_CHARS = 200;
+
+export type AcquireVia = "server-fetch" | "sw-fetch" | "session-tab";
+
+export interface AcquireOutcome {
+  ok: boolean;
+  content?: AcquiredContent;
+  reason?: string;
+  /** Which rung produced the returned content (or failed last). */
+  via?: AcquireVia;
+  /** True when an extension rung was attempted (P2/P3). */
+  usedExtension: boolean;
+}
+
+interface AcquireApiResponse {
+  success: boolean;
+  data?: AcquiredContent;
+  error?: { code?: string; message?: string };
+}
+
+function isThin(content: string | undefined): boolean {
+  return !content || content.trim().length < THIN_CONTENT_CHARS;
+}
+
+async function callAcquireApi(
+  body: Record<string, unknown>,
+): Promise<{ ok: boolean; content?: AcquiredContent; reason?: string }> {
+  try {
+    const res = await fetch("/api/ai/acquisition", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as AcquireApiResponse;
+    if (json.success && json.data) return { ok: true, content: json.data };
+    return { ok: false, reason: json.error?.message ?? "acquisition failed" };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : "acquisition request failed",
+    };
+  }
+}
+
+/** One extension rung: ask the extension for material, then finalize server-side. */
+async function extensionRung(
+  url: string,
+  mode: ExtensionAcquireMode,
+): Promise<{ ok: boolean; content?: AcquiredContent; reason?: string }> {
+  const material = await requestExtensionAcquire(url, { mode });
+  if (!material.ok) {
+    return { ok: false, reason: material.reason ?? "extension could not fetch this page" };
+  }
+  return callAcquireApi({ url, remote: material });
+}
+
+/**
+ * Acquire `url`, escalating P1 → P2 → P3 as needed. Returns the trusted envelope
+ * and which rung produced it, or a reason if every available rung failed.
+ */
+export async function acquireUrlWithFallback(url: string): Promise<AcquireOutcome> {
+  // Rung 1 — server-fetch.
+  const p1 = await callAcquireApi({ url });
+  if (p1.ok && !isThin(p1.content?.content)) {
+    return { ok: true, content: p1.content, via: "server-fetch", usedExtension: false };
+  }
+  const p1Reason = p1.ok ? "the site returned little readable content" : p1.reason;
+
+  // No extension → return the best P1 had (content if any, else the reason).
+  if (!isExtensionInstalled()) {
+    return {
+      ok: Boolean(p1.content),
+      content: p1.content,
+      reason: p1.content ? undefined : p1Reason,
+      via: "server-fetch",
+      usedExtension: false,
+    };
+  }
+
+  // Rung 2 — sw-fetch (credentialed static). Cheap; may clear a cookie wall.
+  const p2 = await extensionRung(url, "sw-fetch");
+  if (p2.ok && !isThin(p2.content?.content)) {
+    return { ok: true, content: p2.content, via: "sw-fetch", usedExtension: true };
+  }
+
+  // Rung 3 — session-tab (full JS render in the user's session).
+  const p3 = await extensionRung(url, "session-tab");
+  if (p3.ok) {
+    return { ok: true, content: p3.content, via: "session-tab", usedExtension: true };
+  }
+
+  // Everything failed — surface the most informative reason we saw, newest first.
+  return {
+    ok: false,
+    reason: p3.reason ?? p2.reason ?? p1Reason ?? "couldn't acquire this page",
+    via: "session-tab",
+    usedExtension: true,
+  };
+}

--- a/lib/domain/browser-extension/page-bridge-client.ts
+++ b/lib/domain/browser-extension/page-bridge-client.ts
@@ -1,0 +1,181 @@
+/**
+ * Page-bridge client (BROWSER-REACH B5).
+ *
+ * The app talks to the browser extension through a content-script bridge
+ * (`page-bridge.js`): the app posts a `dg-browser-bookmarks-app` request (via
+ * both `window.postMessage` and a `dg-browser-bookmarks-request` CustomEvent),
+ * the extension replies with a `dg-browser-bookmarks-extension` message/event.
+ * This is the ONLY app→extension channel that works on any app page (there is
+ * deliberately no `externally_connectable`), so acquisition requests ride it.
+ *
+ * The request/response plumbing was previously trapped inside
+ * `BrowserBookmarksSettingsPage`; this module is the reusable extraction so the
+ * acquisition flow (and, later, the settings page + SendToTabButton) share one
+ * implementation. Everything here is a client-only no-op when there's no DOM.
+ */
+
+const APP_SOURCE = "dg-browser-bookmarks-app";
+const EXTENSION_SOURCE = "dg-browser-bookmarks-extension";
+const PRESENCE_NODE_ID = "dg-browser-bookmarks-extension-presence";
+const DEFAULT_TIMEOUT_MS = 3000;
+// A session-tab fetch loads a real page and waits for it to settle before
+// extracting, so acquisition needs a much longer ceiling than a config read.
+const ACQUIRE_TIMEOUT_MS = 30_000;
+
+/** True when the extension's content script has announced itself on this page. */
+export function isExtensionInstalled(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.getElementById(PRESENCE_NODE_ID) !== null;
+}
+
+/** Fire a request at the extension over both transports the bridge listens on. */
+export function dispatchBridgeRequest(
+  type: string,
+  payload?: Record<string, unknown>
+): void {
+  if (typeof window === "undefined") return;
+  window.postMessage({ source: APP_SOURCE, type, payload }, window.location.origin);
+  document.dispatchEvent(
+    new CustomEvent("dg-browser-bookmarks-request", {
+      detail: { source: APP_SOURCE, type, payload },
+    })
+  );
+}
+
+/**
+ * Send `requestType` and resolve with the payload of the first matching
+ * `successType` reply, rejecting on `bridge-error` or after `timeoutMs`.
+ * Listens on both the `message` and CustomEvent transports.
+ */
+export function requestBridgeResponse<T>(
+  requestType: string,
+  successType: string,
+  payload?: Record<string, unknown>,
+  timeoutMs = DEFAULT_TIMEOUT_MS
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = () => {
+      window.removeEventListener("message", handleMessage);
+      document.removeEventListener(
+        "dg-browser-bookmarks-response",
+        handleBridgeEvent as EventListener
+      );
+      window.clearTimeout(timeoutId);
+    };
+
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+
+    const inspect = (type: string | undefined, detailPayload: unknown): boolean => {
+      if (type === successType) {
+        finish(() => resolve(detailPayload as T));
+        return true;
+      }
+      if (type === "bridge-error") {
+        finish(() =>
+          reject(
+            new Error(
+              (detailPayload as { message?: string } | undefined)?.message ||
+                "Browser extension bridge failed"
+            )
+          )
+        );
+        return true;
+      }
+      return false;
+    };
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.source !== window) return;
+      if (event.data?.source !== EXTENSION_SOURCE) return;
+      inspect(event.data.type, event.data.payload);
+    };
+
+    const handleBridgeEvent = (event: Event) => {
+      const customEvent = event as CustomEvent<{
+        source?: string;
+        type?: string;
+        payload?: unknown;
+      }>;
+      if (customEvent.detail?.source !== EXTENSION_SOURCE) return;
+      inspect(customEvent.detail?.type, customEvent.detail?.payload);
+    };
+
+    const timeoutId = window.setTimeout(() => {
+      finish(() => reject(new Error("Timed out waiting for the browser extension")));
+    }, timeoutMs);
+
+    window.addEventListener("message", handleMessage);
+    document.addEventListener(
+      "dg-browser-bookmarks-response",
+      handleBridgeEvent as EventListener
+    );
+
+    dispatchBridgeRequest(requestType, payload);
+  });
+}
+
+// ── Acquisition over the bridge (B5, P2/P3) ──────────────────────────────────
+
+/** Which browser-side provider the extension should run. */
+export type ExtensionAcquireMode = "session-tab" | "sw-fetch";
+
+/** Readability output from a session-tab (P3) extraction — envelope-less. */
+export interface ExtensionExtracted {
+  title?: string;
+  byline?: string;
+  siteName?: string;
+  excerpt?: string;
+  content: string;
+  quality: "readable" | "raw" | "empty";
+}
+
+/**
+ * Flat result (repo is `strict:false`, matching the acquisition types' own
+ * convention). `ok` true ⇒ exactly one of `rawHtml` (P2) / `extracted` (P3) is
+ * set; `ok` false ⇒ `reason` explains the refusal (policy denial, budget, …).
+ * The extension NEVER builds the trusted envelope — the server does that from
+ * this raw material, so provenance/trust stay server-authoritative.
+ */
+export interface ExtensionAcquireResult {
+  ok: boolean;
+  mode?: ExtensionAcquireMode;
+  url?: string;
+  finalUrl?: string;
+  rawHtml?: string;
+  extracted?: ExtensionExtracted;
+  reason?: string;
+}
+
+/**
+ * Ask the extension to acquire `url` with the user's session. Returns a
+ * structured result (policy denials/budget come back as `ok:false`, not a
+ * throw); a missing extension resolves `ok:false` too so callers can fall back.
+ */
+export async function requestExtensionAcquire(
+  url: string,
+  opts: { mode: ExtensionAcquireMode }
+): Promise<ExtensionAcquireResult> {
+  if (!isExtensionInstalled()) {
+    return { ok: false, reason: "extension not available" };
+  }
+  try {
+    return await requestBridgeResponse<ExtensionAcquireResult>(
+      "acquire-url",
+      "acquire-url-result",
+      { url, mode: opts.mode },
+      ACQUIRE_TIMEOUT_MS
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : "acquire failed",
+    };
+  }
+}

--- a/lib/domain/browser-extension/panel-bridge.ts
+++ b/lib/domain/browser-extension/panel-bridge.ts
@@ -9,6 +9,12 @@
  * affordances unconditionally and let the surface decide.
  */
 
+import { isAllowedEmbedMessageOrigin } from "./embed-message-origins";
+import type {
+  ExtensionAcquireMode,
+  ExtensionAcquireResult,
+} from "./page-bridge-client";
+
 export type OverlayCorner =
   | "top-left"
   | "top-right"
@@ -214,6 +220,59 @@ export function requestOpenUrl(url: string): void {
     { v: 1, source: "dg-panel-embed", type: "open-url", payload: { url } },
     "*"
   );
+}
+
+const PANEL_ACQUIRE_TIMEOUT_MS = 35_000;
+
+/**
+ * Panel-embed acquisition (B5). The extension's `page-bridge` content script
+ * doesn't run in this iframe, so acquisition can't use it here — it rides the
+ * panel-host channel instead (embed → host → background → provider). Unlike the
+ * fire-and-forget helpers above, this is a promise-based round-trip: the host
+ * replies with a single `acquire-url-result`. Only meaningful in the panel
+ * embed; resolves `ok:false` elsewhere so the caller can fall back.
+ *
+ * Requests are issued sequentially by the acquisition ladder (P2 then P3), so a
+ * single in-flight listener is sufficient — no request id needed.
+ */
+export function requestPanelAcquire(
+  url: string,
+  mode: ExtensionAcquireMode
+): Promise<ExtensionAcquireResult> {
+  return new Promise((resolve) => {
+    if (!isPanelEmbedSurface()) {
+      resolve({ ok: false, reason: "not in the panel embed" });
+      return;
+    }
+    let settled = false;
+    const finish = (result: ExtensionAcquireResult) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timer);
+      window.removeEventListener("message", onMessage);
+      resolve(result);
+    };
+    function onMessage(event: MessageEvent) {
+      if (!isAllowedEmbedMessageOrigin(event.origin)) return;
+      const data = event.data;
+      if (!data || typeof data !== "object") return;
+      if (data.v !== 1 || data.source !== "dg-panel-host") return;
+      if (data.type === "acquire-url-result") {
+        finish(
+          (data.payload ?? { ok: false, reason: "empty result" }) as ExtensionAcquireResult
+        );
+      }
+    }
+    const timer = window.setTimeout(
+      () => finish({ ok: false, reason: "the extension took too long" }),
+      PANEL_ACQUIRE_TIMEOUT_MS
+    );
+    window.addEventListener("message", onMessage);
+    window.parent.postMessage(
+      { v: 1, source: "dg-panel-embed", type: "acquire-url", payload: { url, mode } },
+      "*"
+    );
+  });
 }
 
 /** Decode a data: URL into a File for the chat's attachment path. */


### PR DESCRIPTION
Browser Reach **B5** — the extension becomes a **remote acquisition provider** for the app-side Acquisition Service, so the app can read pages a server fetch can't (behind cookies / needing JS) using the user's own browser session. Owner-validated end-to-end (P1 → P2 → P3, in both the main app and the side panel).

**Architecture:** `acquire()` runs server-side but the providers run in the browser, and there's no `externally_connectable`. So the P1→P2→P3 escalation is **client-orchestrated** over the bridge, and the **server builds the trusted `AcquiredContent` envelope** from the extension's raw material — the untrusted extension never asserts trust/provenance. No `offscreen` (server extracts P2's HTML) and no manifest change (tabs/scripting/cookies/`<all_urls>` already present).

---

## Sprint 1 — Acquisition providers (extension side)

- **P2 sw-fetch**: background credentialed `fetch()` (user's cookies) → raw HTML.
- **P3 session-tab**: inactive `tabs.create({active:false})` → injected reader (Readability) → extracted content → close.
- Local policy gate (non-negotiable SSRF/private-network block + app-issued/user deny list + per-window budget) + an activity badge. New `acquire-url` message handler + page-bridge relay.

**Gate:** `pnpm extension:build` ✓; policy denials + budget return structured refusals.

## Sprint 2 — Server finalize + client ladder + UI

- `remote-acquire.ts` builds the envelope from raw material (reuses `extractReadableContent` for P2 HTML + `hydrate`), re-checking policy. `POST /api/ai/acquisition` runs P1 for `{url}` or finalizes `{url, remote}`.
- `acquireUrlWithFallback` ladder: P1 → P2 → P3, escalating on failure **or thin content** (<200 chars); skips extension rungs when unavailable.
- `ExternalLinkViewer` gains **"Read full content"** (works standalone on P1; extension enhances). `read_page` failure hints point users to it.

**Gate:** typecheck ✓ + lint ✓ + full build ✓.

## Sprint 3 — Panel-bridge path (works in the side panel)

- The page-bridge content script runs only in a tab's top frame, so acquisition in the side-panel iframe was silently P1-only. Added a promise-based `requestPanelAcquire` (embed → panel host → background provider → `acquire-url-result`) and routed the ladder through it when `isPanelEmbedSurface()`.

**Gate:** typecheck ✓ + `pnpm extension:build` ✓; owner-confirmed P3 firing in the panel.

## Sprint 4 — Press-and-hold quick-pick

- Short click = auto ladder; press-and-hold (or the caret) = quick-pick to force **Auto / Server fetch / Browser session (P2) / Background tab (P3)**. `acquireUrlVia(url, via)` runs a single provider; extension-only options disable ("needs extension") when unavailable.

**Gate:** typecheck ✓ + lint ✓ (0 errors).

## Sprint 5 — Panel dialog-stacking fixes (bundled)

- The `ExternalLinkDialog` (and 9 other portaled dialogs/pickers) rendered at z-50, *behind* the panel's `#embed-root` (z-100) — visible/interactive in the app, silently click-swallowed in the panel. Lifted them to z-[200].

**Gate:** typecheck ✓; owner-confirmed the create-external dialog works in the panel now.

---

## Housekeeping (in this branch)

- **B3-A removed entirely** from BACKLOG.
- **Server-side Recents unification scheduled as B6's first task** (delete the `isPanelEmbedSurface()` fork → net code removal); schema guardrail is now lifted.

## Pre-merge checklist

**Gates (green locally)**
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors, 151/175 warnings — none in new files)
- [x] `NODE_OPTIONS='--max-old-space-size=8192' pnpm build`
- [x] `pnpm extension:build`
- [x] No `prisma/schema.prisma` change (Prisma regen noise not committed; CI regenerates)

**Smoke tests (owner-validated in this session)**
- [x] Public page → "via server fetch" (P1); bot-hostile/thin page escalates
- [x] P2/P3 escalation fires in the **main app** and the **side panel** (panel-bridge path)
- [x] Press-and-hold quick-pick forces a specific provider; extension-only options disabled without the extension
- [x] Create-external dialog works in the side panel (z-index fix)
- [x] Denied-domain (capture denylist) fails visibly: "this domain is on your deny list"
- [ ] Budget (10 / 5 min) exhausts politely

**Post-merge**
- [x] No Hocuspocus redeploy needed (no publishing blocks / TipTap schema changes)
- [x] `pnpm extension:build` + reload the extension on machines using it (dist/ is gitignored)

**Follow-ups (tracked in BACKLOG)**
- [ ] AI browser-acquisition tool (client-side, conditionally registered) — the deferred mid-stream chat escalation
- [ ] Clearer quick-pick labels ("Signed-in fetch" / "Signed-in tab")
- [ ] Cache acquired content on the external node so it isn't re-fetched each view

Generated with [Claude Bod](https://claude.com/claude-code)
