### PR TITLE
feat(showcase): developer-presence S1+S2 — AI-first README, figure signal system, /demo page, MCP design of record

### DIFF
--- a/.claude/skills/update-showcase/SKILL.md
+++ b/.claude/skills/update-showcase/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: update-showcase
+description: Refresh the recruiter-facing showcase (README, figure registry, demo page, GitHub metadata) against what has actually shipped on main. Use when the user says "update the showcase", after merging notable features or releases, or when the README/roadmap has drifted from reality. Keeps high-demand AI competencies as the presentation driver.
+---
+
+# Update the Showcase
+
+Follow the canonical ritual in
+[docs/notes-feature/guides/showcase/SHOWCASE-MAINTENANCE.md](../../../docs/notes-feature/guides/showcase/SHOWCASE-MAINTENANCE.md).
+Operational checklist:
+
+1. **Baseline**: `git fetch origin`, then `git log -1 --format=%ci -- README.md` and
+   `git log --oneline --since=<that date> origin/main`. Cross-check `docs/notes-feature/STATUS.md`
+   Recent Completions. Build the list of shipped-but-unshowcased work.
+2. **README.md**:
+   - Promote shipped `🔭 Planned` roadmap items into the competency table / feature tour with a
+     repo-relative code link (verify with `git ls-tree origin/main <path>` — never trust the local
+     checkout, it may be behind).
+   - Add new planned items with `🔭` labels. Never let an unshipped capability appear unlabeled.
+   - Re-verify Quickstart commands/ports/env vars against `package.json` and `CLAUDE.md`.
+   - Ordering bias: agentic orchestration → AI infrastructure → multimodal → everything else.
+3. **Figures**: for each new feature worth showing, add a `## Fig <id> — <title>` capture brief to
+   `docs/media/figures/FIGURES.md` (next free number in its section; never renumber) and a
+   `<!-- fig:<id> --> <!-- /fig:<id> -->` slot in the README. Never hand-edit inside slot markers.
+   Then run `pnpm showcase:figures` and include its rewrites in the change.
+4. **Demo page**: if a real demo video now exists, replace the placeholder frame in
+   `components/personal/DemoPage.tsx` with the embed, keeping the custom-demo CTA and the URL.
+5. **GitHub metadata**: if positioning changed, `gh repo edit --description "..."` and
+   `--add-topic` for any new competency keywords (e.g. `mcp` once it ships).
+6. **Gates**: `pnpm typecheck && pnpm lint` when code changed; for markdown-only updates, verify
+   all new relative links resolve.
+7. **Trackers**: update workstream status in
+   `docs/notes-feature/work-tracking/DEVELOPER-PRESENCE-PLAN.md` and the Standing Decisions table
+   in the maintenance guide if any decision changed.
+8. **Report**: summarize what was promoted, what was newly planned, and which figures are still
+   awaiting media (read the count from the `pnpm showcase:figures` output).
+
+Do not open a standalone docs-only PR for this; bundle with the next feature/chore PR unless the
+user asks otherwise.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,70 @@
+# Digital Garden — environment template
+#
+# COMMITTED to source control as a template. Your real `.env.local` is gitignored.
+# Never put real secrets in this file.
+#
+#   cp .env.example .env.local
+#
+# Full variable reference with per-group explanations: docs/DEPLOYMENT.md
+# Local Docker Postgres specifics: .env.docker.example + guides/database/LOCAL-POSTGRES.md
+
+# ── Core (required) ──────────────────────────────────────────────────────────
+# Local dev: keep host as `localhost` — Docker's Postgres binding breaks with
+# explicit 127.0.0.1 / ::1 literals.
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/digital_garden_dev?schema=public"
+# Required when DATABASE_URL points at local Docker Postgres (db:target safety check).
+LOCAL_POSTGRES=1
+
+# 32-byte hex key; encrypts stored storage-provider + AI credentials.
+# Generate:  openssl rand -hex 32
+STORAGE_ENCRYPTION_KEY=""
+
+# Google OAuth sign-in.
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+
+# Session signing secret.  Generate:  openssl rand -base64 32
+NEXTAUTH_SECRET=""
+
+# ── Collaboration (required for live co-editing in dev) ─────────────────────
+# Run `pnpm dev:collab` in a second terminal from the SAME checkout.
+NEXT_PUBLIC_HOCUSPOCUS_URL="ws://localhost:1234"
+COLLABORATION_TOKEN_SECRET=""
+
+# ── Platform & site (optional in dev) ───────────────────────────────────────
+# PLATFORM_DOMAIN=""
+# NEXT_PUBLIC_SITE_URL=""
+# NEXT_PUBLIC_BASE_URL=""
+# SITE_OWNER_ID=""
+# MULTITENANT_ENABLED=""
+# CRON_SECRET=""
+
+# ── Workflows / n8n spoke (optional) ─────────────────────────────────────────
+# N8N_BASE_URL=""
+# N8N_API_KEY=""
+# Public URL n8n can call back to — a localhost dev server is NOT reachable.
+# WORKFLOWS_CALLBACK_BASE_URL=""
+
+# ── Storage providers (configure at least one; also configurable in-app) ────
+# Cloudflare R2 (primary)
+# R2_ACCOUNT_ID=""
+# R2_ACCESS_KEY_ID=""
+# R2_SECRET_ACCESS_KEY=""
+# R2_BUCKET_NAME=""
+# R2_ENDPOINT=""
+# Vercel Blob
+# BLOB_READ_WRITE_TOKEN=""
+
+# ── AI (optional — BYOK keys are configured in-app; these are fallbacks) ────
+# OPENAI_API_KEY=""
+# GOOGLE_AI_API_KEY=""
+# Media generation providers:
+# TOGETHER_API_KEY=""
+# FIREWORKS_API_KEY=""
+# FAL_API_KEY=""
+# RUNWAY_API_KEY=""
+
+# ── Observability (optional) ────────────────────────────────────────────────
+# LOG_LEVEL=""
+# LOG_TRACE=""
+# LOG_RECORD=""

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ next-env.d.ts
 # ── env files (opt-in for committing if needed) ─────────────────────────────
 .env*
 !.env.docker.example
+!.env.example
 
 # ── local-only AI/developer artifacts ───────────────────────────────────────
 # Local agent / AI assistant working files. The `.claude/worktrees/` path

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ pnpm collab:schema:check  # CI gate: validate collaboration schema covers all ed
 pnpm publishing:schema:check  # CI gate: validate every publishing block has Server* variant + correct registerBlock type
 pnpm publishing:audit:defaults  # Static drift detector: Zod defaults vs renderHTML fallbacks across publishing blocks
 pnpm publishing:audit:themes  # Static theme-coverage audit: flags `.public-prose .block-*` rules with extreme colors (white-ish / dark-ish) that lack a `.dark` companion. Triage required — theme-stable surfaces (pricing, testimonial, etc.) are intentional false positives.
