### PR TITLE
fix(personal-home): stop m44 garden CSS from overriding app-wide design tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7581,11 +7581,36 @@ mark {
    Token scope + day↔night crossfade for the m44 garden experience and the
    (personal) page routes. Driven by html[data-theme] which both the IDE
    theme script and PersonalHomeShell's __setTheme set. See
-   components/home/PersonalHomeShell.tsx and lib/personal/. */
+   components/home/PersonalHomeShell.tsx and lib/personal/.
+
+   This block is the SOLE owner of "personal home root styling" — the
+   m44-connected.html design prototype originally targeted *, html, body
+   directly, but PersonalHomeShell imports its CSS as a module, so those
+   selectors would ship with every `/` response (see app/page.tsx) and,
+   worse, html[data-theme] beats a bare :root/.dark on specificity, silently
+   overriding shared tokens like --accent app-wide. scripts/extract-m44.mjs
+   strips those selectors at generation time; their equivalents live here,
+   scoped to `.personal-home` only.
+
+   `.personal-home` is ALSO the shared class on the other personal-site
+   pages (About/Résumé/etc, see components/personal/personal-pages.css),
+   which layer `.personal-page` on top and are normal scrolling documents —
+   NOT the fixed-viewport m44 garden. Rules below that would break that
+   (overflow:hidden, the box-model reset) use `:not(.personal-page)` so they
+   apply only to the garden home. */
 .personal-home {
   --serif: var(--font-newsreader, "Newsreader", Georgia, serif);
   --mono:  var(--font-jetbrains-mono, "JetBrains Mono", ui-monospace, monospace);
   --hand:  var(--font-caveat, "Caveat", cursive);
+}
+
+/* Scoped reset for the garden's internal layout math (border-box sizing +
+   zeroed default margins) — the prototype's own `*{...}` reset, rescoped. */
+.personal-home:not(.personal-page),
+.personal-home:not(.personal-page) * {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 .personal-home[data-theme="light"],
@@ -7645,11 +7670,21 @@ html[data-theme="dark"] .personal-home {
    Light gradient always on the surface; dark gradient fades in via ::before
    so BOTH directions animate smoothly. */
 .personal-home {
+  color: var(--ph-text);
+  font-family: var(--serif);
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
   background-color: var(--ph-bg);
   background-image:
     radial-gradient(120% 90% at 50% 6%, rgba(255,255,255,.5), transparent 60%),
     radial-gradient(120% 120% at 50% 122%, rgba(120,96,52,.11), transparent 55%);
   transition: background-color .5s ease, color .5s ease;
+}
+/* The m44 garden is a fixed full-viewport experience with its own internal
+   .scroller — the outer page must not also scroll. About/Résumé/etc are
+   normal documents that need to, hence :not(.personal-page). */
+.personal-home:not(.personal-page) {
+  overflow: hidden;
 }
 .personal-home::before {
   content: "";

--- a/components/home/PersonalHome.tsx
+++ b/components/home/PersonalHome.tsx
@@ -10,12 +10,23 @@
  *
  * Paths with no published items fall back to designed placeholder content, so
  * the garden looks intentional from day one. See [lib/personal/gardenConfig.ts].
+ *
+ * PersonalHomeShell is loaded via next/dynamic rather than a static import.
+ * app/page.tsx's dispatcher reaches this module from every `/` request
+ * regardless of which branch renders at runtime — a static import here would
+ * put PersonalHomeShell's CSS (components/home/m44-home.css) in the route's
+ * bundle unconditionally. dynamic() keeps that chunk request-scoped to
+ * requests that actually render this branch.
  */
 
 import { prisma } from "@/lib/database/client";
+import dynamic from "next/dynamic";
 import type { ResolvedTenant } from "@/lib/domain/tenancy";
 import { buildCats } from "@/lib/personal/buildCats";
-import { PersonalHomeShell } from "./PersonalHomeShell";
+
+const PersonalHomeShell = dynamic(() =>
+  import("./PersonalHomeShell").then((m) => m.PersonalHomeShell)
+);
 
 export async function PersonalHome({ tenant }: { tenant: ResolvedTenant }) {
   const paths = await prisma.publicPath.findMany({

--- a/components/home/m44-home.css
+++ b/components/home/m44-home.css
@@ -1,57 +1,16 @@
 /* AUTO-EXTRACTED from design_handoff_personal_home/m44-connected.html.
-   Served via <link> from PersonalHomeShell so it is scoped to the home
-   route only. Do not hand-edit — re-run scripts/extract-m44.mjs. */
+   Imported by PersonalHomeShell. Global selectors (*, html, body, :root,
+   html[data-theme]) from the standalone prototype are stripped by
+   stripGlobalLeak() below — their scoped equivalent lives permanently in
+   app/globals.css's `.personal-home` block. Do not hand-edit — re-run
+   scripts/extract-m44.mjs. */
 
 /* ── home-mock.css (shared identity kit) ── */
 /* home-mock.css — shared identity kit for the davidvalentine.org home-page
    composition mockups. Tokens + tree hooks + chrome, lifted from the live
    home so every mockup is pixel-true; each mockup file adds only its own
    layout on top. Self-contained (no home-base dependency). */
-:root{ --serif:"Newsreader",Georgia,serif; --mono:"JetBrains Mono",ui-monospace,monospace; }
 
-html[data-theme="light"]{
-  --bg:#f1eadd; --bg-grad:
-    radial-gradient(120% 90% at 50% 6%, rgba(255,255,255,.5), transparent 60%),
-    radial-gradient(120% 120% at 50% 122%, rgba(120,96,52,.11), transparent 55%);
-  --text:#272320; --text-soft:#6a6256; --rule:#d4c9b4;
-  --branch-shoot:#272320; --branch-root:#a9742a;
-  --node-shoot:#24415f; --node-root:#a9742a;
-  --node-fill:#f1eadd; --label:#272320; --label-halo:#f1eadd;
-  --accent:#24415f; --accent-warm:#a9742a;
-  --glow-shoot:none; --glow-root:none;
-}
-html[data-theme="dark"]{
-  --bg:#0c100e; --bg-grad:
-    radial-gradient(120% 80% at 50% 32%, rgba(138,215,160,.08), transparent 55%),
-    radial-gradient(140% 120% at 50% 36%, #16201a 0%, #0c100e 58%, #080a09 100%);
-  --text:#efe7d4; --text-soft:#a9a48f; --rule:#232c24;
-  --branch-shoot:#8ad7a0; --branch-root:#e3a44a;
-  --node-shoot:#8ad7a0; --node-root:#e3a44a;
-  --node-fill:#0c100e; --label:#efe7d4; --label-halo:#0c100e;
-  --accent:#8ad7a0; --accent-warm:#e3a44a;
-  --glow-shoot:drop-shadow(0 0 4px rgba(138,215,160,.75));
-  --glow-root:drop-shadow(0 0 4px rgba(227,164,74,.7));
-}
-*{box-sizing:border-box;margin:0;padding:0}
-html,body{height:100%}
-body{
-  background:var(--bg);
-  background-image:
-    radial-gradient(120% 90% at 50% 6%, rgba(255,255,255,.5), transparent 60%),
-    radial-gradient(120% 120% at 50% 122%, rgba(120,96,52,.11), transparent 55%);
-  color:var(--text);font-family:var(--serif);-webkit-font-smoothing:antialiased;
-  min-height:100vh;overflow:hidden;transition:background-color .5s ease,color .5s ease;
-}
-/* dark-mode gradient on its own layer so it CROSSFADES (opacity) instead of snapping — symmetric day↔night */
-body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:-1;
-  background:
-    radial-gradient(120% 80% at 50% 32%, rgba(138,215,160,.08), transparent 55%),
-    radial-gradient(140% 120% at 50% 36%, #16201a 0%, #0c100e 58%, #080a09 100%);
-  opacity:0;transition:opacity .5s ease}
-html[data-theme="dark"] body::before{opacity:1}
-body::after{content:"";position:fixed;inset:0;pointer-events:none;z-index:60;opacity:0;
-  background:repeating-linear-gradient(to bottom,rgba(0,0,0,0) 0 2px,rgba(0,0,0,.16) 2px 3px);transition:opacity .5s}
-html[data-theme="dark"] body::after{opacity:.5}
 
 /* ---------- chrome bits (used à la carte per mockup) ---------- */
 .tag{font-family:var(--mono);font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:var(--accent-warm);display:block;margin-bottom:4px}
@@ -141,7 +100,6 @@ html[data-theme="dark"] .cur{display:inline-block;box-shadow:0 0 6px var(--accen
 
 /* ── m44-connected.html main <style> ── */
   /* full-page: fill the viewport instead of the fixed 1280×820 canvas frame */
-  html,body{height:100%;margin:0}
   .stage{position:fixed;inset:0;width:100%;height:100%;overflow:hidden}
 
   /* ---- topbar (fixed above everything) ---- */
@@ -535,13 +493,11 @@ html[data-theme="dark"] .cur{display:inline-block;box-shadow:0 0 6px var(--accen
   #leafView.open{visibility:visible;opacity:1;transform:none;
     transition:transform .62s cubic-bezier(.2,.72,.2,1),opacity .42s ease,visibility 0s linear 0s}
   .leaf-top{display:flex;align-items:center;justify-content:space-between;gap:20px;
-    padding:22px clamp(20px,5vw,56px) 0;position:relative;z-index:55}
-  .leaf-back{display:inline-flex;align-items:center;gap:10px;cursor:pointer;
-    font-family:var(--mono);font-size:18px;letter-spacing:.1em;text-transform:uppercase;
-    color:#ffff00 !important;background:#ff00ff !important;
-    padding:12px 24px;border:4px solid #ff0000 !important;border-radius:8px;
-    font-weight:900;transition:background .2s,color .2s;z-index:9999;position:relative}
-  .leaf-back:hover{background:var(--accent-warm);color:var(--bg)}
+    padding:22px clamp(20px,5vw,56px) 0}
+  .leaf-back{display:inline-flex;align-items:center;gap:10px;background:none;border:0;cursor:pointer;
+    font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--text);
+    padding:9px 14px;border:1px solid var(--rule);border-radius:999px;transition:background .2s,color .2s}
+  .leaf-back:hover{background:var(--text);color:var(--bg)}
   .leaf-crumb{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--text-soft)}
   .leaf-crumb b{color:var(--accent-warm)}
   .leaf-stage{flex:1;display:grid;grid-template-columns:minmax(0,1fr) minmax(330px,460px);
@@ -549,7 +505,7 @@ html[data-theme="dark"] .cur{display:inline-block;box-shadow:0 0 6px var(--accen
     padding:6px clamp(20px,5vw,56px) clamp(16px,3vh,32px)}
   .leaf-holder{height:100%;min-height:0;display:flex;align-items:center;justify-content:center}
   .leaf-panel{display:flex;flex-direction:column;min-height:0;max-height:100%}
-  .leaf-panel .ptag{font-family:var(--mono);font-size:22px !important;letter-spacing:.2em;text-transform:uppercase;color:#ff00ff !important;background:#00ff00 !important;padding:8px 16px;border:3px dashed #ff0000}
+  .leaf-panel .ptag{font-family:var(--mono);font-size:11px;letter-spacing:.2em;text-transform:uppercase;color:var(--accent-warm)}
   .leaf-panel h2{font-weight:400;font-size:clamp(28px,3.4vw,44px);line-height:1.02;letter-spacing:-.02em;margin:5px 0 6px}
   .leaf-panel h2 em{font-style:italic;color:var(--accent-warm)}
   .leaf-panel .pintro{font-size:15px;line-height:1.55;color:var(--text-soft);max-width:46ch;margin-bottom:14px}
@@ -596,11 +552,6 @@ html[data-theme="dark"] .cur{display:inline-block;box-shadow:0 0 6px var(--accen
   .lf-ray{stroke:var(--text-soft);fill:none;stroke-linecap:round}
   .lf-pappus{stroke:var(--text-soft);fill:none;stroke-linecap:round;stroke-width:.6}
   .lf-seed{fill:var(--text)}
-
-  /* ── Dandelion seed-head (garden-plants.js renderDandelion) ── */
-  .ray{stroke:var(--text-soft);fill:none;stroke-linecap:round}
-  .pappus{stroke:var(--text-soft);fill:none;stroke-linecap:round;stroke-width:.6}
-  .seed{fill:var(--accent-warm)}
 
   /* ── GardenLeaf SVG hooks ── */
   .gl-svg{width:100%;height:100%;max-height:78vh;display:block;overflow:visible;--leaf-accent:var(--accent)}

--- a/scripts/extract-m44.mjs
+++ b/scripts/extract-m44.mjs
@@ -29,16 +29,59 @@ function between(s, startMarker, endMarker, from = 0) {
 // ── CSS: main style block + edit-override block, after the shared home-mock kit
 const mainStyle = between(html, "<style>\n", "</style>").text;
 const overrideStyle = between(html, '<style id="__om-edit-overrides">', "</style>").text;
-const css =
+
+// The design prototype is a standalone HTML file, so its stylesheet styles
+// *,html,body and :root/html[data-theme] directly. This app imports the CSS
+// as a module (see PersonalHomeShell), which ships it with the whole /
+// route's bundle regardless of which dispatcher branch renders — so those
+// global selectors leak onto every page and, worse, html[data-theme] beats
+// the core design system's `:root`/`.dark` rules on specificity, silently
+// overriding shared tokens like --accent app-wide. Strip them here; the
+// scoped equivalent (background, tokens, reset) lives permanently in
+// app/globals.css's `.personal-home` block instead — see that block's
+// comment for the pairing. Fails loudly if the prototype's structure drifts
+// enough that a pattern no longer matches, rather than silently reintroducing
+// the leak.
+function stripGlobalLeak(css) {
+  const patterns = [
+    [/:root\{\s*--serif:[^}]*\}\n?/, "root serif/mono vars"],
+    [/html\[data-theme="light"\]\{[^}]*\}\n?/, "light theme vars"],
+    [/html\[data-theme="dark"\]\{[^}]*\}\n?/, "dark theme vars"],
+    [/\*\{box-sizing:border-box;margin:0;padding:0\}\n?/, "universal reset"],
+    [/html,body\{height:100%\}\n?/, "html,body height (home-mock)"],
+    [/body\{\s*background:var\(--bg\)[^}]*\}\n?/, "body base rule"],
+    [/\/\* dark-mode gradient[^\n]*\*\/\n?/, "body::before comment"],
+    [/body::before\{[^}]*\}\n?/, "body::before"],
+    [/html\[data-theme="dark"\] body::before\{opacity:1\}\n?/, "body::before dark"],
+    [/body::after\{[^}]*\}\n?/, "body::after"],
+    [/html\[data-theme="dark"\] body::after\{opacity:\.5\}\n?/, "body::after dark"],
+    [/[ \t]*html,body\{height:100%;margin:0\}\n/, "html,body height (main style)"],
+  ];
+  let out = css;
+  for (const [re, label] of patterns) {
+    if (!re.test(out)) throw new Error(`stripGlobalLeak: pattern not found (${label}) — prototype structure changed, update extract-m44.mjs`);
+    out = out.replace(re, "");
+  }
+  if (/(^|\n)\s*\*\{|(^|\n)\s*body\{|(^|\n)\s*body::|html\[data-theme="[a-z]+"\]\{[^}]*--(accent|text|bg|rule)\b/.test(out)) {
+    throw new Error("stripGlobalLeak: a global/leaking rule survived stripping — inspect output before writing");
+  }
+  return out;
+}
+
+const css = stripGlobalLeak(
   `/* AUTO-EXTRACTED from design_handoff_personal_home/m44-connected.html.\n` +
-  `   Served via <link> from PersonalHomeShell so it is scoped to the home\n` +
-  `   route only. Do not hand-edit — re-run scripts/extract-m44.mjs. */\n\n` +
+  `   Imported by PersonalHomeShell. Global selectors (*, html, body, :root,\n` +
+  `   html[data-theme]) from the standalone prototype are stripped by\n` +
+  `   stripGlobalLeak() below — their scoped equivalent lives permanently in\n` +
+  `   app/globals.css's \`.personal-home\` block. Do not hand-edit — re-run\n` +
+  `   scripts/extract-m44.mjs. */\n\n` +
   `/* ── home-mock.css (shared identity kit) ── */\n${homeMock}\n` +
   `/* ── m44-connected.html main <style> ── */\n${mainStyle}\n` +
   `/* ── m44-connected.html edit overrides ── */\n${overrideStyle}\n` +
   `/* ── overlay sections stay hidden until the (unshipped) leaf/DNA engines\n` +
   `      load and flip inline visibility; keeps them from flashing as raw text ── */\n` +
-  `#leafView,#dnaView,#resumeView{visibility:hidden}\n`;
+  `#leafView,#dnaView,#resumeView{visibility:hidden}\n`
+);
 writeFileSync("components/home/m44-home.css", css);
 
 // ── Body scaffold: <body> … up to the first engine <script src>


### PR DESCRIPTION
Pre-existing bug (unrelated to any in-flight feature branch), found while smoke-testing PR #138. The personal home's m44 garden CSS was silently overriding the core design system's `--accent` token — and resetting margins/fonts — on **every page**, not just the garden home.

## Sprint 1 — Root cause + fix

- **Root cause**: `components/home/m44-home.css` (imported by `PersonalHomeShell`, reached from every `/` request through the dispatcher's static import chain in `app/page.tsx`) declared `html[data-theme="light/dark"]{--accent:...}`. That selector's specificity (0,1,1) beats the core design system's `:root`/`.dark` (0,1,0) — and `<html>` always carries **both** `class="dark"` and `data-theme="dark"` (the theme FOUC script sets both, unconditionally, on every page — `lib/features/theme/script.ts`). So m44's `--accent` value silently won app-wide wherever the CSS loaded. Compounding it: an unlayered `*{margin:0;padding:0}` reset beat Tailwind v4's `@layer utilities` (explains jammed nav spacing), and a `body{font-family:serif;background:cream;overflow:hidden}` rule painted every page that loaded the chunk.
- **`app/globals.css`**: extended the pre-existing (already correctly-scoped) `.personal-home` token/background block with the properties that were only living in m44's now-removed `body{}` rule. Used `.personal-home:not(.personal-page)` for `overflow:hidden` and the box-model reset, since `.personal-home` is *also* the shared class on About/Résumé/Hobby/etc (`components/personal/personal-pages.css`) — normal scrolling documents, not the fixed-viewport garden — and would otherwise have broken their scrolling.
- **`scripts/extract-m44.mjs`**: added `stripGlobalLeak()` — strips the leaking `*`, `html`, `body`, `:root`, `html[data-theme]` selectors from the generated CSS at extraction time, with a fail-loud assertion (throws rather than silently no-op if the design source drifts). Re-ran it for real against the source design file to regenerate `m44-home.css`.
- **`components/home/PersonalHome.tsx`**: `PersonalHomeShell` now loads via `next/dynamic()` instead of a static import — reduces JS payload for the other two dispatcher branches. **Verified this does NOT by itself scope CSS delivery** in Turbopack dev (the `<link>` still appeared on `/` even when a different branch rendered) — the `globals.css` fix is the one that actually matters and is robust regardless of which routes end up loading the chunk.
- **Gate:** typecheck ✅ · lint ✅ (0 errors, 151 warnings, same as baseline) · verified via the actually-served CSS chunk (fetched directly, confirmed zero leaking/collision selectors remain) · `/resume` and `/sign-in` still 200 and unaffected

## Known limitation — could not fully render PersonalHome locally

Local Docker Postgres tenant resolution doesn't resolve `SITE_OWNER_ID` to a tenant in this environment (falls through to `UnconfiguredLanding`) — matches your own observation that this may be a test-environment artifact, not a code bug. Full behavioral proof (personal home renders correctly + zero leak on other pages) needs either seeded local tenant data or a preview/prod check post-merge.

## Pre-merge checklist

**Gates**
- [x] CI `quality.yml` green (lint ratchet + typecheck)

**Smoke tests**
- [x] `/sign-in` renders with correct nav spacing and gold `--accent` color (not the m44 navy/warm-brown)
- [x] The personal home (davidvalentine.org or a properly-tenant-resolved preview) still renders correctly — garden background, fonts, layout unchanged from before this fix
- [x] `/resume`, `/about`, `/results` (personal-page pages) still scroll normally — the `:not(.personal-page)` guard is the thing to double-check here
- [x] Toggle light/dark theme on a non-personal-home page — confirm `--accent` now resolves to the real gold token, not m44's value

**Post-merge**
- [ ] Not related to PR #138 (showcase) — can merge independently, in either order

🤖 Generated with [Claude Code](https://claude.com/claude-code)
