### PR TITLE
Folder wiki-links + AI hyperlink authoring

### DIFF
--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -154,6 +154,7 @@ import { assembleFolderChatContext } from "@/extensions/studio/server/source-sel
 import { refreshContextOnAccess } from "@/lib/domain/ai-context/context-refresh";
 import { ensureFolderContextFresh } from "@/lib/domain/ai-context/gate";
 import { assembleFolderCapsule } from "@/lib/domain/ai-context/capsule";
+import { collectWikiLinkRefs } from "@/lib/domain/editor/wiki-link-refs";
 import {
   parsePlaybook,
   type PlaybookReference,
@@ -191,6 +192,62 @@ import {
 
 const ROUTE_PATH = "/api/ai/chat";
 
+/**
+ * Gate + capsule for ONE folder reference — a chat mention pill, a playbook
+ * [[link]], or a folder wiki-linked from a mentioned note — rendered as a
+ * prompt section per the D5 ladder (fresh capsule / stale capsule flagged /
+ * honest absence / name-only when opted out). Never throws.
+ */
+async function buildFolderMentionSection(
+  userId: string,
+  folderId: string,
+  title: string,
+  budgetMs?: number,
+): Promise<string> {
+  try {
+    const gate = await ensureFolderContextFresh(
+      userId,
+      folderId,
+      budgetMs ? { budgetMs } : undefined,
+    );
+    if (gate.status === "optedOut") {
+      return `### ${title}\n(folder — its AI context is disabled by the user; only the name is available)`;
+    }
+    const capsule =
+      gate.status === "none"
+        ? null
+        : await assembleFolderCapsule(userId, folderId);
+    if (!capsule) {
+      return `### ${title}\n(folder — no context is available yet: generation could not run${gate.reason ? ` (${gate.reason})` : ""}. Say so rather than guessing at its contents.)`;
+    }
+    const staleBanner =
+      gate.status === "stale"
+        ? `\n[NOTE: this folder's context could not be fully refreshed (${gate.reason ?? "budget"}) — parts may lag recent edits.]`
+        : "";
+    logger.info({
+      layer: "ai",
+      event: "ai_context:mention_gate",
+      summary: `folder mention gated: ${gate.status}`,
+      attrs: {
+        folderId,
+        status: gate.status,
+        generationCalls: gate.generationCalls,
+        refreshedNodes: gate.refreshedNodes,
+        waitedMs: gate.waitedMs,
+      },
+    });
+    return capsule.text + staleBanner;
+  } catch (gateError) {
+    logger.warn({
+      layer: "ai",
+      event: "ai_context:mention_gate_caught",
+      summary: "folder mention gate failed — name-only fallback",
+      error: gateError,
+    });
+    return `### ${title}\n(folder — context unavailable due to an internal error)`;
+  }
+}
+
 async function resolvePlaybookReferenceContext(
   userId: string,
   references: PlaybookReference[],
@@ -216,6 +273,7 @@ async function resolvePlaybookReferenceContext(
     select: {
       id: true,
       title: true,
+      contentType: true,
       notePayload: { select: { metadata: true } },
     },
   });
@@ -226,24 +284,57 @@ async function resolvePlaybookReferenceContext(
   const activeReferenceContentIds = Array.from(
     new Set(
       referenceNodes
-        .filter((node) => activeTitles.has(node.title))
+        // Folders are capsule-consumed (below), never getCurrentNote-read —
+        // keep them out of the checkpoint gate's reference expectations.
+        .filter(
+          (node) =>
+            activeTitles.has(node.title) && node.contentType !== "folder",
+        )
         .map((node) => node.id),
     ),
   );
   const lines = uniqueTitles.map((title) => {
     const found = byTitle.get(title);
     if (!found) return `- [[${title}]] — not found in your notes`;
+    if (found.contentType === "folder") {
+      // Folder refs behave like chat folder mentions (capsule-plan
+      // follow-up): active-phase folders get their capsule injected below;
+      // other phases' folders stay lazy behind the walk tool.
+      return activeTitles.has(title)
+        ? `- [[${title}]] — FOLDER (context capsule injected below)`
+        : `- [[${title}]] — FOLDER (call read_folder_context with folderId: ${found.id} when the current phase needs it)`;
+    }
     const isSubPlaybook = isPlaybookMetadata(found.notePayload?.metadata);
     return isSubPlaybook
       ? `- [[${title}]] (getCurrentNote contentId: ${found.id}) — SUB-PLAYBOOK: has its own standing rules/phases; follow its directives once read`
       : `- [[${title}]] (getCurrentNote contentId: ${found.id})`;
   });
 
+  // Active-phase folder refs get the full mention treatment (gate +
+  // capsule), capped so a link-heavy phase can't flood context. Same D5
+  // ladder and 3s budget as the walk tool.
+  const activeFolders = referenceNodes
+    .filter(
+      (node) => node.contentType === "folder" && activeTitles.has(node.title),
+    )
+    .slice(0, 3);
+  let folderCapsules = "";
+  if (activeFolders.length > 0) {
+    const sections = await Promise.all(
+      activeFolders.map((folder) =>
+        buildFolderMentionSection(userId, folder.id, folder.title, 3000),
+      ),
+    );
+    folderCapsules =
+      "\n\n**Referenced folder context:**\n\n" + sections.join("\n\n");
+  }
+
   return {
     manifest:
       "\n\n**Linked extensions** " +
       "(call getCurrentNote with the contentId below when the current phase needs one — not preloaded):\n" +
-      lines.join("\n"),
+      lines.join("\n") +
+      folderCapsules,
     activeReferenceContentIds,
   };
 }
@@ -1201,7 +1292,9 @@ export async function POST(request: Request) {
                 deletedAt: null,
               },
               include: {
-                notePayload: { select: { searchText: true } },
+                // tiptapJson rides along so folder wiki-links inside a
+                // mentioned note can get the capsule treatment below.
+                notePayload: { select: { searchText: true, tiptapJson: true } },
               },
             });
             span.attr("found", result.length).summary(`${result.length} mentions`);