+pnpm showcase:figures # Sync README/docs figure slots with media in docs/media/figures/ + rewrite the FIGURES.md audit (see guides/showcase/SHOWCASE-MAINTENANCE.md; /update-showcase skill)
 pnpm test:e2e         # Playwright visual regression (assumes pnpm dev is running)
 pnpm test:e2e:update  # Regenerate baseline screenshots
 pnpm test:e2e:report  # Open last HTML run report

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 David Valentine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![React 19](https://img.shields.io/badge/React-19-149eca)
 ![TypeScript strict](https://img.shields.io/badge/TypeScript-strict%2C%20no%20any-3178c6)
 ![AI SDK v6](https://img.shields.io/badge/AI%20SDK-v6-000)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 An Obsidian-class knowledge IDE that grew into an **AI automation platform**: agentic chat with a
 typed tool registry, reusable agent playbooks, durable workflows with an n8n spoke, resumable AI
@@ -291,8 +292,7 @@ Labeled honestly — nothing below is shipped yet:
 
 ## License & contact
 
-License: not yet selected — all rights reserved for now. If you want to build on something here,
-[reach out](https://davidvalentine.org/contact).
+[MIT](LICENSE). If you want to build on something here, [reach out](https://davidvalentine.org/contact).
 
 Built and maintained by [David Valentine](https://davidvalentine.org) ·
 [Request a demo](https://davidvalentine.org/demo)

--- a/README.md
+++ b/README.md
@@ -1,435 +1,298 @@
-# Digital Garden - Content IDE
-
-A modern, Obsidian-inspired knowledge management system built with Next.js 16. Combines rich text editing, multi-cloud storage, hierarchical file organization, and an elegant glass-morphism UI.
-
-## Features
-
-### Core Functionality
-- **Panel-Based Layout** - Resizable left/right sidebars with persistent state
-- **Rich Text Editor** - TipTap-powered editor with markdown shortcuts, tables, code blocks
-- **File Tree** - Drag-and-drop file organization with react-arborist
-- **Multi-Cloud Storage** - Support for Cloudflare R2, AWS S3, and Vercel Blob
-- **Search & Tags** - Full-text search with tag filtering and backlink tracking
-- **Custom Extensions** - Wiki-links `[[Note Title]]`, callouts, slash commands, task lists
-
-### Content Types
-- **Notes** - Rich markdown content with TipTap JSON
-- **Files** - Images, PDFs, videos, audio, office documents
-- **Code** - Syntax-highlighted code snippets (50+ languages)
-- **HTML** - Rendered HTML content
-
-### Design System
-- **Liquid Glass** - Glass-morphism design with blur effects and semi-transparent surfaces
-- **Unified Tokens** - Consistent design tokens for surfaces, intents, and motion
-- **Dark Mode** - Full dark mode support via next-themes
-
-## Tech Stack
-
-### Framework & Core
-- **Next.js 16.0.8** - App Router with React Server Components
-- **React 19.2.1** - Latest React with concurrent features
-- **TypeScript 5** - Strict mode type safety
-- **Turbopack** - Fast development builds
-
-### Database & ORM
-- **PostgreSQL** - Primary database (Neon, local, or Prisma Postgres)
-- **Prisma 7.2.0** - Type-safe database client with migrations
-- **ContentNode v2.0** - Hybrid polymorphic content architecture
-
-### UI & State
-- **Tailwind CSS 4** - Utility-first styling with custom design tokens
-- **Radix UI** - Accessible, unstyled component primitives
-- **Zustand 5.0.2** - Lightweight state management with persistence
-- **Allotment 1.20.3** - Resizable panel layout (3.2KB gzipped)
-- **react-arborist 3.4.0** - Virtualized file tree with drag-and-drop
-
-### Rich Text
-- **TipTap 3.15.3** - Extensible rich text editor framework
-- **lowlight 3.3.0** - Syntax highlighting (50+ languages)
-- **Custom Extensions** - Wiki-links, callouts, slash commands, task lists
-
-### Storage
-- **@aws-sdk/client-s3** - S3 and R2 storage integration
-- **@vercel/blob** - Vercel Blob storage
-- **Multi-provider abstraction** - Unified API across storage backends
-
-## Getting Started
-
-### Prerequisites
-
-- **Node.js 20+** - Required for Next.js 16
-- **pnpm** - Package manager (or npm/yarn/bun)
-- **PostgreSQL** - Database (local or cloud-hosted)
-
-### Installation
-
-```bash
-# 1. Clone the repository
-git clone <repository-url>
-cd Digital-Garden
-
-# 2. Install dependencies
-pnpm install
-
-# 3. Set up environment variables
-cp .env.example .env.local
-# Edit .env.local with your database URL and other credentials
-```
-
-### Environment Variables
-
-Required variables for `.env.local`:
-
-```bash
-# Database
-DATABASE_URL="postgresql://user:password@host:5432/database"
-
-# Storage Encryption
-STORAGE_ENCRYPTION_KEY="your-32-byte-hex-key-here"
-
-# Optional: Google OAuth
-GOOGLE_CLIENT_ID="your-google-client-id"
-GOOGLE_CLIENT_SECRET="your-google-client-secret"
-
-# Optional: Storage Providers (configure at least one)
-# Cloudflare R2
-R2_ACCESS_KEY_ID="your-r2-access-key"
-R2_SECRET_ACCESS_KEY="your-r2-secret-key"
-R2_BUCKET_NAME="your-bucket-name"
-R2_REGION="auto"
-R2_ENDPOINT="https://your-account-id.r2.cloudflarestorage.com"
-
-# AWS S3
-AWS_ACCESS_KEY_ID="your-aws-access-key"
-AWS_SECRET_ACCESS_KEY="your-aws-secret-key"
-AWS_BUCKET_NAME="your-bucket-name"
-AWS_REGION="us-east-1"
-
-# Vercel Blob
-BLOB_READ_WRITE_TOKEN="your-vercel-blob-token"
-```
-
-### Database Setup
-
-```bash
-# 1. Generate Prisma client
-npx prisma generate
-
-# 2. Run migrations
-npx prisma migrate deploy
-
-# 3. (Optional) Seed test data
-pnpm db:seed
-
-# 4. (Optional) Open Prisma Studio to view data
-npx prisma studio
-```
-
-### Development
-
-```bash
-# Start development server
-pnpm dev
-
-# Open http://localhost:3000
-```
-
-### Production Build
-
-```bash
-# Build for production
-pnpm build
-
-# Start production server
-pnpm start
-```
-
-### Other Commands
-
-```bash
-# Run linter
-pnpm lint
-
-# Generate design tokens
-pnpm build:tokens
-
-# Database operations
-pnpm db:seed              # Seed test data
-npx prisma generate       # Regenerate Prisma client
-npx prisma migrate dev    # Create new migration
-npx prisma studio         # Open database GUI
-
-```
-
-## Hocuspocus Collaboration
-The Next.js app can remain on Vercel, but the Hocuspocus process should run on a long-lived Node host like Railway or Google Cloud Run to maintain persistent WebSocket connections.
-
-For google cloud run, you can use a `cloudbuild.hocuspocus.yaml` configuration to build and deploy the Hocuspocus service.
-
-```bash
-gcloud builds submit --config=cloudbuild.hocuspocus.yaml .
-
-## Project Structure
-
-```
-Digital-Garden/
-├── app/                          # Next.js App Router
-│   ├── (authenticated)/          # Protected routes
-│   │   └── content/             # Content IDE routes
-│   │       ├── page.tsx         # Main content IDE page
-│   │       └── [id]/            # Individual content pages
-│   ├── api/                     # API routes
-│   │   └── content/             # Content API endpoints
-│   │       ├── route.ts         # List/create content
-│   │       ├── [id]/            # Individual content operations
-│   │       ├── tree/            # Hierarchical tree
-│   │       ├── upload/          # File upload (initiate/finalize)
-│   │       ├── storage/         # Storage provider config
-│   │       ├── search/          # Full-text search
-│   │       ├── backlinks/       # Backlink tracking
-│   │       └── tags/            # Tag management
-│   └── globals.css              # Global styles + design tokens
-├── components/
-│   └── content/                 # Content IDE components
-│       ├── headers/             # Panel headers
-│       ├── left-sidebar/        # File tree, search
-│       ├── right-sidebar/       # Outline, backlinks, tags
-│       ├── editor/              # TipTap editor
-│       └── viewers/             # File type viewers
-├── lib/
-│   ├── content/                 # Content utilities
-│   │   ├── api-types.ts        # API type definitions
-│   │   └── utils.ts            # Helper functions
-│   ├── design-system/          # Design tokens
-│   │   ├── surfaces.ts         # Glass-0/1/2 levels
-│   │   ├── intents.ts          # Semantic colors
-│   │   └── motion.ts           # Animation rules
-│   ├── editor/                 # TipTap extensions
-│   │   ├── extensions.ts       # Extension configs
-│   │   ├── wiki-link-node.ts   # Wiki-link extension
-│   │   ├── callout-extension.ts # Callout blocks
-│   │   └── slash-commands.tsx  # Slash command menu
-│   ├── storage/                # Storage providers
-│   │   ├── factory.ts          # Provider factory
-│   │   ├── r2-provider.ts      # Cloudflare R2
-│   │   ├── s3-provider.ts      # AWS S3
-│   │   └── vercel-provider.ts  # Vercel Blob
-│   └── generated/
-│       └── prisma/             # Generated Prisma client
-├── stores/                      # Zustand state stores
-│   ├── panel-store.ts          # Panel layout state
-│   ├── content-store.ts        # Selected content state
-│   ├── tree-state-store.ts     # Tree expand/collapse
-│   ├── context-menu-store.ts   # Right-click menu
-│   ├── editor-stats-store.ts   # Word count, reading time
-│   └── outline-store.ts        # Document outline
-├── prisma/
-│   ├── schema.prisma           # Database schema
-│   ├── migrations/             # Migration history
-│   └── seed.ts                 # Seed script
-├── docs/
-│   └── notes-feature/          # Comprehensive documentation
-│       ├── 00-index.md         # Documentation index
-│       ├── 01-architecture.md  # System architecture
-│       ├── 03-database-design.md # ContentNode v2.0
-│       └── ...                 # 90+ documentation files
-└── archive/                    # Archived applications
-    ├── web-amino/              # Amino acid learning platform
-    └── open-notes/             # Documentation repository
-```
-
-## Architecture Highlights
-
-### ContentNode v2.0 - Hybrid Polymorphism
-
-A single `ContentNode` table acts as a universal container for all content types. Each leaf node has exactly one typed payload relation:
-
-- **NotePayload** - Rich text content (TipTap JSON + markdown)
-- **FilePayload** - Binary files with storage metadata
-- **HtmlPayload** - Rendered HTML content
-- **CodePayload** - Code snippets with syntax highlighting
-
-### Multi-Cloud Storage System
-
-Provider abstraction layer supports multiple cloud storage backends with encrypted credential storage:
-
-- **Cloudflare R2** - Primary (S3-compatible, no egress fees)
-- **AWS S3** - Traditional cloud storage
-- **Vercel Blob** - Vercel-native storage
-
-### Server/Client Component Split
-
-Maximizes server-side rendering for instant visual feedback, progressively enhances with client interactivity:
-
-- **Server Components** - Panel headers, borders, layout structure, skeleton states
-- **Client Components** - Interactive file tree, resizable panels, drag-and-drop handlers
-
-### Design System - Liquid Glass
-
-Three token categories generated via style-dictionary:
-
-- **Surfaces** - Glass-0/1/2 blur levels for glassmorphism effects
-- **Intents** - Semantic colors (primary, danger, success, warning, info)
-- **Motion** - Conservative animation rules
-
-## Documentation
-
-Comprehensive documentation is available in [`docs/notes-feature/`](docs/notes-feature/):
-
-- **[00-index.md](docs/notes-feature/00-index.md)** - Documentation index (start here)
-- **[IMPLEMENTATION-STATUS.md](docs/notes-feature/IMPLEMENTATION-STATUS.md)** - Current milestone progress
-- **[01-architecture.md](docs/notes-feature/01-architecture.md)** - System architecture
-- **[03-database-design.md](docs/notes-feature/03-database-design.md)** - Database schema
-- **[04-api-specification.md](docs/notes-feature/04-api-specification.md)** - API routes
-- **[CLAUDE.md](CLAUDE.md)** - AI assistant development guide
-
-See [`docs/notes-feature/00-index.md`](docs/notes-feature/00-index.md) for the complete documentation catalog (90+ files).
-
-## Database Management
-
-### Critical Rules
-
-- ✅ Use `npx prisma db push` for development (fast, no data loss)
-- ✅ Use `npx prisma migrate dev` only for production-ready changes
-- ✅ Always run `npx prisma generate` after schema changes
-- ❌ Never use `npx prisma migrate reset` in production (deletes all data!)
-
-### Common Workflows
-
-```bash
-# Making schema changes in development
-npx prisma db push          # Push changes directly (no migration file)
-npx prisma generate         # Regenerate client
-
-# Creating a production migration
-npx prisma migrate dev --name descriptive_name --create-only
-# Review SQL in prisma/migrations/
-npx prisma migrate deploy   # Deploy to production
-
-# Seeding test data
-pnpm db:seed
-
-# Viewing data
-npx prisma studio           # Opens GUI at http://localhost:5555
-```
-
-See [`docs/notes-feature/PRISMA-DATABASE-GUIDE.md`](docs/notes-feature/PRISMA-DATABASE-GUIDE.md) for comprehensive database management guidance.
-
-## Key Features
-
-### Wiki-Links
-
-Link between notes using `[[Note Title]]` or `[[slug|Display Text]]` syntax. Autocomplete suggests existing notes as you type.
-
-### Callouts
-
-Create Obsidian-style callouts with 6 types:
-
-```markdown
-> [!note] Title
-> Content here
-
-> [!tip] Pro Tip
-> Helpful information
-
-> [!warning] Watch Out
-> Important warning
-
-> [!danger] Critical
-> Dangerous operation
-
-> [!info] FYI
-> Additional information
-
-> [!success] Done
-> Successful completion
-```
-
-### Slash Commands
-
-Press `/` in the editor to open the command menu:
-
-- Headings (H1-H3)
-- Code blocks
-- Tables
-- Callouts
-- Task lists
-- Blockquotes
-- Dividers
-
-### Task Lists
-
-Auto-format `- [ ]` to task lists:
-
-```markdown
-- [ ] Todo item
-- [x] Completed item
-```
-
-### Drag-and-Drop Upload
-
-Drag files directly into the file tree or editor to upload. Supports images, PDFs, office documents, videos, and audio.
-
-## Deployment
-
-### Vercel (Recommended)
-
-```bash
-# 1. Install Vercel CLI
-pnpm add -g vercel
-
-# 2. Link project
-vercel link
-
-# 3. Set environment variables
-vercel env add DATABASE_URL
-vercel env add STORAGE_ENCRYPTION_KEY
-# ... add other variables
-
-# 4. Deploy
-vercel --prod
-```
-
-### Other Platforms
-
-The application can be deployed to any platform supporting Next.js 16:
-
-- **Docker** - See Next.js Docker documentation
-- **AWS** - Use AWS Amplify or EC2
-- **Railway** - One-click deployment
-- **DigitalOcean** - App Platform
-
-Ensure all environment variables are configured and database migrations are run before deployment.
-
-## Contributing
-
-Contributions are welcome! Please follow these guidelines:
-
-1. Read [`docs/notes-feature/00-index.md`](docs/notes-feature/00-index.md) for architecture overview
-2. Check [`CLAUDE.md`](CLAUDE.md) for development patterns and conventions
-3. Follow TypeScript strict mode (no `any` types)
-4. Use inline SVG for server component icons (not `lucide-react`)
-5. Test that server components render without JavaScript
-6. Update documentation for any architectural changes
-
-## License
-
-[Your License Here]
-
-## Acknowledgments
-
-- **Obsidian** - Inspiration for the note-taking experience
-- **Novel** - TipTap-based rich text editor
-- **react-arborist** - Virtualized tree component
-- **Radix UI** - Accessible component primitives
-- **Vercel** - Hosting and deployment platform
-
-## Support
-
-For issues, questions, or feature requests, please open an issue on GitHub or contact the maintainers.
+# Digital Garden — an AI-native knowledge IDE
+
+[![Quality Gates](https://github.com/CenterValentine/Digital-Garden/actions/workflows/quality.yml/badge.svg)](https://github.com/CenterValentine/Digital-Garden/actions/workflows/quality.yml)
+![Next.js 16](https://img.shields.io/badge/Next.js-16-black)
+![React 19](https://img.shields.io/badge/React-19-149eca)
+![TypeScript strict](https://img.shields.io/badge/TypeScript-strict%2C%20no%20any-3178c6)
+![AI SDK v6](https://img.shields.io/badge/AI%20SDK-v6-000)
+
+An Obsidian-class knowledge IDE that grew into an **AI automation platform**: agentic chat with a
+typed tool registry, reusable agent playbooks, durable workflows with an n8n spoke, resumable AI
+streams, multimodal pipelines (TTS · STT · image), real-time Y.js collaboration, and a publishing
+system that renders my actual personal site.
+
+**[Live site →](https://davidvalentine.org)** rendered by this repo's publishing system ·
+**[Video demo →](https://davidvalentine.org/demo)** ·
+**[Feature inventory →](docs/FEATURES.md)** ·
+**[Deployment →](docs/DEPLOYMENT.md)** ·
+**[Documentation →](docs/notes-feature/00-START-HERE.md)**
+
+<!-- fig:1-1 -->
+<sub>📷 <b>Fig 1-1</b> · <i>Three-panel Content IDE (hero)</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:1-1 -->
+
+Solo-built, production-deployed, and used daily — this is my working environment for notes,
+research capture, my published site, and the agentic systems that run my own job search.
 
 ---
 
-Built with ❤️ using Next.js 16 and React 19
+## AI & agentic systems
 
+Every AI capability here is a first-class subsystem with typed contracts, CI gates, and fallback
+behavior — not a chat window bolted onto a notes app. The table maps each capability to where it
+lives in the code.
 
+| Capability | What's built | Where |
+|---|---|---|
+| **Tool-calling orchestration** | Server-side tool registry with a client-safe metadata split (no Prisma in the client bundle); editor, flashcard, and workflow tool families; canonical output-placement so agent output lands *in documents*, not just chat | [`lib/domain/ai/tools/`](lib/domain/ai/tools/) |
+| **Multi-model routing + fallback** | Per-feature model routes with fallback chains (`executeWithFallback`), registry-authoritative model catalog, per-model constraints | [`lib/domain/ai/features/`](lib/domain/ai/features/) |
+| **Agent playbooks** | Notes/folders marked as reusable playbooks; progressive-disclosure injection (agents load steps as needed, not all upfront); discoverable via a `search_playbooks` tool; checkpoint gating | [`lib/domain/ai/playbooks/`](lib/domain/ai/playbooks/) |
+| **Durable workflows** | Visual workflow builder (React Flow) with trigger system and run history, plus an n8n spoke — outbound webhooks and inbound callbacks for jobs that outlive a request | [`extensions/workflows/`](extensions/workflows/) |
+| **Resumable streaming** | AI responses stream over SSE and survive a page reload mid-generation (Upstash-backed resumable streams) | [`lib/domain/ai/resumable/`](lib/domain/ai/resumable/) |
+| **Resource governance** | Per-run ledger, tool-output compaction to control context growth, dangling-tool-call repair, prompt caching | [`lib/domain/ai/run-ledger.ts`](lib/domain/ai/run-ledger.ts), [`compact-tool-outputs.ts`](lib/domain/ai/compact-tool-outputs.ts) |
+| **Grounded generation** | Folder Studio: folder-scoped agentic chat grounded in attached context docs with auto-context assembly | [`extensions/studio/`](extensions/studio/) |
+| **Multimodal pipelines** | TTS generation + storage catalog (read-aloud player), speech-to-text, AI image generation, AI-mediated media injection into notes | [`lib/domain/ai/speech/`](lib/domain/ai/speech/), [`transcribe/`](lib/domain/ai/transcribe/), [`image/`](lib/domain/ai/image/) |
+| **Agentic browser reach** | Chrome extension as a content-acquisition provider: service-worker fetch → session-tab ladder, client-mediated with a server-built trust envelope; capture-policy safety gates | [`lib/domain/ai/acquisition/`](lib/domain/ai/acquisition/) |
+| **Provider abstraction (BYOK)** | Anthropic · OpenAI · Google · Groq · Mistral · xAI provider factories behind one interface, encrypted key storage, gateway routing | [`lib/domain/ai/providers/`](lib/domain/ai/providers/) |
+| **MCP interoperability** | 🔭 **Planned** — MCP server exposing garden tools/resources to external agents + MCP client consuming external servers in the chat tool loop (design doc in progress) | — |
+
+### How an AI request flows
+
+```mermaid
+flowchart LR
+  U["Chat / editor / extension surface"] --> R["Feature router<br/>per-feature model routes"]
+  R --> F["Fallback chain<br/>executeWithFallback"]
+  F --> P["Provider factories<br/>Anthropic · OpenAI · Google · Groq · Mistral · xAI"]
+  F --> T["Tool loop<br/>server tool registry"]
+  T --> PB["Playbooks<br/>progressive disclosure"]
+  T --> OP["Output placement<br/>into notes + references"]
+  F --> S["Resumable SSE stream<br/>survives page reload"]
+  S --> L["Run ledger + persistence<br/>conversation tables"]
+```
+
+<!-- fig:2-1 -->
+<sub>📷 <b>Fig 2-1</b> · <i>AI chat executing tools</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:2-1 -->
+
+**Playbooks** turn the agent from a chatbot into an operator: any note or folder can be marked as
+a playbook, and agents discover and execute them with steps injected progressively — my job-search
+playbook runs this way daily (Fig 2-2). **Workflows** cover the durable side: multi-step
+automations built on a visual canvas, executed through triggers and an n8n spoke with callback
+verification (Fig 2-3). **Folder Studio** scopes an agent to a folder's content with attached
+context documents — grounded answers, not vibes (Fig 2-4).
+
+<!-- fig:2-2 -->
+<sub>📷 <b>Fig 2-2</b> · <i>Playbook run (progressive disclosure)</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:2-2 -->
+<!-- fig:2-3 -->
+<sub>📷 <b>Fig 2-3</b> · <i>Workflow canvas + run history</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:2-3 -->
+<!-- fig:2-4 -->
+<sub>📷 <b>Fig 2-4</b> · <i>Folder Studio grounded chat</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:2-4 -->
+
+Infrastructure details that usually get skipped: streams are **resumable** — reload the page
+mid-generation and the response keeps going (Fig 2-5); every run is metered in a ledger; tool
+outputs are compacted to keep context windows honest; and models are **user-configurable per
+feature** with BYOK keys stored encrypted (Fig 2-7). Text-to-speech, transcription, and image
+generation run as first-class pipelines with storage-backed catalogs (Fig 2-6).
+
+<!-- fig:2-5 -->
+<sub>📷 <b>Fig 2-5</b> · <i>Resumable stream surviving a reload</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:2-5 -->
+<!-- fig:2-6 -->
+<sub>📷 <b>Fig 2-6</b> · <i>Read-aloud TTS player</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:2-6 -->
+<!-- fig:2-7 -->
+<sub>📷 <b>Fig 2-7</b> · <i>Model routing & BYOK connections</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:2-7 -->
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+  subgraph Clients
+    B["Browser app"]
+    X["Chrome extension<br/>side panel · capture · acquisition"]
+  end
+  subgraph Vercel
+    N["Next.js 16 app<br/>RSC + API routes + AI domain"]
+  end
+  subgraph CloudRun["Google Cloud Run"]
+    H["Hocuspocus<br/>Y.js collaboration server"]
+  end
+  subgraph HomeServer["Home server · Cloudflare Tunnel"]
+    N8["n8n<br/>workflow spoke"]
+  end
+  PG[("PostgreSQL<br/>Neon prod · Docker dev")]
+  ST[("Object storage<br/>R2 · S3 · Vercel Blob")]
+  AI["AI providers<br/>Anthropic · OpenAI · Google · …"]
+
+  B --> N
+  X --> N
+  B <-->|"WebSocket"| H
+  N --> PG
+  H --> PG
+  N --> ST
+  N <-->|"webhooks + callbacks"| N8
+  N --> AI
+```
+
+**ContentNode v2.0** — one polymorphic table is the universal container: folders form the
+hierarchy; leaves attach exactly one typed payload (`NotePayload` TipTap JSON, `FilePayload`
+binary + storage metadata, `CodePayload`, `HtmlPayload`, `ExternalPayload` with Open Graph
+metadata). Soft delete, display ordering, and full-text search live on the container, so every
+content type inherits them.
+
+**Real-time collaboration** — TipTap documents sync through Y.js CRDTs via a Hocuspocus server on
+Cloud Run. Presence survives Vercel's serverless split by persisting awareness state to Postgres.
+A CI gate (`collab:schema:check`) statically verifies that every editor extension has a
+server-safe variant registered with the collaboration server — schema drift between client and
+collab server fails the build, because at runtime it would corrupt documents.
+
+**Extension system** — features ship as 10 first-party extension modules
+(`daily-notes`, `flashcards`, `people`, `workplaces`, `calendar`, `publishing`, `speed-reader`,
+`browser-bookmarks`, `studio`, `workflows`), each owning its manifest, client/server runtimes,
+components, and state. Disabled extensions disappear through registry filters — shared UI has no
+per-feature conditionals.
+
+---
+
+## Feature tour
+
+### The editor
+
+TipTap-based, with a custom block inventory: wiki-links with autocomplete (`[[Note Title]]`),
+Obsidian-style callouts, tabs/columns/accordions, Mermaid and Excalidraw blocks with collaborative
+sub-documents, inline tags and timestamps, slash commands, and a schema-versioning system with
+migration support. Unknown node types round-trip as explicit placeholders instead of being
+silently dropped.
+
+<!-- fig:1-2 -->
+<sub>📷 <b>Fig 1-2</b> · <i>Sixty-second tour</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:1-2 -->
+<!-- fig:3-1 -->
+<sub>📷 <b>Fig 3-1</b> · <i>Block library breadth</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:3-1 -->
+<!-- fig:3-2 -->
+<sub>📷 <b>Fig 3-2</b> · <i>Live collaboration</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:3-2 -->
+
+### Publishing
+
+Notes compose into public pages from a registry of publishing blocks (hero, cards, galleries,
+pricing, testimonials, …), rendered server-side with light/dark theming and per-block Playwright
+visual regression. [davidvalentine.org](https://davidvalentine.org) is this pipeline in
+production (Fig 4-2).
+
+<!-- fig:4-1 -->
+<sub>📷 <b>Fig 4-1</b> · <i>Publishing composer → live page</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:4-1 -->
+<!-- fig:4-2 -->
+<sub>📷 <b>Fig 4-2</b> · <i>davidvalentine.org, rendered by this repo</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:4-2 -->
+
+### Browser extension
+
+A Chrome extension embeds the garden in a side panel, captures pages under explicit
+capture-policy safety gates, and acts as an **acquisition provider**: when the app needs a page's
+full content, it climbs a ladder from service-worker fetch to session-tab extraction — with the
+server building the trusted envelope (Fig 5-1).
+
+<!-- fig:5-1 -->
+<sub>📷 <b>Fig 5-1</b> · <i>Browser extension side panel & acquisition</i> — <a href="docs/media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:5-1 -->
+
+### And also
+
+Flashcards with FSRS spaced repetition · daily/periodic notes with activity summaries · people +
+workplace entities with mentions · full-text search with tag filtering and backlinks · multi-cloud
+file storage with two-phase presigned uploads · an RSVP speed reader · export to Markdown/HTML/JSON
+with metadata sidecars.
+
+---
+
+## Engineering practice
+
+The part that doesn't screenshot well but matters most:
+
+- **Quality gates, in order:** `pnpm typecheck` → `pnpm lint` (warning-count ratchet — new
+  warnings fail CI) → `pnpm build` → browser smoke test.
+- **CI on every PR** ([workflows](.github/workflows/)): lint + typecheck (`quality.yml`),
+  collaboration schema coverage (`collaboration-hardening.yml`), and publishing schema +
+  per-block visual regression (`publishing-visual.yml`).
+- **Static drift detectors** as CI gates: collab-schema coverage, publishing `Server*` variants,
+  Zod-default vs. render-fallback drift, dark-mode CSS coverage audits.
+- **React Compiler lint rules enforced** — compiler diagnostics are treated as bug reports, and
+  they've caught real ones (stale callbacks, StrictMode-unsafe ref writes, render impurity).
+- **AI-assisted development, documented:** [`CLAUDE.md`](CLAUDE.md) and [`AGENTS.md`](AGENTS.md)
+  encode the repo's conventions for agentic coding tools — the same discipline the product's own
+  agents get held to.
+- 90+ architecture and workflow documents under [`docs/`](docs/notes-feature/00-START-HERE.md),
+  130+ merged PRs in sprint format.
+
+---
+
+## Quickstart
+
+Prerequisites: Node 20+, pnpm, Docker (for local Postgres).
+
+```bash
+git clone https://github.com/CenterValentine/Digital-Garden.git
+cd Digital-Garden
+pnpm install
+cp .env.example .env.local
+pnpm db:local:up
+npx prisma generate
+npx prisma migrate deploy
+pnpm db:seed
+pnpm dev
+```
+
+The app runs at **http://localhost:3015**. Required env vars: `DATABASE_URL` (use `localhost`,
+not `127.0.0.1`, for the Docker Postgres) and `STORAGE_ENCRYPTION_KEY` (32-byte hex). AI features
+need at least one provider key (BYOK — configured in-app). Live collaboration in dev needs the
+local Hocuspocus server in a second terminal:
+
+```bash
+pnpm dev:collab
+```
+
+with `NEXT_PUBLIC_HOCUSPOCUS_URL=ws://localhost:1234` in `.env.local`. Full production builds
+need a larger Node heap: `NODE_OPTIONS='--max-old-space-size=8192' pnpm build`.
+
+## Deployment topology
+
+Three services deploy independently:
+
+| Service | Platform | How |
+|---|---|---|
+| Next.js app | Vercel | `vercel --prod` (build skips local-only gates; migrations run manually via `npx prisma migrate deploy`) |
+| Hocuspocus (collab) | Google Cloud Run | `gcloud builds submit --config cloudbuild.hocuspocus.yaml .` — **must be redeployed after schema-changing merges**, or unknown blocks degrade to placeholders |
+| n8n (workflow spoke) | Any long-lived host | Self-hosted (here: a home server behind a Cloudflare Tunnel, no inbound ports) |
+
+Postgres (Neon in production) and object storage (Cloudflare R2 primary; S3/Vercel Blob
+supported) are managed services. Full guide — env reference, migration baseline caveats, the
+Hocuspocus redeploy rules, and post-deploy verification: **[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)**.
+
+---
+
+## Roadmap
+
+Labeled honestly — nothing below is shipped yet:
+
+- 🔭 **MCP server + client** — expose the garden's tools, content, and playbooks to external
+  agents over the Model Context Protocol, and consume external MCP servers inside the chat tool
+  loop. Design of record: [MCP-PLAN.md](docs/notes-feature/work-tracking/MCP-PLAN.md) — first
+  slice is a read-only server demoable from Claude Desktop.
+- 🔭 **Playbook completeness** — SKILL.md import, richer playbook lifecycle.
+- 🔭 **Resource budgets** — enforced per-run token/step budgets on top of the existing run ledger.
+- 🔭 **Conversation memory** — long-horizon memory bank across chat sessions.
+
+## Documentation & showcase upkeep
+
+- Start here: [`docs/notes-feature/00-START-HERE.md`](docs/notes-feature/00-START-HERE.md)
+- Figures in this README are managed by a registry + sync script — see
+  [`docs/media/figures/FIGURES.md`](docs/media/figures/FIGURES.md). Drop a correctly-named media
+  file in that folder, run `pnpm showcase:figures`, and it appears here automatically.
+- Showcase maintenance guide: [`docs/notes-feature/guides/showcase/SHOWCASE-MAINTENANCE.md`](docs/notes-feature/guides/showcase/SHOWCASE-MAINTENANCE.md)
+
+## License & contact
+
+License: not yet selected — all rights reserved for now. If you want to build on something here,
+[reach out](https://davidvalentine.org/contact).
+
+Built and maintained by [David Valentine](https://davidvalentine.org) ·
+[Request a demo](https://davidvalentine.org/demo)

--- a/app/(public)/demo/page.tsx
+++ b/app/(public)/demo/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { DemoPage } from "@/components/personal/DemoPage";
+
+export const metadata: Metadata = {
+  title: "Product demo — David Valentine",
+  description:
+    "A guided video tour of the Digital Garden: AI chat with tool calls, agent playbooks, durable workflows, live collaboration, and publishing. Request a custom demo.",
+};
+
+/**
+ * Dedicated static route for /demo (linked from the GitHub README).
+ *
+ * Same rationale as /resume: this bypasses the [...path] catch-all handler,
+ * whose tenant-detection path can fail during client-side RSC navigation.
+ * A static route keeps this recruiter-facing URL reliable.
+ */
+export default function DemoRoute() {
+  return <DemoPage />;
+}

--- a/components/personal/DemoPage.tsx
+++ b/components/personal/DemoPage.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import Link from "next/link";
+import { PersonalHeader } from "./PersonalHeader";
+import "./personal-pages.css";
+
+/**
+ * DemoPage — /demo — the video-demo landing referenced from the GitHub README.
+ *
+ * Placeholder state ("the demo reel is still growing"): a video frame with a
+ * play sigil, a CTA to request a custom demo via /contact, and pointers to the
+ * live proof that already exists (this site itself + the repo). When a demo
+ * video ships, replace the frame contents with the embedded player and keep
+ * the surrounding copy — the URL is already public in the README, so this
+ * route must never 404.
+ */
+export function DemoPage() {
+  return (
+    <div className="personal-home personal-page garden-construction-page">
+      <PersonalHeader crumb="demo" />
+
+      <div className="gc-body">
+        <span className="gc-kicker">DAVIDVALENTINE.ORG / PRODUCT DEMO</span>
+
+        <h1 className="gc-title">
+          The demo reel is<br />
+          <em>still growing.</em>
+        </h1>
+
+        {/* Video frame placeholder — swap for the real embed when it ships */}
+        <div
+          aria-hidden="true"
+          style={{
+            width: "min(640px, 100%)",
+            aspectRatio: "16 / 9",
+            margin: "1.75rem auto",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: "12px",
+            border: "1.5px dashed var(--text-soft)",
+            opacity: 0.85,
+          }}
+        >
+          <svg viewBox="0 0 96 96" width="72" height="72" fill="none">
+            {/* Play button seed, mid-sprout */}
+            <circle cx="48" cy="48" r="30" stroke="var(--accent-warm)" strokeWidth="2.5" opacity="0.55" />
+            <path d="M42 36 L62 48 L42 60 Z" fill="var(--accent-warm)" opacity="0.7" />
+            {/* Sprout on top */}
+            <line x1="48" y1="18" x2="48" y2="8" stroke="var(--accent-warm)" strokeWidth="2" strokeLinecap="round" opacity="0.8" />
+            <path d="M48 12 Q41 5 35 9" stroke="var(--accent-warm)" strokeWidth="2" strokeLinecap="round" opacity="0.7" fill="none" />
+            <path d="M48 12 Q55 5 61 9" stroke="var(--accent-warm)" strokeWidth="2" strokeLinecap="round" opacity="0.7" fill="none" />
+          </svg>
+        </div>
+
+        <p className="gc-line">
+          A guided video tour of the Digital Garden — the AI chat and its tool calls, playbooks,
+          workflows, live collaboration, and publishing — is being filmed. The product ships
+          faster than the film crew.
+        </p>
+
+        <p className="gc-line gc-line--soft">
+          Meanwhile, the live proof: the site you&apos;re reading right now is rendered by the
+          garden&apos;s own publishing pipeline, and the code is public on{" "}
+          <a
+            href="https://github.com/CenterValentine/Digital-Garden"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "var(--accent-warm)" }}
+          >
+            GitHub
+          </a>
+          .
+        </p>
+
+        <p className="gc-line">
+          Want to see something specific — for a role, a team, or just curiosity?{" "}
+          <strong>I&apos;ll record a custom demo for you.</strong>
+        </p>
+
+        <Link className="gc-back-cta" href="/contact">
+          Request a custom demo →
+        </Link>
+
+        <Link
+          className="gc-back-cta"
+          href="/"
+          style={{ opacity: 0.7, marginTop: "0.5rem" }}
+        >
+          ← Back to the garden
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,144 @@
+# Deployment Guide
+
+How the Digital Garden actually runs in production: **three independently-deployed services**
+plus managed data stores. This is the honest topology — see the README's architecture diagram
+for the picture.
+
+| Service | Platform | Deploy command | Notes |
+|---|---|---|---|
+| Next.js app (UI + API + AI domain) | Vercel | `vercel --prod` | `vercel-build` intentionally skips typecheck/lint (enforced locally + in CI) for fast deploys; Turbopack |
+| Hocuspocus (Y.js collaboration) | Google Cloud Run | `gcloud builds submit --config cloudbuild.hocuspocus.yaml .` | See redeploy rules below — this is the #1 operational footgun |
+| n8n (workflow spoke) | Any long-lived host | self-hosted | Reference setup: a home server behind a Cloudflare Tunnel — zero inbound ports |
+
+Managed stores: **PostgreSQL** (Neon in production; local Docker for dev) and **object storage**
+(Cloudflare R2 primary; AWS S3 and Vercel Blob supported).
+
+---
+
+## 1. Environment variables
+
+Copy [`.env.example`](../.env.example) to `.env.local` and fill in. Groups, from
+most- to least-required:
+
+### Core (required)
+
+| Var | Purpose |
+|---|---|
+| `DATABASE_URL` | Postgres connection. Local dev: use `localhost` (not `127.0.0.1` — Docker binds IPv6) |
+| `STORAGE_ENCRYPTION_KEY` | 32-byte hex; encrypts stored provider credentials |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth sign-in |
+| `NEXTAUTH_SECRET` | Session signing |
+| `LOCAL_POSTGRES=1` | Only when pointed at local Docker Postgres — read by the `db:target` safety check |
+
+### Collaboration
+
+| Var | Purpose |
+|---|---|
+| `NEXT_PUBLIC_HOCUSPOCUS_URL` | WebSocket URL the browser connects to. Dev: `ws://localhost:1234` — never a `0.0.0.0` bind address |
+| `COLLABORATION_TOKEN_SECRET` | Signs per-document access tokens |
+| `HOCUSPOCUS_PORT`, `HOCUSPOCUS_STORE_DEBOUNCE_MS`, `HOCUSPOCUS_STORE_MAX_DEBOUNCE_MS`, `HOCUSPOCUS_ACCESS_REVALIDATION_MS` | Server-side tunables (Hocuspocus process only) |
+
+### Platform & site
+
+| Var | Purpose |
+|---|---|
+| `PLATFORM_DOMAIN`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_BASE_URL` | Canonical host resolution (public site + app) |
+| `SITE_OWNER_ID` | Which user owns the public personal site |
+| `MULTITENANT_ENABLED` | Tenancy flag — leave off for single-owner deployments |
+| `CRON_SECRET` | Authenticates Vercel cron invocations of `app/api/cron/` |
+
+### Workflows (n8n spoke)
+
+| Var | Purpose |
+|---|---|
+| `N8N_BASE_URL`, `N8N_API_KEY` | Outbound calls to your n8n instance |
+| `WORKFLOWS_CALLBACK_BASE_URL` | **Public** URL n8n calls back to — must be reachable from the n8n host (a localhost dev server is not; use a deployed URL or tunnel) |
+
+### Storage providers (configure at least one)
+
+`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`, `R2_ENDPOINT` ·
+AWS S3 equivalents · `BLOB_READ_WRITE_TOKEN` (Vercel Blob). Providers can also be configured
+per-user in-app (credentials encrypted with `STORAGE_ENCRYPTION_KEY`).
+
+### AI
+
+Model keys are **BYOK-first**: users add provider keys in-app (stored encrypted). Env keys act as
+server-side fallbacks / feature keys: `OPENAI_API_KEY`, `GOOGLE_AI_API_KEY`, plus media-generation
+providers (`TOGETHER_API_KEY`, `FIREWORKS_API_KEY`, `FAL_API_KEY`, `RUNWAY_API_KEY`) as needed.
+Resumable streams need the Upstash Redis credentials provisioned by the Vercel integration
+(project-prefixed `dg_*` REST vars).
+
+### Observability
+
+`LOG_LEVEL`, `LOG_TRACE`, `LOG_RECORD` — structured logging + trace recording
+(`pnpm trace:view` to inspect).
+
+---
+
+## 2. Database: migrations & the baseline
+
+Production migrations are **manual and reviewed** — never run from CI:
+
+```bash
+npx prisma migrate deploy
+```
+
+⚠ **Baseline caveat:** the migration history was squashed to a single from-empty baseline
+(PR #119). Any database created **before** that squash must be marked as baselined once, before
+its next `migrate deploy`:
+
+```bash
+npx prisma migrate resolve --applied 00000000000000_baseline
+```
+
+Full runbook: [MIGRATION-BASELINE-SQUASH.md](notes-feature/guides/database/MIGRATION-BASELINE-SQUASH.md).
+Development uses `npx prisma db push` (no migration files); the
+[database change checklist](notes-feature/guides/database/DATABASE-CHANGE-CHECKLIST.md) is
+mandatory for schema changes.
+
+## 3. Hocuspocus deploy rules (read before deploying)
+
+1. **Deploy only from a checkout at `origin/main`.** Cloud Build ships your *working directory*.
+   Verify first: `git rev-list --count HEAD..origin/main` must print `0`.
+2. **Redeploy after every merge that touches the TipTap/collab schema** (new blocks, new marks).
+   The collab server is a Docker snapshot — Vercel deploys do NOT update it. A stale server
+   serializes unknown blocks as `unsupportedBlock` placeholders **inside collaborative documents**.
+3. Don't infer staleness from `/readyz` `uptimeMs` — with `min-instances=0` it measures cold-start
+   age, not deploy age. Use `gcloud builds list`.
+
+## 4. n8n spoke
+
+Any long-lived host works. The reference deployment: Coolify on a home server, exposed via
+Cloudflare Tunnel (no inbound ports — `cloudflared` runs as a host service). Configure
+`N8N_BASE_URL` to the tunnel hostname and point n8n's callback workflows at
+`WORKFLOWS_CALLBACK_BASE_URL`. In n8n webhook nodes, remember the payload nests under
+`$json.body.*`.
+
+## 5. Local development
+
+```bash
+pnpm install
+cp .env.example .env.local     # fill in core vars
+pnpm db:local:up               # Docker Postgres
+npx prisma generate
+npx prisma migrate deploy
+pnpm db:seed
+pnpm dev                       # http://localhost:3015
+pnpm dev:collab                # second terminal — required for live collaboration
+```
+
+Gotchas that cost real debugging time:
+
+- **Local collab is required** in dev: the hosted Hocuspocus authorizes against the production DB
+  and cannot see locally-created content. Run `pnpm dev:collab` from the **same checkout** as the
+  dev server.
+- Full builds need heap: `NODE_OPTIONS='--max-old-space-size=8192' pnpm build`.
+- `pnpm dev` hardcodes port 3015; parallel worktrees need explicit `--port`.
+- `pnpm db:target` tells you which database you're pointed at before you do anything regrettable.
+
+## 6. Post-deploy verification
+
+- App: sign in, open a note, confirm the auto-save indicator cycles.
+- Collab: `/readyz` on the Hocuspocus service; open one note in two browsers, see both cursors.
+- Workflows: trigger a Run; confirm the n8n execution and the inbound callback land in run history.
+- Publishing: load a public page (davidvalentine.org) in light **and** dark themes.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,179 @@
+# Feature Inventory
+
+The complete map of what this codebase does, with status and code entry points. Companion to the
+[README](../README.md) (positioning + architecture) and [DEPLOYMENT.md](DEPLOYMENT.md) (running it).
+
+**Legend:** ✅ shipped · 🚧 in progress · 🔭 planned — nothing unshipped appears unlabeled.
+Figures referenced below are tracked in the [figure registry](media/figures/FIGURES.md).
+
+---
+
+## AI & agentic systems
+
+The headline domain — see the README's competency table for the recruiter-level summary; this is
+the full inventory.
+
+| Feature | Status | Notes | Code |
+|---|---|---|---|
+| Agentic chat engine | ✅ | Shared conversation engine across all chat surfaces; persisted conversations with associations to content | `lib/domain/ai/use-conversation-engine.ts` |
+| Server tool registry | ✅ | Editor, flashcard, and workflow tool families; client-safe metadata split (no Prisma in client bundle) | `lib/domain/ai/tools/` |
+| Output placement | ✅ | Canonical modules place agent output *into documents* — bot outputs nest under chats as movable references | `lib/domain/ai/output-target.ts`, `tools/output-placement.ts` |
+| Playbooks | ✅ | Notes/folders marked as reusable agent procedures; progressive-disclosure injection; `search_playbooks` discovery; checkpoint gating | `lib/domain/ai/playbooks/` |
+| Multi-model routing + fallback | ✅ | Per-feature routes, fallback chains, registry-authoritative model catalog, per-model constraints | `lib/domain/ai/features/`, `model-route-resolver.ts` |
+| Provider abstraction (BYOK) | ✅ | Anthropic · OpenAI · Google · Groq · Mistral · xAI factories; encrypted key storage; env-key fallbacks | `lib/domain/ai/providers/` |
+| Resumable streaming | ✅ | SSE responses survive page reload mid-generation (Upstash-backed) | `lib/domain/ai/resumable/` |
+| Resource governance | ✅ / 🔭 | Shipped: per-run ledger, tool-output compaction, dangling-tool repair, prompt caching. Planned: enforced per-run token/step budgets | `run-ledger.ts`, `compact-tool-outputs.ts` |
+| Folder Studio (grounded chat) | ✅ | Folder-scoped agents grounded in attached Context docs with auto-context assembly; Create/Practice/Analyze shelves | `extensions/studio/` |
+| Folder assist | ✅ | AI operations over folder contents from the tree | `lib/domain/ai/folder-assist/` |
+| Chat contexts | ✅ | Custom-instruction presets per conversation | `app/api/ai/` + chat UI |
+| Follow-up suggestions | ✅ | Model-generated next-step chips after responses | `lib/domain/ai/follow-ups.ts` |
+| Text-to-speech | ✅ | TTS generation + stored catalog; read-aloud player for docs/selections; block-level `ttsSkip` | `lib/domain/ai/speech/` |
+| Speech-to-text | ✅ | Transcription pipeline | `lib/domain/ai/transcribe/` |
+| AI image generation | ✅ | Generate + store, gateway path, AI-mediated media injection into notes ("Add to…") | `lib/domain/ai/image/`, `app/api/ai/inject-media/` |
+| Browser content acquisition | ✅ | Extension as acquisition provider: service-worker fetch → session-tab ladder; server-built trust envelope | `lib/domain/ai/acquisition/` |
+| Markdown source view | ✅ | Rich-text ⇄ markdown toggle with a self-verifying lossless serializer (deny-by-default, fenced fallback) + CI gate | editor source-view modules |
+| MCP server + client | 🔭 | Design of record: [MCP-PLAN.md](notes-feature/work-tracking/MCP-PLAN.md) — read-only server first | — |
+| Conversation memory bank | 🔭 | Long-horizon memory across chat sessions | — |
+
+<!-- fig:2-1 -->
+<sub>📷 <b>Fig 2-1</b> · <i>AI chat executing tools</i> — <a href="media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:2-1 -->
+
+## Workflows (durable automation)
+
+| Feature | Status | Notes | Code |
+|---|---|---|---|
+| Workflow hub + visual builder | ✅ | React Flow canvas, typed node graph, run history | `extensions/workflows/` |
+| Trigger system | ✅ | Manual Run (the sanctioned trigger), with trigger registry for growth | `extensions/workflows/server/` |
+| n8n spoke | ✅ | Outbound webhooks + inbound callbacks to a self-hosted n8n; validated live | `app/api/workflows/` |
+| Workflow AI tools | ✅ | Agents can inspect/operate workflows via the tool registry | `lib/domain/ai/tools/workflow-tools.ts` |
+| In-browser capture/supervise workflows | 🚧 | Extension-side workflow surfaces (chooser, badge/toast, embed reuse) | worktree `feature/workflows-extension` |
+
+```mermaid
+flowchart LR
+  TR["Trigger<br/>(Run button · API)"] --> HUB["Workflow hub<br/>run records + state"]
+  HUB --> EX["Node executor<br/>typed graph"]
+  EX -->|"outbound webhook"| N8N["n8n spoke<br/>self-hosted"]
+  N8N -->|"signed callback"| CB["Callback route"]
+  CB --> HUB
+  HUB --> HIST["Run history<br/>+ outputs"]
+```
+
+<!-- fig:2-3 -->
+<sub>📷 <b>Fig 2-3</b> · <i>Workflow canvas + run history</i> — <a href="media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:2-3 -->
+
+## Editor
+
+| Feature | Status | Notes | Code |
+|---|---|---|---|
+| TipTap rich-text editor | ✅ | Markdown shortcuts, tables, code blocks (50+ languages), auto-save w/ indicator | `lib/domain/editor/` |
+| Wiki-links | ✅ | `[[Note Title]]` / `[[slug\|Display]]`, autocomplete, click-through, backlink tracking | `extensions/wiki-link.ts` |
+| Callouts | ✅ | Obsidian syntax, 6 types | `extensions/callout.ts` |
+| Block library | ✅ | Section headers, cards, accordions, tabs, columns, pull quotes, TOC, daily/weekly summaries | `extensions/blocks/` |
+| Diagram blocks | ✅ | Excalidraw + Mermaid + diagrams.net, each collaboration-aware via Y.js sub-documents | `lib/domain/visualization/` |
+| Inline atoms | ✅ | Tags (colored pills), person mentions, clickable timestamps w/ picker | `extensions/tag.ts`, `inline-timestamp.ts` |
+| Slash commands | ✅ | `/` insertion menu | `commands/slash-commands.tsx` |
+| Schema versioning | ✅ | Semver'd TipTap schema + migration hooks; MAJOR bumps require migrations | `schema-version.ts` |
+| Unsupported-content safety net | ✅ | Unknown nodes become explicit placeholders — never silently dropped | `unsupported-content.ts` |
+
+<!-- fig:3-1 -->
+<sub>📷 <b>Fig 3-1</b> · <i>Block library breadth</i> — <a href="media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:3-1 -->
+
+## Collaboration
+
+| Feature | Status | Notes | Code |
+|---|---|---|---|
+| Real-time co-editing | ✅ | Y.js CRDTs via Hocuspocus (Cloud Run); TipTap binding | `lib/domain/collaboration/` |
+| Presence | ✅ | Awareness persisted to Postgres (survives serverless split); two-tier staleness | collaboration runtime |
+| Availability ladder | ✅ | canonical → localFallback → plainFallback client states; explicit connection lifecycle | `runtime.ts` |
+| Sleep mode | ✅ | Deliberate idle/hidden disconnects as a cost control | collaboration runtime |
+| Schema-coverage CI gate | ✅ | Every editor Node/Mark must register a `Server*` variant with the collab server — drift fails the build | `scripts/validate-collaboration-schema.ts` |
+
+## Content model, storage & interop
+
+```mermaid
+erDiagram
+  ContentNode ||--o{ ContentNode : "parentId hierarchy"
+  ContentNode ||--o| NotePayload : "note (TipTap JSON)"
+  ContentNode ||--o| FilePayload : "file (binary + storage meta)"
+  ContentNode ||--o| CodePayload : "code"
+  ContentNode ||--o| HtmlPayload : "html"
+  ContentNode ||--o| ExternalPayload : "external URL + OG meta"
+  NotePayload ||--o| CollaborationDocument : "Y.js binary state"
+  ContentNode {
+    string parentId
+    int displayOrder
+    datetime deletedAt
+    string searchText
+  }
+```
+
+| Feature | Status | Notes | Code |
+|---|---|---|---|
+| ContentNode v2.0 | ✅ | One polymorphic container; typed payloads; soft delete; ordering; full-text column | `prisma/schema.prisma` |
+| Multi-cloud storage | ✅ | R2 (primary) / S3 / Vercel Blob behind a factory; encrypted credentials; two-phase presigned upload | `lib/infrastructure/storage/` |
+| File viewers | ✅ | Images, PDF, video, audio, code, office (OnlyOffice integration) | `components/content/viewer/` |
+| External links | ✅ | Open Graph preview fetch; "Read full content" via extension acquisition ladder | `components/content/external/` |
+| Export | ✅ | Markdown (wiki-links/callouts/tags preserved), standalone HTML, lossless JSON; bulk vault ZIP; metadata sidecars | `lib/domain/export/` |
+| Google Drive integration | ✅ | Browse/import | `app/api/google-drive/` |
+| Trash / restore | ✅ | Soft-delete lifecycle | `app/api/trash/` |
+
+## Organization & knowledge
+
+| Feature | Status | Notes | Code |
+|---|---|---|---|
+| Full-text search + filters | ✅ | Query, tag filters, results cache | `lib/domain/search/` |
+| Tags & backlinks | ✅ | Inline tags feed a graph; backlinks tab | content APIs |
+| Folder views | ✅ | List / grid / kanban per-folder view settings | `components/content/folder-views/` |
+| Periodic notes | ✅ | Daily→yearly cadences, calendar nav, summary blocks with activity signals | `extensions/daily-notes/`, `lib/domain/periodic-notes/` |
+| Flashcards (FSRS) | ✅ | ts-fsrs scheduling, deck tree, editor-embedded decks, AI-proposed cards via chat | `extensions/flashcards/` |
+| Speed reader | ✅ | RSVP reader as a global dialog | `extensions/speed-reader/` |
+| People & workplaces | ✅ | Typed entities with editor mentions | `extensions/people/`, `extensions/workplaces/` |
+| Calendar | ✅ | Calendar surface + API | `extensions/calendar/` |
+| Connections / inbox / DMs | ✅ | Event-log architecture for sharing + messaging | `app/api/connections/`, `messages/` |
+
+## Publishing & personal site
+
+| Feature | Status | Notes | Code |
+|---|---|---|---|
+| Publishing block system | ✅ | Registered block inventory (hero, cards, galleries, pricing, …) with `Server*` variants + schema CI gate | `extensions/publishing/` |
+| Public rendering | ✅ | Server-rendered public pages, light/dark theming, scroll-reveal | `app/(public)/`, `components/public/` |
+| Per-block visual regression | ✅ | Playwright snapshots per block, both themes, hard CI gate | `tests/e2e/`, `publishing-visual.yml` |
+| SitePage composer | ✅ | Visual page governance: Draft→Live, content picker, live preview — runs davidvalentine.org | `app/api/site-pages/` |
+| Video demo page | ✅ | `/demo` — placeholder + custom-demo CTA until the reel ships | `app/(public)/demo/` |
+
+<!-- fig:4-1 -->
+<sub>📷 <b>Fig 4-1</b> · <i>Publishing composer → live page</i> — <a href="media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:4-1 -->
+
+## Browser extension
+
+| Feature | Status | Notes | Code |
+|---|---|---|---|
+| Side-panel garden | ✅ | Full app embedded in Chrome's side panel via hardened iframe channel | `extensions/browser-bookmarks/` |
+| Page capture | ✅ | Capture-policy safety gates, settle-then-associate, privacy settings, kill-switch | extension source |
+| Recents | ✅ | Local viewership history (chrome.storage, deliberately not server-side yet) | extension source |
+| Acquisition provider | ✅ | "Read full content" split-button: auto ladder or quick-pick; client-mediated, server-verified | extension + `lib/domain/ai/acquisition/` |
+| Overlay projection | ✅ | Immersive overlay surfaces on live pages | extension source |
+| Server-side Recents unification | 🔭 | First task of the extension hardening pass | — |
+
+<!-- fig:5-1 -->
+<sub>📷 <b>Fig 5-1</b> · <i>Browser extension side panel & acquisition</i> — <a href="media/figures/FIGURES.md">media pending</a></sub>
+<!-- /fig:5-1 -->
+
+## Platform & engineering rigor
+
+| Feature | Status | Notes | Code |
+|---|---|---|---|
+| Extension module system | ✅ | 10 first-party modules; registry-filtered UI (no per-feature conditionals in shared components); sync-check CI gate | `lib/extensions/` |
+| Design system | ✅ | Liquid Glass tokens (surfaces/intents/motion) + tone scale, style-dictionary → CSS vars | `lib/design/system/` |
+| Auth | ✅ | Custom OAuth (Google), role hierarchy, session hardening (scoped embed cookies) | `lib/infrastructure/auth/` |
+| Admin + audit logging | ✅ | Role-gated admin surface, audit trail | `lib/domain/admin/` |
+| Structured logging + tracing | ✅ | `withTrace`/`withSpan` spans, trace viewer scripts | `lib/` logger + `scripts/render-trace.ts` |
+| Quality gates | ✅ | typecheck → lint (warning ratchet) → build → smoke; React Compiler diagnostics enforced as errors-are-bugs | `package.json`, `.github/workflows/` |
+| Static drift detectors | ✅ | Collab schema, publishing schema, Zod-vs-render defaults, dark-mode CSS coverage, extension registry sync | `scripts/validate-*.ts`, `audit-*.ts` |
+| Visual regression harness | ✅ | Playwright light+dark projects, themed fixtures, stub conventions | `tests/e2e/` |
+| Multi-tenant foundations | 🚧 | Tenancy columns + backfill + `MULTITENANT_ENABLED` flag; single-owner remains the shipped mode | tenancy migrations |
+| Mobile compatibility | 🚧 | Viewport/touch phases landed; TipTap touch interactions paused pending device testing | `feat/mobile-compat` |

--- a/docs/media/figures/FIGURES.md
+++ b/docs/media/figures/FIGURES.md
@@ -1,0 +1,169 @@
+# Showcase Figure Registry & Audit
+
+This file is the **single source of truth and audit log** for every visual figure used in the
+public showcase surfaces (README.md and docs). It serves two jobs:
+
+1. **Audit** — the table below is auto-maintained by `pnpm showcase:figures` and always reflects
+   what media actually exists on disk and where each figure appears.
+2. **Capture briefs** — each figure section describes exactly what the media should demonstrate,
+   so anyone (including future-you) can produce the asset without re-deriving intent.
+
+## How to add media (the signal system)
+
+Drop a file in **this folder** named after the figure id — that's the whole workflow:
+
+```
+docs/media/figures/fig-2-1.png     ← satisfies Fig 2-1
+docs/media/figures/fig-1-2.gif     ← satisfies Fig 1-2
+docs/media/figures/fig-2-5.mp4     ← satisfies Fig 2-5 (rendered as a ▶ link)
+```
+
+Then run `pnpm showcase:figures`. The script:
+
+- Embeds the media everywhere the figure's marker appears (README, docs) and removes the
+  "media pending" caption. **No empty placeholder ever renders once the file exists.**
+- Updates the Status column in the audit table and the Status line in the figure's section.
+- Warns about orphan files (media with no registry entry) and unplaced figures.
+
+**Supported formats:** `.png .jpg .jpeg .webp .svg .gif` embed inline; `.mp4 .webm .mov` render
+as a "▶ watch video" link (GitHub does not play committed videos inline in READMEs). If both an
+image and a video exist for one id, the image embeds inline and the video is linked beneath it.
+
+**Numbering:** `Fig <section>-<n>` — section groups follow the README's narrative
+(1 = overview, 2 = AI & agentic, 3 = editor & collaboration, 4 = publishing, 5 = browser extension).
+New figures take the next free `n` in their section; never renumber existing figures.
+
+---
+
+## Audit table (auto-generated — do not edit by hand)
+
+<!-- figures-audit:start -->
+| Fig | Title | Status | Media file | Appears in |
+|---|---|---|---|---|
+| 1-1 | Three-panel Content IDE (hero) | ⬜ | — | README.md |
+| 1-2 | Sixty-second tour | ⬜ | — | README.md |
+| 2-1 | AI chat executing tools | ⬜ | — | README.md, docs/FEATURES.md |
+| 2-2 | Playbook run (progressive disclosure) | ⬜ | — | README.md |
+| 2-3 | Workflow canvas + run history | ⬜ | — | README.md, docs/FEATURES.md |
+| 2-4 | Folder Studio grounded chat | ⬜ | — | README.md |
+| 2-5 | Resumable stream surviving a reload | ⬜ | — | README.md |
+| 2-6 | Read-aloud TTS player | ⬜ | — | README.md |
+| 2-7 | Model routing & BYOK connections | ⬜ | — | README.md |
+| 3-1 | Block library breadth | ⬜ | — | README.md, docs/FEATURES.md |
+| 3-2 | Live collaboration | ⬜ | — | README.md |
+| 4-1 | Publishing composer → live page | ⬜ | — | README.md, docs/FEATURES.md |
+| 4-2 | davidvalentine.org, rendered by this repo | ⬜ | — | README.md |
+| 5-1 | Browser extension side panel & acquisition | ⬜ | — | README.md, docs/FEATURES.md |
+<!-- figures-audit:end -->
+
+---
+
+## Fig 1-1 — Three-panel Content IDE (hero)
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG (or subtle GIF), ≥1600 px wide, dark theme
+- **Demonstrates:** The flagship first impression: file tree (left), a rich note with headings,
+  callout, and a mermaid or excalidraw block (center), backlinks/outline (right sidebar). Should
+  read instantly as "a serious knowledge IDE," not a toy notes app.
+- **Capture notes:** Use a well-groomed demo note (no personal content). Dark theme, both sidebars
+  open, editor focused. Hide any dev banners.
+
+## Fig 1-2 — Sixty-second tour
+- **Status:** ⬜ awaiting media
+- **Wanted:** GIF, ≤10 s, ~1200 px wide
+- **Demonstrates:** Fluency of the editing loop: open a note from the tree → `/` slash command
+  inserts a block → type `[[` and autocomplete a wiki-link → auto-save indicator flips
+  yellow → green.
+- **Capture notes:** Keep it fast; trim dead frames. One continuous take.
+
+## Fig 2-1 — AI chat executing tools
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG, chat panel prominent
+- **Demonstrates:** The agentic core: a chat turn where the assistant invokes visible tool calls
+  (tool chips / run status) and places output into a note as a nested reference. This is the
+  single most important AI figure — it shows orchestration, not just chat.
+- **Capture notes:** Pick a prompt that triggers 2+ tools (e.g., search + create note). Make sure
+  the tool-call UI state is visible, not collapsed.
+
+## Fig 2-2 — Playbook run (progressive disclosure)
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG or GIF
+- **Demonstrates:** A marked playbook note driving an agentic session: the playbook being
+  discovered (`search_playbooks`), its checklist/steps injected progressively, and the agent
+  working through them. The jobhunt playbook is the canonical subject.
+- **Capture notes:** Scrub any real employer/contact names from the playbook content first.
+
+## Fig 2-3 — Workflow canvas + run history
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG, workflow canvas front and center
+- **Demonstrates:** Durable automation: the React Flow workflow canvas with a multi-node workflow,
+  plus a visible run history entry showing an n8n-spoke execution round-trip (trigger → n8n →
+  callback).
+- **Capture notes:** A workflow with 4–6 nodes reads best. Include the Run button and a
+  completed-run indicator.
+
+## Fig 2-4 — Folder Studio grounded chat
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG
+- **Demonstrates:** RAG-adjacent grounding: a folder's Studio view with Context docs attached and
+  a chat answer that cites/uses folder content. Shows retrieval scoping, not just generation.
+- **Capture notes:** Use a folder with 5+ notes so the grounding is plausible.
+
+## Fig 2-5 — Resumable stream surviving a reload
+- **Status:** ⬜ awaiting media
+- **Wanted:** GIF or short MP4, ≤15 s
+- **Demonstrates:** Infrastructure maturity: a long AI response streaming, the page reloaded
+  mid-generation, and the stream resuming instead of dying. This one needs motion — a still can't
+  prove it.
+- **Capture notes:** Pick a prompt yielding a long response so the reload lands mid-stream.
+
+## Fig 2-6 — Read-aloud TTS player
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG (GIF optional)
+- **Demonstrates:** Multimodal pipeline: the read-aloud player active on a note (TTS generated and
+  cached), showing play/pause/skip controls in context.
+- **Capture notes:** Player visible with progress mid-way so it reads as "playing," not idle.
+
+## Fig 2-7 — Model routing & BYOK connections
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG
+- **Demonstrates:** Provider abstraction: the AI connections/settings surface with multiple
+  providers configured (key states visible as configured — never the keys), and per-feature model
+  routing populated from the registry.
+- **Capture notes:** ⚠ Double-check no key material or account emails are visible.
+
+## Fig 3-1 — Block library breadth
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG, full editor width
+- **Demonstrates:** Editor depth: one note composing callouts, tabs/columns, a mermaid diagram,
+  an excalidraw sketch, and a code block — the custom TipTap node inventory at a glance.
+- **Capture notes:** Compose a dedicated "kitchen sink" demo note; keep it visually tidy.
+
+## Fig 3-2 — Live collaboration
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG or GIF
+- **Demonstrates:** Real-time Y.js collaboration: two named cursors/selections in the same note,
+  presence indicators visible.
+- **Capture notes:** Two browser profiles side-by-side; distinct user names/colors.
+
+## Fig 4-1 — Publishing composer → live page
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG (side-by-side) or GIF (compose → publish → view)
+- **Demonstrates:** The publish pipeline: authoring publishing blocks in the IDE on the left, the
+  rendered public page on the right. Proves the same TipTap document drives both surfaces.
+- **Capture notes:** Pick a visually rich page (hero block + cards) so both panes look designed.
+
+## Fig 4-2 — davidvalentine.org, rendered by this repo
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG
+- **Demonstrates:** Production proof: the live personal site (a real page, real domain) rendered
+  by the publishing system in this codebase.
+- **Capture notes:** Browser chrome with visible URL bar strengthens the claim.
+
+## Fig 5-1 — Browser extension side panel & acquisition
+- **Status:** ⬜ awaiting media
+- **Wanted:** PNG or GIF
+- **Demonstrates:** Agentic browser reach: the extension side panel open on a live page with the
+  "Read full content" acquisition split-button (tap = auto ladder, hold = quick-pick), and/or a
+  capture landing in the garden.
+- **Capture notes:** Use a public article page. Check the Recents list for private history before
+  capturing.

--- a/docs/notes-feature/guides/showcase/SHOWCASE-MAINTENANCE.md
+++ b/docs/notes-feature/guides/showcase/SHOWCASE-MAINTENANCE.md
@@ -74,7 +74,7 @@ summary:
 
 | Decision | State | Date |
 |---|---|---|
-| License | **TBD** — README says "all rights reserved for now"; owner choosing MIT vs. source-available | 2026-07-29 |
+| License | **MIT** — `LICENSE` file + README badge added | 2026-07-29 |
 | Tier-3 live demo account | **Deferred** — video-first strategy instead | 2026-07-29 |
 | Video demo | Placeholder page live at /demo ("still growing" + custom-demo CTA via /contact) | 2026-07-29 |
 | MCP | Plan-first: design doc (Workstream G) before implementation; first slice = read-only server | 2026-07-29 |

--- a/docs/notes-feature/guides/showcase/SHOWCASE-MAINTENANCE.md
+++ b/docs/notes-feature/guides/showcase/SHOWCASE-MAINTENANCE.md
@@ -1,0 +1,88 @@
+# Showcase Maintenance Guide
+
+The **showcase** is every surface a recruiter, hiring manager, or engineering peer sees before
+they ever run the app. Its job: make AI Automation Engineer competencies identifiable in under
+90 seconds, and reward anyone who digs deeper with real, current code. This guide is the canonical
+reference for keeping it truthful and current. The `/update-showcase` Claude Code skill
+(`.claude/skills/update-showcase/`) automates the ritual below.
+
+## Showcase surface inventory
+
+| Surface | Location | What it must stay in sync with |
+|---|---|---|
+| README | `README.md` | Shipped features, roadmap labels, code paths, commands, stats |
+| Feature inventory | `docs/FEATURES.md` | Every domain's shipped/🚧/🔭 state + code entry points |
+| Deployment guide | `docs/DEPLOYMENT.md` + `.env.example` | Real env vars in code, service topology, migration caveats |
+| MCP design of record | `docs/notes-feature/work-tracking/MCP-PLAN.md` | Promote milestones to README/FEATURES as they ship |
+| Figure registry + audit | `docs/media/figures/FIGURES.md` | Media files on disk (auto via script) |
+| Video demo page | `app/(public)/demo/page.tsx` → davidvalentine.org/demo | Placeholder until a demo video ships |
+| GitHub metadata | repo description, topics, homepage (via `gh repo edit`) | README positioning |
+| Plan of record | `docs/notes-feature/work-tracking/DEVELOPER-PRESENCE-PLAN.md` | Workstream status |
+
+## The prime directive: honesty
+
+**Nothing planned may appear unlabeled.** Every unshipped capability in any showcase surface
+carries `🔭 Planned` and, once one exists, a link to its design doc. When something ships, the
+update ritual promotes it: label removed, evidence link added. Technical screeners check claims
+against code; one inflated claim costs more than ten missing features.
+
+**Presentation driver: high-demand AI skills first.** When choosing what to surface, feature, or
+lead with, the priority order is: agentic orchestration (tools, playbooks, workflows) → AI
+infrastructure (routing, fallback, streaming, governance) → multimodal pipelines → everything
+else. Non-AI features earn README space by demonstrating engineering depth (collab CRDTs, CI
+gates), not by completeness.
+
+## The update ritual ("update the showcase")
+
+1. **Diff reality against the README.** Find what shipped since the last showcase update:
+   `git log -1 --format=%ci -- README.md` for the baseline date, then
+   `git log --oneline --since=<that date> origin/main` plus the Recent Completions section of
+   `docs/notes-feature/STATUS.md`.
+2. **Promote shipped roadmap items.** Move them from the Roadmap section into the competency
+   table / feature tour, with a code-path link. Add newly planned items with `🔭`.
+3. **Verify every claimed code path still exists** (`git ls-tree origin/main <path>`), and that
+   commands/ports/env vars in Quickstart still match `package.json` and `CLAUDE.md`.
+4. **Reconcile figures.** New feature worth showing → add a registry entry (next free number in
+   its section, never renumber) + a marker in the README + a capture brief. Then run
+   `pnpm showcase:figures` and commit its rewrites.
+5. **Check the demo page.** If a demo video now exists, replace the placeholder frame in
+   `components/personal/DemoPage.tsx` with the embed (keep the custom-demo CTA).
+6. **Sync GitHub metadata** if positioning changed: `gh repo edit --description ... --add-topic ...`.
+7. **Gates:** `pnpm typecheck && pnpm lint` (README-only changes still deserve a link-check pass
+   by eye; script/page changes need the full gates).
+8. **Update the plan doc** workstream statuses and this guide's Standing Decisions if any changed.
+
+## The figure signal system (spec)
+
+Full contract lives in [`docs/media/figures/FIGURES.md`](../../../media/figures/FIGURES.md);
+summary:
+
+- **Registry**: `FIGURES.md` declares each figure as `## Fig <id> — <title>` with a capture brief.
+  It is also the **audit log** — its status table and per-figure Status lines are rewritten by the
+  script on every run, so it always reflects disk truth.
+- **Slots**: showcase markdown contains `<!-- fig:<id> --> … <!-- /fig:<id> -->` markers. Content
+  between markers is script-owned; never hand-edit inside them.
+- **Signal**: dropping `fig-<id>.<ext>` into `docs/media/figures/` and running
+  `pnpm showcase:figures` embeds the media in every slot. No file → a one-line "media pending"
+  caption. **An empty or broken placeholder must never render** — that invariant is the script's
+  core job.
+- **Formats**: images/GIFs embed inline; videos become ▶ links (GitHub won't inline-play committed
+  video). Image + video for the same id → image inline, video linked beneath.
+- The script warns on: orphan media files, registered-but-unplaced figures, unregistered markers.
+
+## Standing decisions (update when the owner rules)
+
+| Decision | State | Date |
+|---|---|---|
+| License | **TBD** — README says "all rights reserved for now"; owner choosing MIT vs. source-available | 2026-07-29 |
+| Tier-3 live demo account | **Deferred** — video-first strategy instead | 2026-07-29 |
+| Video demo | Placeholder page live at /demo ("still growing" + custom-demo CTA via /contact) | 2026-07-29 |
+| MCP | Plan-first: design doc (Workstream G) before implementation; first slice = read-only server | 2026-07-29 |
+
+## Remaining workstreams (from the plan of record)
+
+See `DEVELOPER-PRESENCE-PLAN.md` §3–4. Shipped in S1: README overhaul, figure system, demo page,
+repo metadata. Shipped in S2: `docs/FEATURES.md`, `docs/DEPLOYMENT.md` + `.env.example`,
+`MCP-PLAN.md`, ContentNode + workflow diagrams. Next: **S3** — capture the 14 registered figures
++ record the video (owner; deferred until after release). **S4** — showcase seed vault +
+read-only MCP server slice (M1 of MCP-PLAN.md).

--- a/docs/notes-feature/work-tracking/DEVELOPER-PRESENCE-PLAN.md
+++ b/docs/notes-feature/work-tracking/DEVELOPER-PRESENCE-PLAN.md
@@ -27,6 +27,10 @@ audience: recruiters, hiring managers, engineering peers
 >   HTTP via mcp-handler, PAT→OAuth 2.1 auth ladder, M1 read-only slice; client: AI SDK MCP
 >   client with namespacing + injection defenses); README wired to all three + figure slots
 >   added to FEATURES.md (sync run ✅).
+> - **2026-07-29 — License decided: MIT.** Added `LICENSE` (MIT, copyright David
+>   Valentine 2025-2026) + README badge + license section rewrite. Maintenance
+>   guide's standing-decisions table updated. No owner decisions remain open
+>   from §5 below except the ones already marked deferred.
 > - **Next:** S3 — owner captures the 14 figures + records video (deferred until after release).
 >   S4 — showcase seed vault + MCP M1.
 
@@ -149,7 +153,7 @@ S1 alone converts the repo from "invisible AI" to "legible AI." Ship it first; e
 
 ## 5. Owner decisions needed (non-blocking for S1 except license)
 
-1. **License** — MIT vs. source-available vs. all-rights-reserved-but-viewable. (Blocks the LICENSE file only; README can ship with "License: TBD" removed and section omitted.)
+1. ~~**License** — MIT vs. source-available vs. all-rights-reserved-but-viewable.~~ **Decided 2026-07-29: MIT.**
 2. **Tier 3 live demo** — go/no-go on a seeded demo account (recommend: defer).
 3. **Video** — owner narration vs. captioned screen-capture only.
 4. **Repo rename?** — `Digital-Garden` is fine; only revisit if positioning shifts.

--- a/docs/notes-feature/work-tracking/DEVELOPER-PRESENCE-PLAN.md
+++ b/docs/notes-feature/work-tracking/DEVELOPER-PRESENCE-PLAN.md
@@ -1,0 +1,162 @@
+---
+title: Developer Presence & AI Competency Showcase Plan
+status: IN PROGRESS — S1 executed 2026-07-29
+created: 2026-07-29
+last_updated: 2026-07-29
+owner: davidvalentine
+audience: recruiters, hiring managers, engineering peers
+---
+
+> **Execution log**
+> - **2026-07-29 — S1 SHIPPED** (branch `feat/tone-system-and-extension-tts`): README overhauled
+>   (AI-first, competency table, 2 Mermaid diagrams, 14 figure slots); **figure signal system**
+>   built (`docs/media/figures/` + FIGURES.md audit registry + `pnpm showcase:figures` sync
+>   script — drop `fig-<id>.<ext>` in the folder, run the script, media embeds; no broken
+>   placeholders ever); `/demo` page live-ready (placeholder + custom-demo CTA → /contact);
+>   GitHub description/homepage/topics updated; maintenance guide
+>   (`guides/showcase/SHOWCASE-MAINTENANCE.md`) + `/update-showcase` Claude skill added.
+>   Gates: typecheck ✅ lint ✅. Owner decisions applied: Tier-3 demo **deferred**, video demo
+>   page **placeholder-first**. Still open: license choice.
+> - **2026-07-29 — S2 SHIPPED** (same branch): `docs/FEATURES.md` (full inventory, ✅/🚧/🔭
+>   labels, ContentNode ERD + workflow diagrams inline — landed there instead of a separate
+>   docs/architecture/ to keep it one hop from the README); `docs/DEPLOYMENT.md` (real env
+>   reference from code scan of origin/main, migration-baseline caveat, Hocuspocus redeploy
+>   rules, post-deploy verification); **`.env.example` created** (README's `cp .env.example`
+>   instruction had been broken since April — file never existed; whitelisted in .gitignore);
+>   `MCP-PLAN.md` design of record (server: tools/resources/playbooks-as-prompts over Streamable
+>   HTTP via mcp-handler, PAT→OAuth 2.1 auth ladder, M1 read-only slice; client: AI SDK MCP
+>   client with namespacing + injection defenses); README wired to all three + figure slots
+>   added to FEATURES.md (sync run ✅).
+> - **Next:** S3 — owner captures the 14 figures + records video (deferred until after release).
+>   S4 — showcase seed vault + MCP M1.
+
+# Developer Presence & AI Competency Showcase Plan
+
+**Objective:** Make the Digital Garden repo and its public surfaces legible to employer recruiters in under 90 seconds, with AI Automation Engineer core competencies identifiable at a glance — while staying strictly honest about what is shipped vs. planned.
+
+**Framing constraint:** Recruiters skim; engineers doing due diligence dig. Every artifact below serves the skimmer first (headline, diagram, GIF) and rewards the digger second (code entry points, plan docs, PR history).
+
+---
+
+## 1. Current-State Audit (2026-07-29)
+
+| Surface | State | Problem |
+|---|---|---|
+| README.md | Stale (Apr 26) | **Zero AI mentions.** Predates AI v3.x, workflows/Trellis, browser reach, playbooks, TTS/STT, publishing, Folder Studio. Stale paths (`stores/` vs `state/`), wrong dev port (3000 vs 3015), unclosed code fence in Hocuspocus section, `[Your License Here]` placeholder |
+| GitHub repo meta | Public ✅ | No topics, generic description, no social preview image, no LICENSE file |
+| Architecture diagrams | None in repo | 90+ docs exist but no visual system map anywhere |
+| Screenshots/video | None | No visual evidence of the product at all |
+| Live demo | Partial | davidvalentine.org runs the publishing system (public); the IDE itself is auth-gated with no demo path |
+| Feature inventory | Scattered | Capabilities live across CLAUDE.md, STATUS.md, 7 plan docs, and 136 PRs — no single consumable list |
+| Deployment docs | Stale | README deploy section predates the 3-service topology (Vercel + Cloud Run Hocuspocus + n8n on home server) |
+| MCP | **Not present** | A gap for the "AI competency" story — addressed via Workstream G (plan-first, implement later) |
+
+**What already exists but is invisible:** ~25 modules in `lib/domain/ai/` (multi-model routing with fallback chains, tool registry, playbooks, run-ledger, resumable streams, TTS/STT/image, acquisition), the Trellis workflow subsystem with n8n spoke, the browser extension acquisition ladder, Y.js/Hocuspocus collaboration with CI schema gates, and the publishing system that renders davidvalentine.org.
+
+---
+
+## 2. Competency Map — feature → AI Automation Engineer skill → proof
+
+This table is the skeleton for the README's AI section and FEATURES.md. Every row must link to a real code entry point (recruiters' engineers WILL click).
+
+| Competency | Shipped evidence | Entry point |
+|---|---|---|
+| LLM orchestration & tool calling | 13+ registered AI tools, client-safe metadata / server-only registry split | `lib/domain/ai/tools/` |
+| Multi-model routing & fallback | `FEATURE_REGISTRY`, `resolveFeatureRoute()`, `executeWithFallback()`, registry-authoritative model catalog (PR #133) | `lib/domain/ai/features/` |
+| Agent skills / progressive disclosure | Playbooks: marked notes/folders injected progressively, `search_playbooks` tool | `lib/domain/ai/` playbooks modules |
+| Durable/agentic workflows | Trellis hub tables + WDK + triggers + React Flow canvas; n8n spoke w/ webhook callbacks | `extensions/workflows/` |
+| Resource governance | Run-ledger, tool-output compaction, dangling-tool repair; budgets planned (v3.7) | `lib/domain/ai/run-ledger.ts`, `compact-tool-outputs.ts` |
+| Resilient streaming | Resumable AI streams over Upstash (PR #130); SSE chat | `app/api/ai/chat/` |
+| Multimodal pipelines | TTS generate+store, STT transcription, AI image gen, media injection into notes | `lib/domain/ai/speech/`, `transcribe/`, `image/` |
+| Agentic browser reach | Extension as acquisition provider (sw-fetch / session-tab ladder), overlay projection, capture-policy safety gates | `extensions/browser-bookmarks/` + extension repo dirs |
+| Grounded generation (RAG-adjacent) | Folder Studio grounded chat + Context docs + auto-context | `extensions/studio/` |
+| BYOK & provider abstraction | Anthropic/OpenAI provider factories, encrypted key storage | `lib/domain/ai/providers/` |
+| MCP (interoperability) | **PLANNED** — design doc first (Workstream G), implementation follows | `docs/.../MCP-PLAN.md` (to create) |
+| Eng rigor around AI surfaces | CI gates: collab schema check, publishing schema check, drift audits, lint ratchet | `.github/workflows/`, `scripts/` |
+
+**Honesty rule (non-negotiable):** every planned-but-unshipped item is labeled `🔭 Planned` with a link to its design doc. Nothing planned appears in a "Features" list without the label. Recruiters' technical screeners check; an inflated README costs more credibility than a gap.
+
+---
+
+## 3. Workstreams
+
+### A. README overhaul (highest leverage, do first)
+- New structure: hero paragraph → 1 screenshot/GIF → **"AI & Agentic Systems" section near the top** (competency table from §2, condensed) → architecture diagram (Mermaid, renders natively on GitHub) → feature tour → quickstart → deployment → docs index → license.
+- Lead positioning: "AI-native knowledge IDE" — not "Obsidian-inspired notes app." The Obsidian comparison buries the differentiator.
+- Fix all stale content: paths, port 3015, broken code fence, heap-size note, `pnpm dev:collab` requirement.
+- Badges: CI status (quality.yml), Next.js 16 / React 19 / TypeScript strict, license.
+- Cross-link: davidvalentine.org (live publishing output), AGENTS.md/CLAUDE.md (signals mature AI-assisted dev practice — itself a competency).
+
+### B. Architecture diagrams (Mermaid, in-repo)
+All as Mermaid in markdown so GitHub renders them without image maintenance:
+1. **System topology** — Vercel app ⇄ Postgres (Neon prod / Docker dev) ⇄ Hocuspocus (Cloud Run) ⇄ storage providers ⇄ n8n (home server, Cloudflare Tunnel) ⇄ browser extension.
+2. **AI request lifecycle** — chat request → feature route resolution → model fallback chain → tool loop (registry) → run-ledger → resumable stream → persistence.
+3. **ContentNode v2.0 data model** — the polymorphic payload ERD.
+4. **Workflow subsystem** — trigger → hub → n8n spoke → callback.
+Diagram 2 is the recruiter-facing money shot; put it in the README, others in `docs/architecture/`.
+
+### C. Visual walkthrough
+- 6–8 screenshots (light+dark where it matters): three-panel IDE, AI chat with tool call visible, workflow canvas (React Flow), playbook in action, publishing composer, published page on davidvalentine.org, browser extension panel.
+- 2–3 short GIFs (≤10s each): slash command insert, AI chat placing output into a note, read-aloud TTS player.
+- One 2–3 min narrated video (Loom/YouTube unlisted): the jobhunt playbook flow end-to-end. Recruiters won't clone the repo; video is the only "demo" most will consume.
+- Store stills in `docs/media/` (or `.github/assets/`); video linked, not committed.
+
+### D. Use-case narrative
+- **Flagship: the jobhunt playbook** — "I built an agentic system and use it to run my own job search": playbook doc marked in the garden → progressive-disclosure injection → chat agent executes with tools → outputs filed as references under the chat → workflow triggers for follow-ups. This is self-demonstrating and memorable.
+- Secondary narratives: (1) capture-to-knowledge pipeline (browser extension acquisition → note → AI enrichment → published page); (2) spaced-repetition learning loop (notes → AI-proposed flashcards → FSRS scheduling).
+- Format: `docs/USE-CASES.md` + condensed version in README + long-form case study post on davidvalentine.org (dogfoods the publishing system — the medium is itself evidence).
+
+### E. Working demonstration
+Three tiers, cheapest-credible first:
+1. **Tier 1 (ship now):** davidvalentine.org IS a working demo of the publishing pipeline — label it as such ("this site is rendered by this repo's publishing system").
+2. **Tier 2:** the narrated video (Workstream C) as the demo of auth-gated surfaces.
+3. **Tier 3 (decision needed):** live demo account — seeded read-mostly "demo vault" user, server-side rate-limited AI on owner's key or disabled-with-explainer. Real cost/abuse surface (BYOK, storage). **Recommend deferring Tier 3** until 1–2 land; a good video captures 90% of the value at 5% of the risk.
+- Enhance `pnpm db:seed` into a showcase vault (notes exercising every block type, a playbook, a workflow) — doubles as reviewer-quickstart and Tier 3 foundation.
+
+### F. Feature inventory + deployment instructions
+- `docs/FEATURES.md`: full inventory grouped by domain (AI, editor, collaboration, publishing, extensions, infra), each with status (✅ shipped / 🔭 planned), competency tags, and code entry point. The §2 table is the AI section; non-AI sections follow the same grammar.
+- Deployment guide rewrite (`docs/DEPLOYMENT.md`, README links to it): honest 3-service topology — Vercel (app), Cloud Run (Hocuspocus, `cloudbuild.hocuspocus.yaml`), n8n (any host), Postgres, storage providers; env var reference; migration baseline caveat (`migrate resolve --applied 00000000000000_baseline` for existing DBs); local dev incl. Docker Postgres + `pnpm dev:collab` + `NODE_OPTIONS` heap note. Deploying a multi-service system is itself an automation-engineer competency — document it as one.
+
+### G. MCP strategy (fills the competency gap — owner-directed)
+Plan-first so the competency is present and credible before code lands:
+1. **`docs/notes-feature/work-tracking/MCP-PLAN.md`** — spec-accurate design doc:
+   - **MCP server** exposing the garden: tools (`search_notes`, `read_note`, `create_note`, `list_tree`, `run_workflow`), resources (notes as `garden://` URIs), auth via existing session/token infra. Lets Claude Desktop/Code/other agents operate on the user's garden.
+   - **MCP client** in the chat engine: consume external MCP servers as dynamic tools alongside the native registry (AI SDK v6 has MCP client support — natural fit with the existing tool registry).
+   - Sequencing, security model (capability scoping per token), and how it composes with playbooks + workflows.
+2. README/FEATURES.md list it as `🔭 Planned — [design doc]`. A rigorous, spec-accurate design doc demonstrates the competency honestly; shipping even the read-only server later upgrades the label.
+3. Suggested first slice: read-only MCP server (search + read) — small, safe, and immediately demoable from Claude Desktop.
+
+### H. Repo & profile hygiene (cheap, do with Workstream A)
+- **LICENSE** — currently none + placeholder text. ⚠ Owner decision: MIT (max approachability) vs. source-available (e.g., PolyForm Noncommercial) if protecting the product is a concern. Recruiter-optimal is MIT; do not leave the placeholder.
+- GitHub topics: `nextjs`, `typescript`, `ai`, `agents`, `ai-sdk`, `tiptap`, `yjs`, `knowledge-management`, `mcp` (once planned doc exists), etc.
+- Repo description: rewrite to lead with AI ("AI-native knowledge IDE — agentic chat, durable workflows, real-time collab. Next.js 16 / TypeScript").
+- Social preview image (the README hero shot).
+- Pin the repo on the GitHub profile; align profile README if one exists.
+- Optional: `CHANGELOG.md` distilled from the 136-PR history — the shipping cadence itself is a strong signal.
+
+---
+
+## 4. Sequencing
+
+| Sprint | Scope | Effort |
+|---|---|---|
+| **S1 — Legibility** | Workstream A (README) + H (hygiene, minus LICENSE decision) + B diagrams 1–2 | 1 session |
+| **S2 — Inventory & MCP** | F (FEATURES.md + DEPLOYMENT.md) + G1 (MCP-PLAN.md) + B diagrams 3–4 | 1 session |
+| **S3 — Show, don't tell** | C (screenshots, GIFs, video) + D (use-case narrative + site case study) | 1–2 sessions (video needs owner) |
+| **S4 — Demo depth** | E (seed vault; Tier 3 decision) + G3 (read-only MCP server slice) | 1–2 sessions |
+
+S1 alone converts the repo from "invisible AI" to "legible AI." Ship it first; everything else compounds on it.
+
+## 5. Owner decisions needed (non-blocking for S1 except license)
+
+1. **License** — MIT vs. source-available vs. all-rights-reserved-but-viewable. (Blocks the LICENSE file only; README can ship with "License: TBD" removed and section omitted.)
+2. **Tier 3 live demo** — go/no-go on a seeded demo account (recommend: defer).
+3. **Video** — owner narration vs. captioned screen-capture only.
+4. **Repo rename?** — `Digital-Garden` is fine; only revisit if positioning shifts.
+
+## 6. Success criteria
+
+- A recruiter can answer "what is this and why is this person an AI automation engineer?" from the README above the fold, in <90s.
+- A technical screener clicking any competency row lands on real, current code within one click.
+- Zero claims in public docs that the codebase cannot substantiate (planned items labeled).
+- README/diagram content survives `main` drift — paths and commands verified against the tree at time of writing.

--- a/docs/notes-feature/work-tracking/MCP-PLAN.md
+++ b/docs/notes-feature/work-tracking/MCP-PLAN.md
@@ -1,0 +1,163 @@
+---
+title: MCP Integration Plan — Model Context Protocol server + client
+status: 🔭 PLANNED (design of record — no implementation yet)
+created: 2026-07-29
+last_updated: 2026-07-29
+owner: davidvalentine
+---
+
+# MCP Integration Plan
+
+**Status: 🔭 Planned.** This is the design of record for making the Digital Garden a first-class
+citizen of the Model Context Protocol ecosystem — in **both directions**:
+
+1. **MCP server** — external agents (Claude Desktop, Claude Code, IDE agents, other MCP clients)
+   operate on the garden: search it, read and write notes, run playbooks and workflows.
+2. **MCP client** — the garden's own chat engine consumes *external* MCP servers, so its agents
+   can use third-party tools alongside the native tool registry.
+
+Nothing here ships until it clears the standard gates. The README links this doc from its
+roadmap; when milestones land, promote them there per the showcase maintenance guide.
+
+---
+
+## 1. Protocol grounding (what we're building against)
+
+MCP is a JSON-RPC 2.0 protocol with capability negotiation at `initialize`. The concepts this
+plan relies on:
+
+- **Server primitives:** `tools` (model-invocable functions with JSON Schema inputs), `resources`
+  (URI-addressed content, with templates and optional subscriptions), and `prompts`
+  (user-selectable, parameterized instruction sets). Servers emit `list_changed` notifications
+  when their offerings change.
+- **Client primitives:** `sampling` (server asks the client's model to generate), `roots`
+  (client-scoped filesystem/URI boundaries), and `elicitation` (server asks the user for input).
+- **Transports:** `stdio` for local processes; **Streamable HTTP** for remote servers — a single
+  endpoint accepting POSTed JSON-RPC with an optional SSE response stream and an
+  `Mcp-Session-Id` session header. Streamable HTTP superseded the older HTTP+SSE dual-endpoint
+  transport and is the only remote transport we target.
+- **Authorization:** for HTTP transports, the spec's OAuth 2.1 framework — the MCP server acts as
+  a **resource server** advertising protected-resource metadata (RFC 9728), with an external
+  authorization server issuing tokens. Simpler bearer-token schemes are permissible for
+  first-party clients; we exploit that for M1 (below).
+- **SDK/runtime:** the official TypeScript SDK (`@modelcontextprotocol/sdk`) provides
+  `McpServer` with `registerTool` / `registerResource` / `registerPrompt`. Vercel's `mcp-handler`
+  adapts it to Next.js route handlers, which fits our deployment (Fluid Compute handles SSE and
+  long-lived responses; no separate service needed).
+
+Pin the SDK version and record the spec revision it implements at implementation time; MCP
+revisions move quickly and auth details have changed between revisions.
+
+## 2. Why this fits the existing architecture (the design's core argument)
+
+Each MCP server primitive maps onto a subsystem the garden already has. The work is mostly
+**adapter surface**, not new capability:
+
+| MCP primitive | Existing subsystem | Adapter work |
+|---|---|---|
+| `tools` | Server tool registry (`lib/domain/ai/tools/registry.ts`) — search, content CRUD, flashcards, workflows already exist as internal AI tools | Wrap a curated subset with MCP JSON Schema definitions + per-token capability filtering |
+| `resources` | ContentNode tree + payloads | `garden://note/{id}`, `garden://folder/{id}` URI scheme; markdown serialization via the existing lossless TipTap⇄markdown serializer |
+| `prompts` | Playbooks (`lib/domain/ai/playbooks/`) — already named, discoverable, parameterized instruction sets | Expose rendered playbooks as MCP prompts; `search_playbooks` becomes `prompts/list` filtering |
+| auth | Session/token infra + tenant model | Personal Access Tokens (M1), OAuth 2.1 resource server (M3) |
+| write safety | Output-placement modules (`output-target.ts`, `tools/output-placement.ts`) | All MCP writes route through the same canonical placement path as native AI tools — one write-safety surface, not two |
+
+**Design rule:** the MCP layer never talks to Prisma directly. It calls the same domain services
+the native tool registry calls. That keeps authorization, tenancy, soft-delete, and collaboration
+semantics (Y.doc-authoritative notes) in one place — and means an MCP write can't corrupt a
+collab document any differently than a native tool write could.
+
+## 3. Server design
+
+### 3.1 Transport & mounting
+
+- Route: `app/api/mcp/[transport]/route.ts` via `mcp-handler` (Streamable HTTP; SSE fallback
+  handled by the adapter). Stateless-session mode initially: each request authenticates
+  independently; `Mcp-Session-Id` supported but no server-side session state beyond auth.
+- Deployed with the main Vercel app. No new service, no new infra.
+
+### 3.2 Tool surface (curated, capability-scoped)
+
+M1 (read-only):
+
+| MCP tool | Backs onto | Notes |
+|---|---|---|
+| `garden_search` | content search service | full-text + tag filters; returns ids + snippets, never full payloads |
+| `garden_read_note` | note read + markdown serializer | returns markdown + metadata (tags, backlinks); respects soft-delete |
+| `garden_list_tree` | tree endpoint service | scoped to token's root caps; depth-limited |
+| `garden_get_backlinks` | backlinks service | knowledge-graph traversal for agents |
+
+M2 (write, gated per token):
+
+| MCP tool | Backs onto | Notes |
+|---|---|---|
+| `garden_create_note` | create-document service + output placement | parent folder must be inside token scope |
+| `garden_append_to_note` | output-placement modules | append-only by default; full replace requires an elevated capability |
+| `garden_run_workflow` | workflow trigger service | only workflows explicitly marked externally-triggerable; honors the "Run button is the sanctioned trigger" rule by making MCP an *equivalent sanctioned* entry with its own audit trail |
+
+Everything returns structured content (typed JSON alongside text) so capable clients get machine-
+readable results.
+
+### 3.3 Resources & prompts
+
+- `garden://note/{id}` (markdown), `garden://folder/{id}` (listing) via resource templates.
+  Subscriptions (`resources/subscribe`) deferred — requires change-feed plumbing; revisit after M3.
+- Playbooks exposed as MCP prompts: `prompts/list` returns playbooks the token can see;
+  `prompts/get` returns the **rendered** playbook (progressive disclosure is an in-engine
+  optimization; external clients get the compiled form). This gives any MCP client one-command
+  access to the garden's operating procedures.
+
+### 3.4 Authorization model
+
+- **M1 — Personal Access Tokens.** Created in Settings; stored hashed; each token carries
+  **capabilities** (`read` | `write` | `run-workflows`) and an optional **content scope** (a
+  folder subtree — reusing the Folder Studio caps model). Sent as `Authorization: Bearer`.
+  Sufficient for first-party use (your own Claude Desktop/Code talking to your garden).
+- **M3 — OAuth 2.1 resource server** for third-party clients: protected-resource metadata
+  (RFC 9728) advertising the authorization server, token audience validation, scope→capability
+  mapping. Not before there's a real third-party consumer.
+- Every MCP call is audit-logged (actor = token, action, target ids) through the existing
+  admin/audit logging.
+
+## 4. Client design (M4 — external tools inside garden chat)
+
+- Settings surface: register external MCP servers (name, URL, auth header), per-server enable.
+- Engine integration: AI SDK's MCP client (`experimental_createMCPClient`) converts a server's
+  tools into AI SDK tool definitions, merged into the chat tool loop **namespaced by server**
+  (e.g. `linear__create_issue`) to avoid collisions with native tools.
+- **Trust boundary:** external tool descriptions and outputs are untrusted input (prompt-injection
+  surface). Mitigations, in order: per-tool allowlist at registration (user picks which tools the
+  agent may see); human approval required for any external tool call that follows reading
+  external content in the same run; external tool output wrapped in delimited, provenance-tagged
+  blocks in context; `list_changed` re-pins — if a server redefines a tool, it drops to
+  unapproved until re-allowlisted (rug-pull defense).
+- Runs consuming external tools are metered by the existing run ledger; per-run external-call
+  budgets ride the planned resource-governance work (AI 3.7).
+
+## 5. Threat model (summary)
+
+| Threat | Mitigation |
+|---|---|
+| Token leakage → full-garden read | Scoped tokens (capability + subtree), hashed at rest, revocable, audit-logged |
+| Prompt injection via external MCP tools/resources | Allowlists, approval gates, provenance tagging, no chained writes after untrusted reads without approval |
+| Confused deputy (garden server invoked with someone else's authority) | Token ↔ tenant binding checked in the domain layer, not the adapter |
+| Tool-definition rug-pull on external servers | Pin-and-reapprove on `list_changed` |
+| Write amplification / doc corruption | All writes through canonical output-placement + collab-safe paths; append-only default |
+
+## 6. Milestones & gates
+
+| Milestone | Scope | Gate |
+|---|---|---|
+| **M1 — read-only server** | PAT auth + `garden_search` / `garden_read_note` / `garden_list_tree` / `garden_get_backlinks` + note/folder resources | MCP Inspector clean; Claude Desktop + Claude Code connect and answer questions from garden content; zero write paths exist |
+| **M2 — writes** | create/append tools behind `write` capability; audit trail | Round-trip: external agent files a note, it appears correctly in-app incl. collab view |
+| **M3 — OAuth 2.1 + playbook prompts** | Resource-server metadata; prompts surface | Third-party MCP client authorizes without a PAT |
+| **M4 — MCP client in chat** | Settings registration, namespacing, approval gates | External tool called mid-conversation with approval flow; injection red-team checklist passes |
+
+M1 is deliberately small — it's the showcase slice (demoable from Claude Desktop against a real
+garden) and carries no write risk. Testing throughout: MCP Inspector for contract conformance,
+Claude Desktop/Code as reference clients, plus route-handler unit tests for auth/scoping.
+
+## 7. Explicitly out of scope (for now)
+
+Resource subscriptions/change feeds; MCP `sampling` from our server (we have our own model
+stack); exposing binary `FilePayload` content (presigned-URL dance needs its own design);
+multi-tenant third-party marketplace listing (single-owner garden first).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -116,6 +116,7 @@ const eslintConfig = defineConfig([
     "app/.well-known/workflow/**",
     // Local git worktree copies of the same repo.
     ".claude/worktrees/**",
+    ".codex/worktrees/**",
     ".worktrees/**",
     // Playwright artifacts.
     "test-results/**",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "publishing:schema:check": "tsx scripts/validate-publishing-schema.ts",
     "publishing:audit:defaults": "tsx scripts/audit-publishing-defaults.ts",
     "publishing:audit:themes": "tsx scripts/audit-publishing-themes.ts",
+    "showcase:figures": "tsx scripts/sync-showcase-figures.ts",
     "db:seed": "tsx prisma/seed.ts",
     "db:target": "tsx scripts/check-db-target.ts",
     "preflight": "bash scripts/preflight.sh",

--- a/scripts/sync-showcase-figures.ts
+++ b/scripts/sync-showcase-figures.ts
@@ -1,0 +1,240 @@
+/**
+ * sync-showcase-figures.ts — the showcase "figure signal system".
+ *
+ * Contract (documented in docs/media/figures/FIGURES.md):
+ *   - Figures are declared in the registry as `## Fig <id> — <title>` sections.
+ *   - Markdown surfaces (README.md, docs/**) contain marker slots:
+ *       <!-- fig:1-1 --> ... <!-- /fig:1-1 -->
+ *   - Dropping a media file named `fig-<id>.<ext>` into docs/media/figures/
+ *     and running `pnpm showcase:figures` embeds it inside every matching slot.
+ *   - When no file exists, the slot renders a one-line "media pending" caption —
+ *     never an empty or broken placeholder.
+ *   - The registry's audit table + per-figure Status lines are rewritten on every
+ *     run, so FIGURES.md is always a faithful audit of what exists on disk.
+ *
+ * Idempotent: re-running without changes rewrites nothing.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = process.cwd();
+const FIG_DIR = path.join(ROOT, "docs", "media", "figures");
+const REGISTRY_PATH = path.join(FIG_DIR, "FIGURES.md");
+
+/** Inline-embeddable formats, in preference order when several exist. */
+const INLINE_PRIORITY = [".gif", ".png", ".jpg", ".jpeg", ".webp", ".svg"];
+/** Video formats (GitHub won't inline-play committed videos → rendered as links). */
+const VIDEO_PRIORITY = [".mp4", ".webm", ".mov"];
+
+const AUDIT_START = "<!-- figures-audit:start -->";
+const AUDIT_END = "<!-- figures-audit:end -->";
+
+interface FigureMedia {
+  inline?: string; // file name of best inline asset
+  video?: string; // file name of best video asset
+}
+
+interface FigureEntry {
+  id: string;
+  title: string;
+  media: FigureMedia;
+  placements: string[]; // repo-relative markdown paths containing this figure's marker
+}
+
+function fail(msg: string): never {
+  console.error(`✖ ${msg}`);
+  process.exit(1);
+}
+
+function toPosix(p: string): string {
+  return p.split(path.sep).join("/");
+}
+
+function relFrom(fromFile: string, target: string): string {
+  return toPosix(path.relative(path.dirname(fromFile), target));
+}
+
+// ── 1. Parse the registry ────────────────────────────────────────────────────
+if (!fs.existsSync(REGISTRY_PATH)) {
+  fail(`Registry not found: ${toPosix(path.relative(ROOT, REGISTRY_PATH))}`);
+}
+const registrySource = fs.readFileSync(REGISTRY_PATH, "utf8");
+
+const HEADER_RE = /^## Fig ([a-z0-9]+(?:-[a-z0-9]+)*) — (.+)$/gim;
+const figures = new Map<string, FigureEntry>();
+for (const match of registrySource.matchAll(HEADER_RE)) {
+  const id = match[1].toLowerCase();
+  if (figures.has(id)) fail(`Duplicate registry entry for Fig ${id}`);
+  figures.set(id, { id, title: match[2].trim(), media: {}, placements: [] });
+}
+if (figures.size === 0) fail("Registry contains no `## Fig <id> — <title>` sections.");
+
+// ── 2. Scan the media folder ─────────────────────────────────────────────────
+const orphanFiles: string[] = [];
+const mediaByFigure = new Map<string, string[]>();
+for (const name of fs.readdirSync(FIG_DIR)) {
+  const parsed = /^fig-(.+)\.([a-z0-9]+)$/i.exec(name);
+  if (!parsed) continue;
+  const id = parsed[1].toLowerCase();
+  if (!figures.has(id)) {
+    orphanFiles.push(name);
+    continue;
+  }
+  const list = mediaByFigure.get(id) ?? [];
+  list.push(name);
+  mediaByFigure.set(id, list);
+}
+for (const [id, files] of mediaByFigure) {
+  const entry = figures.get(id);
+  if (!entry) continue;
+  const pick = (priority: string[]): string | undefined => {
+    for (const ext of priority) {
+      const hit = files.find((f) => f.toLowerCase().endsWith(ext));
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  entry.media.inline = pick(INLINE_PRIORITY);
+  entry.media.video = pick(VIDEO_PRIORITY);
+}
+
+// ── 3. Rewrite marker slots in showcase surfaces ─────────────────────────────
+function collectMarkdownFiles(): string[] {
+  const found: string[] = [];
+  const readme = path.join(ROOT, "README.md");
+  if (fs.existsSync(readme)) found.push(readme);
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+        walk(full);
+      } else if (entry.name.endsWith(".md") && full !== REGISTRY_PATH) {
+        found.push(full);
+      }
+    }
+  };
+  const docsDir = path.join(ROOT, "docs");
+  if (fs.existsSync(docsDir)) walk(docsDir);
+  return found;
+}
+
+function escapeAttr(text: string): string {
+  return text.replace(/"/g, "&quot;");
+}
+
+function renderSlot(id: string, filePath: string): string {
+  const entry = figures.get(id);
+  const registryRef = relFrom(filePath, REGISTRY_PATH);
+  if (!entry) {
+    return `<sub>📷 <b>Fig ${id}</b> — unregistered figure · <a href="${registryRef}">add it to the registry</a></sub>`;
+  }
+  const { inline, video } = entry.media;
+  const videoRef = video ? relFrom(filePath, path.join(FIG_DIR, video)) : undefined;
+  if (inline) {
+    const inlineRef = relFrom(filePath, path.join(FIG_DIR, inline));
+    const videoSuffix = videoRef ? ` · <a href="${videoRef}">▶ video</a>` : "";
+    return [
+      `<p align="center">`,
+      `  <img src="${inlineRef}" alt="Fig ${id} — ${escapeAttr(entry.title)}" width="850" />`,
+      `  <br /><sub><b>Fig ${id}</b> — ${entry.title}${videoSuffix}</sub>`,
+      `</p>`,
+    ].join("\n");
+  }
+  if (videoRef) {
+    return `<p align="center"><sub><b>Fig ${id}</b> — ${entry.title} · <a href="${videoRef}">▶ watch video</a></sub></p>`;
+  }
+  return `<sub>📷 <b>Fig ${id}</b> · <i>${entry.title}</i> — <a href="${registryRef}">media pending</a></sub>`;
+}
+
+const MARKER_RE = /<!-- fig:([a-z0-9-]+) -->[\s\S]*?<!-- \/fig:\1 -->/gi;
+const unregisteredMarkers = new Set<string>();
+let filesRewritten = 0;
+
+for (const filePath of collectMarkdownFiles()) {
+  const source = fs.readFileSync(filePath, "utf8");
+  const relPath = toPosix(path.relative(ROOT, filePath));
+  const next = source.replace(MARKER_RE, (_full, rawId: string) => {
+    const id = rawId.toLowerCase();
+    const entry = figures.get(id);
+    if (entry) {
+      if (!entry.placements.includes(relPath)) entry.placements.push(relPath);
+    } else {
+      unregisteredMarkers.add(`${id} (${relPath})`);
+    }
+    return `<!-- fig:${id} -->\n${renderSlot(id, filePath)}\n<!-- /fig:${id} -->`;
+  });
+  if (next !== source) {
+    fs.writeFileSync(filePath, next);
+    filesRewritten += 1;
+  }
+}
+
+// ── 4. Rewrite the registry: audit table + per-figure Status lines ──────────
+const sorted = [...figures.values()].sort((a, b) =>
+  a.id.localeCompare(b.id, undefined, { numeric: true })
+);
+
+const auditRows = sorted.map((f) => {
+  const files = [f.media.inline, f.media.video].filter(Boolean) as string[];
+  const status = files.length > 0 ? "✅" : "⬜";
+  const fileCell = files.length > 0 ? files.map((n) => `\`${n}\``).join(" + ") : "—";
+  const placementCell = f.placements.length > 0 ? f.placements.join(", ") : "⚠ not placed";
+  return `| ${f.id} | ${f.title} | ${status} | ${fileCell} | ${placementCell} |`;
+});
+const auditTable = [
+  "| Fig | Title | Status | Media file | Appears in |",
+  "|---|---|---|---|---|",
+  ...auditRows,
+].join("\n");
+
+let registryNext = registrySource;
+const auditStart = registryNext.indexOf(AUDIT_START);
+const auditEnd = registryNext.indexOf(AUDIT_END);
+if (auditStart === -1 || auditEnd === -1 || auditEnd < auditStart) {
+  fail(`Registry is missing the ${AUDIT_START} / ${AUDIT_END} markers.`);
+}
+registryNext =
+  registryNext.slice(0, auditStart + AUDIT_START.length) +
+  "\n" +
+  auditTable +
+  "\n" +
+  registryNext.slice(auditEnd);
+
+for (const f of sorted) {
+  const files = [f.media.inline, f.media.video].filter(Boolean) as string[];
+  const statusLine =
+    files.length > 0
+      ? `- **Status:** ✅ present — ${files.map((n) => `\`${n}\``).join(" + ")}`
+      : `- **Status:** ⬜ awaiting media`;
+  // Replace the first Status line inside this figure's section only.
+  const sectionRe = new RegExp(
+    `(## Fig ${f.id} — [^\\n]+\\n(?:(?!## Fig )[\\s\\S])*?)- \\*\\*Status:\\*\\*[^\\n]*`,
+    "i"
+  );
+  registryNext = registryNext.replace(sectionRe, `$1${statusLine}`);
+}
+
+if (registryNext !== registrySource) {
+  fs.writeFileSync(REGISTRY_PATH, registryNext);
+  filesRewritten += 1;
+}
+
+// ── 5. Report ────────────────────────────────────────────────────────────────
+const present = sorted.filter((f) => f.media.inline || f.media.video);
+const unplaced = sorted.filter((f) => f.placements.length === 0);
+console.log(
+  `Figures: ${sorted.length} registered · ${present.length} with media · ${
+    sorted.length - present.length
+  } awaiting media · ${filesRewritten} file(s) rewritten`
+);
+if (unplaced.length > 0) {
+  console.warn(`⚠ Registered but not placed in any surface: ${unplaced.map((f) => f.id).join(", ")}`);
+}
+if (orphanFiles.length > 0) {
+  console.warn(`⚠ Media files with no registry entry: ${orphanFiles.join(", ")}`);
+}
+if (unregisteredMarkers.size > 0) {
+  console.warn(`⚠ Markers with no registry entry: ${[...unregisteredMarkers].join("; ")}`);
+}


### PR DESCRIPTION
Developer-presence showcase: makes the public repo legible to recruiters as AI Automation Engineer evidence in <90 seconds. Plan of record: `docs/notes-feature/work-tracking/DEVELOPER-PRESENCE-PLAN.md`. All feature claims verified against `origin/main`; everything unshipped is labeled 🔭.

## Sprint 1 — Showcase legibility

- **README rewritten AI-first**: "AI & Agentic Systems" competency table (11 capabilities → code links), 2 Mermaid diagrams (AI request lifecycle, system topology), feature tour, accurate quickstart (port 3015, Docker PG, `dev:collab`, heap note), honest 🔭-labeled roadmap.
- **Figure signal system**: `docs/media/figures/FIGURES.md` = audit registry + capture briefs for 14 figures; `pnpm showcase:figures` (new `scripts/sync-showcase-figures.ts`) fills `<!-- fig:id -->` slots from files named `fig-<id>.<ext>`. Missing media renders a one-line pending caption — never a broken placeholder. Drop a file, run the script, it embeds everywhere.
- **`/demo` page** (`app/(public)/demo/` + `components/personal/DemoPage.tsx`): "demo reel is still growing" placeholder + custom-demo CTA → `/contact`; reuses `gc-*` classes + `PersonalHeader`, zero new CSS. Linked from README — must never 404.
- **Maintenance layer**: `docs/notes-feature/guides/showcase/SHOWCASE-MAINTENANCE.md` (update ritual, honesty rule, standing decisions) + `/update-showcase` Claude skill (`.claude/skills/`).
- **Lint-gate repair**: added `.codex/worktrees/**` to `eslint.config.mjs` globalIgnores — an unignored Codex CLI worktree copy (~92k TS files) made `pnpm lint` report 111k phantom problems in any checkout containing it.
- GitHub metadata already applied via `gh repo edit` (AI-first description, homepage → davidvalentine.org, 12 topics).
- **Gate:** typecheck ✅ · lint ✅ 151/159 warnings, 0 errors · figure sync idempotent (re-run rewrites 0 files)

## Sprint 2 — Inventory, deployment truth, MCP design of record

- **`docs/FEATURES.md`**: full inventory (~70 features, 10 domains) with ✅/🚧/🔭 status + code entry points; ContentNode ERD + workflow-spoke Mermaid diagrams inline; carries 5 figure slots.
- **`docs/DEPLOYMENT.md`**: honest 3-service topology (Vercel / Cloud Run Hocuspocus / self-hosted n8n), env reference grouped by concern, migration-baseline `resolve --applied` caveat, Hocuspocus redeploy rules, post-deploy verification checklist.
- **`.env.example` created** (+ `.gitignore` whitelist): the README's `cp .env.example .env.local` instruction has been broken since April — the file never existed. Built from a `process.env` scan of `origin/main`, grouped required → optional, no secrets.
- **`docs/notes-feature/work-tracking/MCP-PLAN.md`** 🔭: design of record for MCP server + client. Server: tools/resources/playbooks-as-prompts over Streamable HTTP (`mcp-handler` at a Next.js route), PAT → OAuth 2.1 auth ladder, capability+subtree-scoped tokens, M1 = read-only slice demoable from Claude Desktop. Client: AI SDK MCP client with per-server namespacing, allowlists, and prompt-injection defenses. Threat model included. No implementation in this PR.
- **Gate:** markdown + env template only (no runtime code); all doc links verified against the `origin/main` tree

## Pre-merge checklist

**Gates**
- [x] CI `quality.yml` green (lint ratchet + typecheck)
- [x] No migrations in this PR — `migration-drift` unaffected (docs/config/one page component only)

**Smoke tests**
- [x] README renders on GitHub: both Mermaid diagrams draw, 14 "media pending" captions show small (no broken images), competency-table links resolve
- [x] `docs/FEATURES.md` on GitHub: ERD + workflow diagrams render, links resolve
- [x] `/demo` in browser (light + dark): placeholder frame + play sigil render, "Request a custom demo" → `/contact`, back-link → `/`
- [x] `pnpm showcase:figures` runs clean on this branch (expect: 14 registered, 0 with media)
- [x] `cp .env.example .env.local` works on a fresh clone path

**Owner decisions**
- [x] License choice still open — README currently says "all rights reserved for now" (can land post-merge)

**Post-merge**
- [x] Discard the duplicate uncommitted showcase files from the `feat/tone-system-and-extension-tts` checkout (this PR supersedes them)
- [ ] When capturing figures later: drop `fig-<id>.<ext>` into `docs/media/figures/`, run `pnpm showcase:figures`, commit (S3 of the plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
