### PR TITLE
feat(ai-chat): auto-resume a dropped stream — network drops no longer fatal

### DIFF
--- a/lib/domain/ai/use-conversation-engine.ts
+++ b/lib/domain/ai/use-conversation-engine.ts
@@ -214,6 +214,50 @@ const chatBodyResolvers = new Map<string, () => Record<string, unknown>>();
  */
 const lastSentBodies = new Map<string, Record<string, unknown>>();
 
+/**
+ * Network-resilience knobs for auto-resuming a dropped stream (AI 3.3+).
+ *
+ * A transient client-side fetch failure (network blip, connection reset, a
+ * serverless response cut) is NOT fatal when resumable streams are configured:
+ * the server keeps producing into Redis via `result.consumeStream()`, decoupled
+ * from the client socket, so the client can reconnect with `resumeStream()` and
+ * continue receiving the SAME stream. Before this, that drop fired `onError` →
+ * a fatal toast, ending the run mid-iteration. These constants bound the retry
+ * so a genuinely-dead stream still surfaces an error instead of spinning
+ * forever. Backoff: 0.8s, 1.6s, 3.2s, 6.4s; each attempt watches ~2s for the
+ * stream to go active before giving up on that attempt.
+ */
+const MAX_RECONNECT_ATTEMPTS = 4;
+const RECONNECT_BACKOFF_MS = 800;
+const RECOVERY_POLL_MS = 400;
+const RECOVERY_POLL_COUNT = 5;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * True only for the browser's transient network-failure TypeErrors — the class
+ * of error a stream resume can actually recover. Deliberately narrow: a real
+ * HTTP error (auth, provider, a 500 with a body) is NOT transient and must
+ * surface immediately rather than spin the reconnect loop. The message text
+ * varies by engine — Chrome "Failed to fetch", Safari "Load failed" / "network
+ * connection was lost", Firefox "NetworkError when attempting to fetch".
+ */
+function isTransientNetworkError(err: unknown): boolean {
+  const message = (
+    err instanceof Error ? err.message : String(err ?? "")
+  ).toLowerCase();
+  return (
+    message.includes("failed to fetch") ||
+    message.includes("load failed") ||
+    message.includes("network connection was lost") ||
+    message.includes("networkerror") ||
+    message.includes("network request failed")
+  );
+}
+
 const chatTransport = new DefaultChatTransport({
   api: "/api/ai/chat",
   prepareSendMessagesRequest: ({ id, messages, trigger, messageId, body }) => {
@@ -1191,6 +1235,59 @@ export function useConversationEngine({
     null,
   );
 
+  // ── network resilience (AI 3.3): auto-resume a dropped stream ──
+  // A transient network drop mid-stream would otherwise reach onError and
+  // toast fatally, ending the run. When the chat is conversation-bound AND
+  // resumable streams are configured, the server is still producing into
+  // Redis, so we reconnect (resumeStream) with bounded backoff and surface an
+  // error only if every attempt fails. Refs — not state — so the useChat
+  // onError closure and the async loop read live values off-render (no
+  // re-subscription, no stale capture). Populated by a sync effect below.
+  const resumeStreamRef = useRef<null | (() => Promise<void> | void)>(null);
+  const streamStatusRef = useRef<string>("ready");
+  const resumableEnabledRef = useRef<boolean>(true);
+  const conversationIdRef = useRef<string | null>(null);
+  const reconnectingRef = useRef<boolean>(false);
+  // Bumped by every fresh user send so an in-flight reconnect loop bails —
+  // otherwise its poll would read the NEW stream's "submitted" as a recovery.
+  const reconnectGenRef = useRef<number>(0);
+  const reconnectToastIdRef = useRef<string | number | null>(null);
+
+  const runReconnectLoop = useCallback(async () => {
+    const gen = reconnectGenRef.current;
+    for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+      reconnectToastIdRef.current = toast.loading(
+        `Connection interrupted — reconnecting (${attempt}/${MAX_RECONNECT_ATTEMPTS})…`,
+        reconnectToastIdRef.current != null
+          ? { id: reconnectToastIdRef.current }
+          : undefined,
+      );
+      await sleep(RECONNECT_BACKOFF_MS * 2 ** (attempt - 1));
+      if (reconnectGenRef.current !== gen) return; // superseded by a fresh send
+      // Reconnect to the server's buffered stream. Fire-and-forget: the safe
+      // reconnect URL (conversationId-bound) is built by the transport's
+      // prepareReconnectToStreamRequest; we detect success by polling status.
+      void resumeStreamRef.current?.();
+      for (let poll = 0; poll < RECOVERY_POLL_COUNT; poll++) {
+        await sleep(RECOVERY_POLL_MS);
+        if (reconnectGenRef.current !== gen) return;
+        const s = streamStatusRef.current;
+        if (s === "streaming" || s === "submitted") {
+          toast.success("Reconnected.", {
+            id: reconnectToastIdRef.current ?? undefined,
+          });
+          reconnectToastIdRef.current = null;
+          return;
+        }
+      }
+    }
+    toast.error(
+      "Connection lost — the response couldn't be restored. Send your message again to continue.",
+      { id: reconnectToastIdRef.current ?? undefined },
+    );
+    reconnectToastIdRef.current = null;
+  }, []);
+
   // ── useChat ──
   const chat = useChat({
     transport: chatTransport,
@@ -1581,7 +1678,26 @@ export function useConversationEngine({
     onError: (err) => {
       if (onError) {
         onError(err);
-      } else {
+        return;
+      }
+      // Network resilience: a transient drop on a resumable, conversation-bound
+      // chat is recoverable — reconnect to the server's buffered stream instead
+      // of failing. Non-transient errors (auth, provider, server) and
+      // unbound/transient chats surface immediately, as before.
+      if (
+        isTransientNetworkError(err) &&
+        resumableEnabledRef.current &&
+        conversationIdRef.current &&
+        !reconnectingRef.current
+      ) {
+        reconnectingRef.current = true;
+        void runReconnectLoop().finally(() => {
+          reconnectingRef.current = false;
+        });
+        return;
+      }
+      // Don't stomp an in-flight reconnect's own toast with a duplicate.
+      if (!reconnectingRef.current) {
         toast.error(err.message || "Chat request failed");
       }
     },
@@ -1838,6 +1954,16 @@ export function useConversationEngine({
     resumeStream,
   ]);
 
+  // Keep the network-resilience refs current for the onError closure + the
+  // reconnect loop, which read them off-render. A no-dep effect (pure ref
+  // writes) is the compiler-safe way to mirror live values into refs.
+  useEffect(() => {
+    streamStatusRef.current = status;
+    resumeStreamRef.current = resumeStream;
+    resumableEnabledRef.current = resumableStreamsEnabled;
+    conversationIdRef.current = conversationId ?? null;
+  });
+
   const isActive = status === "streaming" || status === "submitted";
   const stop = useCallback(() => {
     // Settle synchronously for immediate visual feedback; the SDK's abort
@@ -2062,6 +2188,13 @@ export function useConversationEngine({
     // A fresh user send has no buffered backlog — clear the resume flag so
     // this turn types normally (and un-stick the no-stream 204 case).
     streamStartedViaResumeRef.current = false;
+    // Supersede any in-flight reconnect loop: this new stream's "submitted"
+    // status must not be mistaken for a recovery of the dropped one.
+    reconnectGenRef.current += 1;
+    if (reconnectToastIdRef.current != null) {
+      toast.dismiss(reconnectToastIdRef.current);
+      reconnectToastIdRef.current = null;
+    }
     // Agentic Browsing Phase 1 — a fresh user turn ends any prior research run
     // (backstop for a run the model never closed via record_research_findings),
     // so this turn's reads are never charged to a stale budget.


### PR DESCRIPTION
## Sprint — WIP resilience change

**Problem (observed on a production per-item run):** a transient network drop mid-stream surfaced a red **"Failed to fetch"** toast and *ended the run*, even though the item in flight had already been recorded to the ledger and the server was still generating the rest of the response into Redis.

**Root cause:** `useChat`'s `onError` toasted fatally. The `resumeStream()` reconnect existed but only fired **once on mount/reload** — never on a mid-run drop — so the server's buffered stream sat there unreconnected. Resumable streams decouple generation (`consumeStream()` → Redis) from the client socket, so the tokens were recoverable; nothing reached for them.

## What changed (`use-conversation-engine.ts`)
- `onError` now separates a **transient network TypeError** (`Failed to fetch` / `Load failed` / `NetworkError` / "connection lost") from a real error (auth, provider, 500-with-body). Only transient drops trigger recovery; real errors surface immediately, unchanged.
- A **bounded reconnect loop** calls `resumeStream()` with exponential backoff (0.8/1.6/3.2/6.4s), watching ~2s per attempt for the stream to go active. Reuses the transport's existing `conversationId`-bound `prepareReconnectToStreamRequest` bridge — so it does **not** reintroduce the naked-resume bug the turn-start body snapshots fixed.
- One updating toast: **"reconnecting (n/4)…" → "Reconnected."** on success, or a clear **"send your message again to continue"** only after all attempts fail.
- A fresh user send supersedes an in-flight loop (generation counter) so the new stream's `submitted` isn't mistaken for a recovery.
- Live values the off-render closure/loop need are mirrored into refs via a no-dep sync effect (compiler-safe).

## Graceful either way
- **Redis configured on prod** → silent recovery, run continues.
- **Redis absent** → `resumeStream()` gets a 204, the loop exhausts ~15s of retries, then a clean "send again" toast. Still strictly better than the old instant-fatal toast; the ledger already persisted every completed item.

**Gate:** typecheck clean · lint 0 err / 0 warn on the changed file. No schema/Prisma changes. App-side only (no extension rebuild).

## Companion step (env, not code)
Confirm the server can buffer — `isResumableConfigured()` needs `REDIS_URL` / `dg_REDIS_URL` set on prod (per AI 3.3 this was provisioned as `dg_`-prefixed Upstash). Verify with `vercel env ls production | grep -i redis`.

## Preflight checklist
- [ ] Start a long browser-iteration run; kill wifi briefly mid-stream → toast shows "reconnecting…", then "Reconnected." and the run continues (Redis path).
- [ ] Confirm a genuine error (e.g. invalid key) still toasts immediately — no reconnect spin.
- [ ] Confirm sending a new message during a reconnect window cancels the loop cleanly (no spurious "Reconnected").