@@ -1221,60 +1314,79 @@ export async function POST(request: Request) {
             mentionedNodes
               .filter((node) => node.contentType === "folder")
               .map(async (node) => {
-                try {
-                  const gate = await ensureFolderContextFresh(
+                folderSections.set(
+                  node.id,
+                  await buildFolderMentionSection(
                     session.user.id,
-                    node.id
-                  );
-                  if (gate.status === "optedOut") {
-                    folderSections.set(
-                      node.id,
-                      `### ${node.title}\n(folder — its AI context is disabled by the user; only the name is available)`
-                    );
-                    return;
-                  }
-                  const capsule =
-                    gate.status === "none"
-                      ? null
-                      : await assembleFolderCapsule(session.user.id, node.id);
-                  if (!capsule) {
-                    folderSections.set(
-                      node.id,
-                      `### ${node.title}\n(folder — no context is available yet: generation could not run${gate.reason ? ` (${gate.reason})` : ""}. Say so rather than guessing at its contents.)`
-                    );
-                    return;
-                  }
-                  const staleBanner =
-                    gate.status === "stale"
-                      ? `\n[NOTE: this folder's context could not be fully refreshed (${gate.reason ?? "budget"}) — parts may lag recent edits.]`
-                      : "";
-                  folderSections.set(node.id, capsule.text + staleBanner);
-                  logger.info({
-                    layer: "ai",
-                    event: "ai_context:mention_gate",
-                    summary: `folder mention gated: ${gate.status}`,
-                    attrs: {
-                      folderId: node.id,
-                      status: gate.status,
-                      generationCalls: gate.generationCalls,
-                      refreshedNodes: gate.refreshedNodes,
-                      waitedMs: gate.waitedMs,
-                    },
-                  });
-                } catch (gateError) {
-                  logger.warn({
-                    layer: "ai",
-                    event: "ai_context:mention_gate_caught",
-                    summary: "folder mention gate failed — name-only fallback",
-                    error: gateError,
-                  });
-                  folderSections.set(
                     node.id,
-                    `### ${node.title}\n(folder — context unavailable due to an internal error)`
-                  );
-                }
+                    node.title
+                  )
+                );
               })
           );
