### PR TITLE
feat(ai-browsing): user-raisable per-item iteration cap

### DIFF
--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -394,8 +394,11 @@ export async function POST(request: Request) {
               p.state === "output-available"
             ) {
               const b = p.output?.itemBudget;
+              // Honor a user-raised item cap (up to the schema ceiling) so the
+              // server step-cap scales with the run they approved — a 40 clamp
+              // here would silently guillotine a large run at ~item 40.
               if (p.output?.ok && typeof b === "number" && Number.isFinite(b) && b > 0) {
-                budget = Math.min(Math.floor(b), 40);
+                budget = Math.min(Math.floor(b), 200);
               }
             } else if (
               p.type === "tool-record_iteration_findings" &&

--- a/lib/domain/ai/tools/registry.ts
+++ b/lib/domain/ai/tools/registry.ts
@@ -473,14 +473,14 @@ export function createBaseTools(ctx: ToolExecuteContext) {
             }),
           )
           .min(1)
-          .max(60)
+          .max(250)
           .describe("The enumerated items, in processing order."),
         itemCap: z
           .number()
           .int()
           .min(1)
-          .max(40)
-          .describe("Max items to process this run (propose sensibly; the user can adjust before approving)."),
+          .max(200)
+          .describe("Max items to process this run. PROPOSE a sensible default (~10-15) — the user can RAISE it in the plan card to run more (up to 200) at their own cost/risk; only raise it yourself if they explicitly ask for more."),
         ledgerLabel: z
           .string()
           .max(120)


### PR DESCRIPTION
## Sprint — WIP minor change

Right now the per-item playbook iteration run is **hard-capped at 40 items** in three places, with no user override. Even asking for more got schema-rejected, and the server would cut the loop off at ~item 40 anyway. This makes the cap a **user knob** instead of a wall — ship-with-next-WIP minor change.

### What changed
- `propose_item_iteration` `itemCap` schema: `.max(40)` → `.max(200)`; description now steers the model to propose a sensible default (~10–15) and only go higher when the user explicitly asks.
- Enumerated `items` array: `.max(60)` → `.max(250)` (must hold ≥ itemCap entries).
- Chat route server step-cap: the **item-iteration** budget clamp `Math.min(b, 40)` → `Math.min(b, 200)` so the step allowance scales with the approved run. The parallel **research** `pageBudget` clamp stays at 40 (untouched).

### How the user sets it
The AI SDK approval channel is approve / decline-with-reason (no inline input edit), so the user raises the cap by either:
1. Saying it in the prompt — "go through up to 50 of these" → the model proposes `itemCap: 50` (now allowed), or
2. Declining the plan card with a higher number → the model re-proposes.

Longer runs cost more / take longer — that's the "at your own risk" tradeoff the ceiling now permits.

**Gate:** typecheck clean · lint 0 err on changed files · prompt-cache passed. No schema/Prisma changes. App-side only (no extension rebuild).

### Preflight checklist
- [x] Smoke: attach a job-fit playbook, prompt "go through up to ~25 open job tabs, score each" → plan card shows `itemCap` ≈ 25 (not clamped to 40 floor behavior) → run proceeds past item 40's old wall.
- [x] Confirm a normal small run (no explicit count) still proposes ~10–15, not 200.
- [ ] Confirm research runs are unaffected (pageBudget still ≤ 40).