### PR TITLE
AI 3.6 follow-up — consolidate playbook menu + rename edit action

### DIFF
--- a/components/content/context-menu/file-tree-actions.tsx
+++ b/components/content/context-menu/file-tree-actions.tsx
@@ -284,19 +284,10 @@ export const fileTreeActionProvider: ContextMenuActionProvider = (ctx) => {
           label: "Add",
           icon: <Plus className="h-4 w-4" />,
           submenu: newMenuItems.map(mapMenuItem),
-          divider: true,
-        },
-        {
-          // Import an Anthropic SKILL.md as a marked playbook note (AI v3.2
-          // T3, P5-import). Uses the same resolved `targetId` as the Add
-          // submenu — folder → into it, file → sibling, empty → root.
-          id: "import-skill-playbook",
-          label: "Import Skill as Playbook…",
-          icon: <BookUp className="h-4 w-4" />,
-          onClick: () => useImportSkillStore.getState().openDialog(targetId),
         },
       ],
     });
+    // "Import Skill as Playbook…" moved to the Playbook section below (v3.6).
   }
 
   if (isPeopleMount) {
@@ -314,26 +305,29 @@ export const fileTreeActionProvider: ContextMenuActionProvider = (ctx) => {
     return sections;
   }
 
-  // --- Playbook: Mark / Edit description / Unmark (v3.6; moved off the editor
-  // context menu). Any note-bearing content — a note, or a folder with a Notes
-  // payload — can become a playbook. State-aware via clickedNode.isPlaybook so
-  // the menu shows the right verb; editing the description opens a centered
-  // modal (a modal never grows the menu past the viewport, unlike an inline
-  // input). Mark/unmark just flag NotePayload.metadata; the file's title is the
-  // playbook name and its `##` sections are the phases.
-  if (
-    isSingleSelection &&
-    clickedId &&
-    clickedNode &&
-    (clickedNode.contentType === "note" || clickedNode.contentType === "folder")
-  ) {
-    const playbookTitle = clickedNode.title;
-    const contentId = clickedId;
-    const playbookActions: ContextMenuAction[] = clickedNode.isPlaybook
-      ? [
+  // --- Playbook (v3.6; consolidated off the editor context menu) ---
+  // Import Skill turns a pasted SKILL.md into a marked playbook note.
+  // Mark / Edit / Unmark act on a single note (or folder with a Notes payload);
+  // state-aware via clickedNode.isPlaybook so the menu shows the right verb.
+  // Editing details opens a centered modal — a modal never grows the menu past
+  // the viewport, unlike an inline input. The file's title is the playbook name
+  // and its `##` sections are the phases.
+  {
+    const playbookActions: ContextMenuAction[] = [];
+
+    if (
+      isSingleSelection &&
+      clickedId &&
+      clickedNode &&
+      (clickedNode.contentType === "note" || clickedNode.contentType === "folder")
+    ) {
+      const playbookTitle = clickedNode.title;
+      const contentId = clickedId;
+      if (clickedNode.isPlaybook) {
+        playbookActions.push(
           {
-            id: "edit-playbook-description",
-            label: "Edit Playbook Description…",
+            id: "edit-playbook-details",
+            label: "Edit Playbook Details…",
             icon: <BookMarked className="h-4 w-4" />,
             onClick: () =>
               usePlaybookDialogStore.getState().openDialog({
@@ -361,21 +355,42 @@ export const fileTreeActionProvider: ContextMenuActionProvider = (ctx) => {
               }
             },
           },
-        ]
-      : [
-          {
-            id: "mark-as-playbook",
-            label: "Mark as Playbook…",
-            icon: <BookMarked className="h-4 w-4" />,
-            onClick: () =>
-              usePlaybookDialogStore.getState().openDialog({
-                contentId,
-                title: playbookTitle,
-                editing: false,
-              }),
-          },
-        ];
-    sections.push({ title: "Playbook", actions: playbookActions });
+        );
+      } else {
+        playbookActions.push({
+          id: "mark-as-playbook",
+          label: "Mark as Playbook…",
+          icon: <BookMarked className="h-4 w-4" />,
+          onClick: () =>
+            usePlaybookDialogStore.getState().openDialog({
+              contentId,
+              title: playbookTitle,
+              editing: false,
+            }),
+        });
+      }
+    }
+
+    // Import Skill — available wherever new content can be created (single
+    // selection or empty space). Same target rule as the Add submenu:
+    // folder → into it, file/note → sibling, empty → root.
+    if (isSingleSelection || !clickedId) {
+      const importTarget: string | null = !clickedId
+        ? null
+        : isFolder
+          ? clickedId
+          : clickedNode?.parentId ?? null;
+      playbookActions.push({
+        id: "import-skill-playbook",
+        label: "Import Skill as Playbook…",
+        icon: <BookUp className="h-4 w-4" />,
+        onClick: () => useImportSkillStore.getState().openDialog(importTarget),
+      });
+    }
+
+    if (playbookActions.length > 0) {
+      sections.push({ title: "Playbook", actions: playbookActions });
+    }
   }
 
   // Section 2: Folder view mode (folder only, single selection)

--- a/components/content/dialogs/PlaybookDescriptionDialog.tsx
+++ b/components/content/dialogs/PlaybookDescriptionDialog.tsx
@@ -88,7 +88,7 @@ function Body({
       window.dispatchEvent(new CustomEvent("dg:tree-refresh"));
       toast.success(
         editing
-          ? "Playbook description updated"
+          ? "Playbook details updated"
           : "Marked as playbook — attach it from any chat with /playbook",
       );
       onClose();
@@ -103,7 +103,7 @@ function Body({
       <DialogHeader>
         <DialogTitle className="flex items-center gap-2">
           <BookMarked className="h-4 w-4 text-indigo-400" />
-          {editing ? "Edit Playbook Description" : "Mark as Playbook"}
+          {editing ? "Edit Playbook Details" : "Mark as Playbook"}
         </DialogTitle>
       </DialogHeader>
 


### PR DESCRIPTION
Follow-up to **#134** (AI 3.6). Two small UX refinements to the file-tree playbook menu, requested during smoke testing. 3.6 itself is already merged; this PR carries only the changes below.

## Sprint 1 — Playbook menu polish

- **Consolidated the playbook menu.** "Import Skill as Playbook…" moved out of the **Add** section and into the **Playbook** section, so every playbook action (Import / Mark / Edit / Unmark) lives in one group. Its import-target logic is unchanged — folder → into it, file/note → sibling, empty → root — and it stays available in the same contexts as before (single selection or empty space).
- **Renamed** "Edit Playbook Description…" → **"Edit Playbook Details…"** (menu label + modal title + save toast), leaving room for the dialog to grow beyond just the description later.

**What "Import Skill as Playbook…" is** (for the record): it opens a dialog to paste/load an Anthropic **SKILL.md** (YAML frontmatter `name`/`description` + markdown body) and turns it into a marked playbook note whose `##` sections become phases. Kept — it's a legitimate import path.

**Gate:** `pnpm typecheck` + `pnpm lint` (0 errors, 151 warnings — under the 175 ratchet, all pre-existing).

## Pre-merge checklist

**Gates**
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors, no new warnings

**Smoke test (owner)**
- [ ] Right-click a folder/note → the **Playbook** section now contains "Import Skill as Playbook…" (no longer under Add)
- [ ] Right-click empty space / a file → "Import Skill as Playbook…" still appears (Playbook section) and imports to the right target
- [ ] Right-click a playbook note → action reads **"Edit Playbook Details…"**; opening it shows the same centered modal
- [ ] Mark / Unmark still work; badge still toggles

**Migrations / Post-merge**
- [x] None (menu-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