+
+          // Transitive folder links (capsule-plan follow-up): a mentioned
+          // NOTE that wiki-links folders behaves like mentioning those
+          // folders directly — same rule as a playbook's [[refs]]. Id-first
+          // resolution with exact-title fallback, deduped against direct
+          // mentions, capped at 3.
+          const linkedFolderSections: string[] = [];
+          try {
+            const linkedRefs = mentionedNodes
+              .filter((node) => node.contentType !== "folder")
+              .flatMap((node) =>
+                collectWikiLinkRefs(
+                  (node.notePayload?.tiptapJson ?? null) as JSONContent | null
+                )
+              );
+            if (linkedRefs.length > 0) {
+              const mentionedIds = new Set(mentionedNodes.map((n) => n.id));
+              const idRefs = linkedRefs
+                .map((ref) => ref.targetId)
+                .filter((id): id is string => !!id);
+              const titleRefs = [
+                ...new Set(
+                  linkedRefs
+                    .filter((ref) => !ref.targetId)
+                    .map((ref) => ref.targetTitle)
+                ),
+              ];
+              const linkedFolders = await prisma.contentNode.findMany({
+                where: {
+                  ownerId: session.user.id,
+                  contentType: "folder",
+                  deletedAt: null,
+                  OR: [
+                    ...(idRefs.length > 0 ? [{ id: { in: idRefs } }] : []),
+                    ...(titleRefs.length > 0
+                      ? [{ title: { in: titleRefs } }]
+                      : []),
+                  ],
+                },
+                select: { id: true, title: true },
+                take: 3,
+              });
+              for (const folder of linkedFolders) {
+                if (mentionedIds.has(folder.id)) continue;
+                linkedFolderSections.push(
+                  await buildFolderMentionSection(
+                    session.user.id,
+                    folder.id,
+                    folder.title,
+                    3000
+                  )
+                );
+              }
+            }
+          } catch (linkError) {
+            logger.warn({
+              layer: "ai",
+              event: "ai_context:linked_folder_caught",
+              summary:
+                "transitive folder-link resolution failed — continuing without it",
+              error: linkError,
+            });
+          }
 
           const sections = mentionedNodes.map((node) => {
             const folderSection = folderSections.get(node.id);
@@ -1283,6 +1395,7 @@ export async function POST(request: Request) {
               node.notePayload?.searchText || "(no text content available)";
             return `### ${node.title}\n${text.slice(0, 2000)}`;
           });
+          sections.push(...linkedFolderSections);
           mentionedContext = `\n\nThe user has referenced the following content:\n\n${sections.join("\n\n")}`;
         }
       }

--- a/components/content/content/MainPanelContent.tsx
+++ b/components/content/content/MainPanelContent.tsx
@@ -1292,12 +1292,16 @@ export function MainPanelContent({ paneId, initialContent = null }: MainPanelCon
         }
 
         type NoteItem = { id: string; title: string; slug: string; contentType: string };
+        // Notes AND folders (FOLDER-CONTEXT-CAPSULE follow-up): a folder
+        // wiki-link navigates to the folder and, in playbooks/chat, injects
+        // its context capsule like a chat mention.
         return ((result.data?.items as NoteItem[] | undefined) || [])
-          .filter((item) => item.contentType === 'note')
+          .filter((item) => item.contentType === 'note' || item.contentType === 'folder')
           .map((item) => ({
             id: item.id,
             title: item.title,
             slug: item.slug,
+            contentType: item.contentType,
           }));
       } catch (err) {
         clientLogger.error({

--- a/components/content/editor/ExpandableEditor.tsx
+++ b/components/content/editor/ExpandableEditor.tsx
@@ -47,7 +47,7 @@ interface ExpandableEditorProps {
   /** Callback when a wiki-link is clicked */
   onWikiLinkClick?: (target: WikiLinkClickTarget) => void;
   /** Fetch notes for wiki-link autocomplete */
-  fetchNotesForWikiLink?: (query: string) => Promise<Array<{ id: string; title: string; slug: string }>>;
+  fetchNotesForWikiLink?: (query: string) => Promise<Array<{ id: string; title: string; slug: string; contentType?: string }>>;
   /** Fetch tags for tag autocomplete */
   fetchTags?: (query: string) => Promise<Array<{ id: string; name: string; slug: string; color: string | null; usageCount: number }>>;
   fetchPeopleMentions?: (query: string) => Promise<Array<{ id: string; personId: string; label: string; slug: string; email: string | null; phone: string | null; avatarUrl: string | null }>>;

--- a/components/content/editor/MarkdownEditor.tsx
+++ b/components/content/editor/MarkdownEditor.tsx
@@ -173,7 +173,7 @@ export interface MarkdownEditorProps {
   /** Callback when a wiki-link is clicked */
   onWikiLinkClick?: (target: WikiLinkClickTarget) => void;
   /** Fetch notes for wiki-link autocomplete */
-  fetchNotesForWikiLink?: (query: string) => Promise<Array<{ id: string; title: string; slug: string }>>;
+  fetchNotesForWikiLink?: (query: string) => Promise<Array<{ id: string; title: string; slug: string; contentType?: string }>>;
   /** Callback when a tag is clicked */
   onTagClick?: (tagId: string, tagName: string) => void;
   /** Fetch tags for tag autocomplete */

--- a/lib/domain/ai/tools/registry.ts
+++ b/lib/domain/ai/tools/registry.ts
@@ -33,6 +33,7 @@ import {
   extractSearchTextFromTipTap,
   markdownToTiptapResult,
 } from "@/lib/domain/content";
+import { linkifyWikiRefsInTiptap } from "@/lib/domain/editor/wiki-link-refs";
 import { generateAndStoreImage } from "@/lib/domain/ai/image/generate-and-store";
 import { IMAGE_PROVIDER_CATALOG } from "@/lib/domain/ai/image/catalog";
 import type { ImageProviderId, ImageModelId, ImageSize } from "@/lib/domain/ai/image/types";
@@ -1298,7 +1299,8 @@ export function createBaseTools(ctx: ToolExecuteContext) {
         "Ambiguous phrasings to watch for: 'update the note in this chat', 'add to this conversation's notes', 'put X in the note' — these do NOT mean 'create a new note'. They typically refer to an existing note. When the phrasing is ambiguous, ASK the user whether to create a new note or update an existing one before calling this tool. " +
         "If they confirm a new note, this is the right tool. If they name an existing note, use `searchNotes` to find its id then use `updateNote`. " +
         "Do NOT create output on your own initiative — only when the user asks for it. " +
-        "Targeting: omit placement fields to use the configured output-target preset. If the user or active playbook gives THIS note a different relative destination, pass `outputLocation` (`under_chat`, `under_content`, or `beside_content`). Pass `parentId` only for a specifically resolved folder UUID. A per-note instruction always overrides the preset.",
+        "Targeting: omit placement fields to use the configured output-target preset. If the user or active playbook gives THIS note a different relative destination, pass `outputLocation` (`under_chat`, `under_content`, or `beside_content`). Pass `parentId` only for a specifically resolved folder UUID. A per-note instruction always overrides the preset. " +
+        "HYPERLINKING: to link other garden content inline (notes OR folders), write wiki-links in the markdown — [[Exact Title]] or [[Exact Title|Shown Text]]. They become real clickable links, resolve by title, and a linked FOLDER also feeds its context to the AI when the note is used in chat or as a playbook. Use the content's exact title; do not invent URL-style links for internal content.",
       inputSchema: z.object({
         title: z
           .string()
@@ -1392,7 +1394,11 @@ export function createBaseTools(ctx: ToolExecuteContext) {
         const conversion = content
           ? markdownToTiptapResult(content)
           : { json: { type: "doc", content: [{ type: "paragraph" }] }, degraded: false };
-        const tiptapJson = conversion.json;
+        // Wiki-link enrichment: literal [[Title]] / [[Title|Alias]] in the
+        // AI's markdown becomes real wikiLink nodes (clickable, id-healing,
+        // capsule-injecting for folders). The global markdown parser stays
+        // untouched — this is an authoring-seam upgrade only.
+        const tiptapJson = linkifyWikiRefsInTiptap(conversion.json);
         const searchText = extractSearchTextFromTipTap(tiptapJson);
         const wordCount = searchText.split(/\s+/).filter(Boolean).length;
 
@@ -1467,7 +1473,8 @@ export function createBaseTools(ctx: ToolExecuteContext) {
         "If the user is chatting in a full-page chat and asks to update 'the note in this chat' or 'this chat's notes', pass the CHAT's contentId here — that updates the notes panel attached to the chat itself, not a separate file. " +
         "Do NOT use this to create new top-level notes — use `createNote` for that. " +
         "Do NOT call this on your own initiative — only when the user asks you to write to a note. There is no default between writing-to-a-note and creating new output (createNote/create_docx); pick whichever the user's request actually asks for, and do neither unless they ask. " +
-        "This updates CONTENT ONLY — it never changes the title. Renaming is a separate, explicit action: if the user asks to rename/retitle, use `renameNote`. Do not rename as a side effect of a content update.",
+        "This updates CONTENT ONLY — it never changes the title. Renaming is a separate, explicit action: if the user asks to rename/retitle, use `renameNote`. Do not rename as a side effect of a content update. " +
+        "HYPERLINKING: to link other garden content inline (notes OR folders), write wiki-links in the markdown — [[Exact Title]] or [[Exact Title|Shown Text]]. They become real clickable links, resolve by title, and a linked FOLDER also feeds its context to the AI when the note is used in chat or as a playbook. Use the content's exact title; do not invent URL-style links for internal content.",
       inputSchema: z.object({
         contentId: z
           .string()
@@ -1505,7 +1512,11 @@ export function createBaseTools(ctx: ToolExecuteContext) {
         // tool's own "do NOT … rename" guard text into the title field
         // ("/do-not-rename/"). No title param = nothing to bleed in.
         const conversion = markdownToTiptapResult(content);
-        const tiptapJson = conversion.json;
+        // Wiki-link enrichment: literal [[Title]] / [[Title|Alias]] in the
+        // AI's markdown becomes real wikiLink nodes (clickable, id-healing,
+        // capsule-injecting for folders). The global markdown parser stays
+        // untouched — this is an authoring-seam upgrade only.
+        const tiptapJson = linkifyWikiRefsInTiptap(conversion.json);
         const searchText = extractSearchTextFromTipTap(tiptapJson);
         const wordCount = searchText.split(/\s+/).filter(Boolean).length;
         const degradedMeta = conversion.degraded

--- a/lib/domain/editor/extensions-client.ts
+++ b/lib/domain/editor/extensions-client.ts
@@ -96,7 +96,7 @@ export interface EditorExtensionsOptions {
   /** Callback when a wiki-link is clicked */
   onWikiLinkClick?: (target: WikiLinkClickTarget) => void;
   /** Fetch notes for wiki-link autocomplete */
-  fetchNotesForWikiLink?: (query: string) => Promise<Array<{ id: string; title: string; slug: string }>>;
+  fetchNotesForWikiLink?: (query: string) => Promise<Array<{ id: string; title: string; slug: string; contentType?: string }>>;
   /** Callback when a tag is clicked */
   onTagClick?: (tagId: string, tagName: string) => void;
   /** Fetch tags for tag autocomplete */

--- a/lib/domain/editor/extensions/wiki-link-suggestion.tsx
+++ b/lib/domain/editor/extensions/wiki-link-suggestion.tsx
@@ -17,6 +17,8 @@ interface WikiLinkSuggestionItem {
   id: string;
   title: string;
   slug: string;
+  /** "note" (default) or "folder" — folders link to their capsule-backed view. */
+  contentType?: string;
 }
 
 interface WikiLinkListProps {
@@ -77,7 +79,7 @@ export const WikiLinkList = forwardRef<WikiLinkListRef, WikiLinkListProps>((prop
   if (props.items.length === 0) {
     return (
       <div className="rounded-lg border border-white/10 bg-gray-900/95 p-3 shadow-xl backdrop-blur-sm">
-        <div className="text-sm text-gray-400">No notes found</div>
+        <div className="text-sm text-gray-400">No matches found</div>
       </div>
     );
   }
@@ -95,7 +97,14 @@ export const WikiLinkList = forwardRef<WikiLinkListRef, WikiLinkListProps>((prop
                 : "text-gray-300 hover:bg-white/5"
             }`}
           >
-            {item.title}
+            <span className="flex items-center justify-between gap-2">
+              <span className="truncate">{item.title}</span>
+              {item.contentType === "folder" && (
+                <span className="shrink-0 rounded border border-white/15 px-1 py-px text-[9px] uppercase tracking-wide text-gray-400">
+                  folder
+                </span>
+              )}
+            </span>
           </button>
         ))}
       </div>

--- a/lib/domain/editor/wiki-link-refs.ts
+++ b/lib/domain/editor/wiki-link-refs.ts
@@ -1,0 +1,100 @@
+/**
+ * Wiki-link reference utilities (pure, client- and server-safe).
+ *
+ * Two jobs, one seam:
+ *  - `collectWikiLinkRefs` — walk a TipTap doc for `wikiLink` NODES and
+ *    return their refs (id-first: autocomplete-authored links carry
+ *    `targetId`; hand-typed and AI-authored ones resolve by title).
+ *  - `linkifyWikiRefsInTiptap` — upgrade literal `[[Title]]` /
+ *    `[[Title|Alias]]` TEXT into real wikiLink nodes. The markdown→TipTap
+ *    converter has no wiki syntax (deliberately — the lossless system
+ *    serializes wikiLink at Tier 2 node-HTML), so AI-authored markdown lands
+ *    as plain text. The AI write tools run this enrichment post-conversion;
+ *    the global parser stays untouched.
+ */
+
+import type { JSONContent } from "@tiptap/core";
+
+export interface WikiLinkRef {
+  targetId: string | null;
+  targetTitle: string;
+}
+
+/** Collect distinct wikiLink-node refs anywhere in a TipTap doc. */
+export function collectWikiLinkRefs(doc: JSONContent | null | undefined): WikiLinkRef[] {
+  const out: WikiLinkRef[] = [];
+  const seen = new Set<string>();
+  const walk = (node: JSONContent | undefined) => {
+    if (!node) return;
+    if (node.type === "wikiLink") {
+      const attrs = (node.attrs ?? {}) as {
+        targetId?: string | null;
+        targetTitle?: string | null;
+      };
+      const title = (attrs.targetTitle ?? "").trim();
+      if (title) {
+        const key = `${attrs.targetId ?? ""}::${title.toLowerCase()}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          out.push({ targetId: attrs.targetId ?? null, targetTitle: title });
+        }
+      }
+    }
+    for (const child of node.content ?? []) walk(child);
+  };
+  walk(doc ?? undefined);
+  return out;
+}
+
+const WIKI_TEXT_RE = /\[\[([^\[\]|\n]+?)(?:\|([^\[\]\n]+?))?\]\]/g;
+
+/** True when a text node carries a `code` mark — wiki syntax stays literal there. */
+function hasCodeMark(node: JSONContent): boolean {
+  return (node.marks ?? []).some((mark) => mark.type === "code");
+}
+
+/**
+ * Replace literal `[[…]]` runs in text nodes with wikiLink nodes (marks
+ * preserved on surrounding text; code blocks and inline code left alone).
+ * Returns a new doc; the input is not mutated.
+ */
+export function linkifyWikiRefsInTiptap(doc: JSONContent): JSONContent {
+  const transform = (node: JSONContent): JSONContent | JSONContent[] => {
+    if (node.type === "codeBlock") return node;
+    if (node.type === "text" && typeof node.text === "string" && !hasCodeMark(node)) {
+      const text = node.text;
+      if (!text.includes("[[")) return node;
+      const pieces: JSONContent[] = [];
+      let last = 0;
+      WIKI_TEXT_RE.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = WIKI_TEXT_RE.exec(text)) !== null) {
+        const [full, target, alias] = match;
+        const title = target.trim();
+        if (!title) continue;
+        if (match.index > last) {
+          pieces.push({ ...node, text: text.slice(last, match.index) });
+        }
+        pieces.push({
+          type: "wikiLink",
+          attrs: {
+            targetId: null,
+            targetTitle: title,
+            ...(alias?.trim() ? { displayText: alias.trim() } : {}),
+          },
+        });
+        last = match.index + full.length;
+      }
+      if (pieces.length === 0) return node;
+      if (last < text.length) pieces.push({ ...node, text: text.slice(last) });
+      return pieces;
+    }
+    if (!node.content) return node;
+    return {
+      ...node,
+      content: node.content.flatMap((child) => transform(child)),
+    };
+  };
+  const result = transform(doc);
+  return Array.isArray(result) ? { ...doc, content: result } : result;
+}


### PR DESCRIPTION
## Sprint 58 — Folder wiki-links + AI hyperlink authoring

Two gaps surfaced while using the Folder Context Capsule (#149):

### 1. Folder wiki-links (`41cd3083`)
Folders couldn't be wiki-linked — the whole gap was the autocomplete's note-only filter (resolution and click-nav were already type-agnostic). Now:
- `[[` autocomplete offers folders, with a type badge in the dropdown; clicking a folder link opens the folder.
- **Playbook `[[folder]]` refs behave like chat folder mentions**: the reference manifest is folder-aware — active-phase folder refs inject their context capsule (gate + failure ladder, capped 3, 3s budget); other phases' folders stay lazy behind `read_folder_context`. Folders are excluded from the checkpoint gate's getCurrentNote expectations.
- **Mentioned-note transitive links**: folder wiki-links inside an @-mentioned note resolve (id-first, exact-title fallback) and inject capsules, deduped against direct mentions.
- Route's inline mention logic extracted to a shared `buildFolderMentionSection` helper (one D5 ladder, three consumers).
**Gate:** typecheck clean; lint 0 errors / 151 warnings (baseline).

### 2. AI hyperlink authoring
Asked to "include hyperlinks," the model wrote plain content names — it had no linking syntax and the markdown pipeline had no `[[` parse. Now:
- `linkifyWikiRefsInTiptap` upgrades literal `[[Title]]` / `[[Title|Alias]]` in AI-authored markdown into real wikiLink nodes at the createNote/updateNote conversion seam only (code blocks and inline code excluded; the global markdown parser is untouched).
- createNote/updateNote tool descriptions teach the syntax, including that folder links feed context in chat/playbooks.
**Gate:** `markdown:blocks:check` all passed (lossless system unaffected).

New shared module: `lib/domain/editor/wiki-link-refs.ts` (pure ref walker + linkifier).

## Preflight checklist

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors, 151 warnings (baseline)
- [x] `pnpm markdown:blocks:check` — all passed
- [x] Smoke: type `[[` in a note → folders appear with badge; select one → pill renders; click → folder opens
- [x] Smoke: playbook whose active phase contains `[[SomeFolder]]` → run it → capsule appears in context (model references folder contents without searching)
- [x] Smoke: @mention a note that wiki-links a folder → capsule injected (model knows the folder's contents)
- [x] Smoke: ask the AI to "rewrite this note with hyperlinks to related content" → output contains clickable wiki-links, not plain names
- [x] Post-merge: none — no migration, no Hocuspocus redeploy (no TipTap schema change; wikiLink node unchanged, only authored more often)

🤖 Generated with [Claude Code](https://claude.com/claude-code)