### PR TITLE
feat(mobile): native:app-state — sleep on background, resync on return

### DIFF
--- a/lib/domain/collaboration/runtime.ts
+++ b/lib/domain/collaboration/runtime.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/domain/collaboration/content-safety";
 import { getCollaborationServerExtensions } from "@/lib/domain/collaboration/extensions";
 import { sanitizeTipTapJsonWithExtensions } from "@/lib/domain/editor/unsupported-content";
+import { onNativeMessage } from "@/lib/mobile-bridge/client";
 import { clientLogger } from "@/lib/core/logger/client";
 
 // Initial-promote deferral.
@@ -2150,42 +2151,84 @@ class CollaborationRuntimeManager {
       if (!entry.visibilitySleepTimer) {
         entry.visibilitySleepTimer = setTimeout(() => {
           entry.visibilitySleepTimer = null;
-          // Deep-hidden: stop the SSE presence stream (kills the server-side
-          // 10s Postgres poll) and drop to the dormant heartbeat cadence.
-          entry.presenceStreamSuspended = true;
-          this.closePresenceStream(entry);
-          this.maybeEnterSleepMode(entry);
+          this.enterDeepHidden(entry);
         }, VISIBILITY_SLEEP_DELAY_MS);
       }
     } else {
-      // Tab became visible — cancel any pending sleep countdown.
-      if (entry.visibilitySleepTimer) {
-        clearTimeout(entry.visibilitySleepTimer);
-        entry.visibilitySleepTimer = null;
-      }
-      // Reset activity clock so inactivity timer gets a fresh window.
-      entry.lastActivityAt = Date.now();
-      // Lift deep-hidden suspension: reopen the presence stream (if leader)
-      // and heartbeat immediately so our record refreshes and we re-learn who
-      // else is here without waiting out a dormant-cadence interval.
-      if (entry.presenceStreamSuspended) {
-        entry.presenceStreamSuspended = false;
-        this.syncPresenceTransport(entry);
-        this.schedulePresenceHeartbeat(entry, 0);
-      }
-      // If we slept and came back to an active session, re-promote.
-      if (
-        entry.state.connectionState === "localOnly" &&
-        !entry.state.reconnectIntent &&
-        (entry.state.browserSessionTopology === "multiSession" ||
-          entry.state.remoteCollaborationTopology === "remotePresent")
-      ) {
-        void this.promote(entry, "reconnect-after-offline");
-      }
+      this.handleBecameVisible(entry);
+    }
+  }
 
-      // If Hocuspocus dropped unexpectedly (passive backoff timer running),
-      // jump straight to reconnect now that the user is back on the tab.
-      this.activityTriggeredReconnect(entry);
+  /**
+   * Deep-hidden: stop the SSE presence stream (kills the server-side 10s
+   * Postgres poll), drop to the dormant heartbeat cadence, and sleep the
+   * transport. Reached either by outlasting the visibility countdown or,
+   * in the native shell, by the host app actually backgrounding.
+   */
+  private enterDeepHidden(entry: DocumentRuntimeEntry) {
+    entry.presenceStreamSuspended = true;
+    this.closePresenceStream(entry);
+    this.maybeEnterSleepMode(entry);
+  }
+
+  /** The surface came back to the foreground: cancel sleep, resync, re-promote. */
+  private handleBecameVisible(entry: DocumentRuntimeEntry) {
+    // Cancel any pending sleep countdown.
+    if (entry.visibilitySleepTimer) {
+      clearTimeout(entry.visibilitySleepTimer);
+      entry.visibilitySleepTimer = null;
+    }
+    // Reset activity clock so inactivity timer gets a fresh window.
+    entry.lastActivityAt = Date.now();
+    // Lift deep-hidden suspension: reopen the presence stream (if leader)
+    // and heartbeat immediately so our record refreshes and we re-learn who
+    // else is here without waiting out a dormant-cadence interval.
+    if (entry.presenceStreamSuspended) {
+      entry.presenceStreamSuspended = false;
+      this.syncPresenceTransport(entry);
+      this.schedulePresenceHeartbeat(entry, 0);
+    }
+    // If we slept and came back to an active session, re-promote.
+    if (
+      entry.state.connectionState === "localOnly" &&
+      !entry.state.reconnectIntent &&
+      (entry.state.browserSessionTopology === "multiSession" ||
+        entry.state.remoteCollaborationTopology === "remotePresent")
+    ) {
+      void this.promote(entry, "reconnect-after-offline");
+    }
+
+    // If Hocuspocus dropped unexpectedly (passive backoff timer running),
+    // jump straight to reconnect now that the user is back on the tab.
+    this.activityTriggeredReconnect(entry);
+  }
+
+  /**
+   * Host-app lifecycle, reported by the native shell (`native:app-state`).
+   *
+   * iOS suspends the app process within seconds of backgrounding: JS stops
+   * dead, so the visibility sleep countdown never runs — while the OS tears
+   * the WebSocket down regardless. The session is then left believing it is
+   * connected over a socket that no longer exists, and nothing re-checks on
+   * return. The native signal is authoritative where the WebView's own
+   * visibility events are not.
+   *
+   * `background` sleeps immediately: there is no point scheduling a countdown
+   * the OS is about to freeze, and sleeping sooner is strictly cheaper (sleep
+   * is a deliberate cost feature, not a bug). `active` runs the same wake path
+   * a tab-visible transition would — including its topology guards, so a solo
+   * editor still stays local-only and doesn't reconnect Cloud Run for nothing.
+   *
+   * `inactive` is deliberately ignored: iOS emits it for transient overlays
+   * (app switcher, Control Center, an incoming call), and sleeping on those
+   * would thrash the transport every time the user peeks away.
+   */
+  handleHostAppStateChange(state: "active" | "background" | "inactive") {
+    if (state === "inactive") return;
+    for (const entry of this.entries.values()) {
+      if (entry.consumers.size === 0) continue;
+      if (state === "active") this.handleBecameVisible(entry);
+      else this.enterDeepHidden(entry);
     }
   }
 
@@ -2410,6 +2453,16 @@ export const collaborationRuntimeManager = new CollaborationRuntimeManager();
 if (typeof navigator !== "undefined" && "storage" in navigator && "persist" in navigator.storage) {
   void navigator.storage.persist();
 }
+
+// Subscribe to host-app lifecycle from the native shell. Wired here rather than
+// in a component so no surface has to remember to do it — the runtime owns its
+// own input sources, exactly as it does for visibilitychange/online/offline.
+// Outside the native shell this is inert: the event simply never fires.
+onNativeMessage((message) => {
+  if (message.type === "native:app-state") {
+    collaborationRuntimeManager.handleHostAppStateChange(message.state);
+  }
+});
 
 export function useCollaborationRuntime({
   contentId,

--- a/lib/mobile-bridge/client.ts
+++ b/lib/mobile-bridge/client.ts
@@ -20,6 +20,21 @@ export type WebToNativeMessage =
   | { type: "web:request-microphone" }
   | { type: "web:request-location" };
 
+/** Mirror of `mobile/src/bridge/messages.ts` (`NativeToWebMessage`). */
+export type NativeToWebMessage =
+  | { type: "native:ready" }
+  | { type: "native:app-state"; state: "active" | "background" | "inactive" }
+  | { type: "native:permission-result"; permission: string; granted: boolean };
+
+/**
+ * Event name the shell dispatches on `window` for native→web messages.
+ * A CustomEvent (rather than a global callback the page must register first)
+ * means a message that arrives before any listener mounts is simply missed
+ * rather than lost in a race — acceptable because every native→web message so
+ * far is a state *transition*, and the next one re-establishes the truth.
+ */
+const NATIVE_MESSAGE_EVENT = "dg:native-message";
+
 interface ReactNativeWebViewBridge {
   postMessage: (data: string) => void;
 }
@@ -55,4 +70,39 @@ export function openExternalUrl(url: string): void {
   if (typeof window !== "undefined") {
     window.open(url, "_blank", "noopener,noreferrer");
   }
+}
+
+/** Narrow an arbitrary payload to a NativeToWebMessage, or null. */
+function parseNativeToWebMessage(raw: unknown): NativeToWebMessage | null {
+  let data: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof data !== "object" || data === null) return null;
+  const type = (data as { type?: unknown }).type;
+  if (typeof type !== "string" || !type.startsWith("native:")) return null;
+  return data as NativeToWebMessage;
+}
+
+/**
+ * Subscribe to messages from the native shell. Returns an unsubscribe fn.
+ * No-ops (returning a no-op unsubscriber) outside the shell and on the server,
+ * so callers can wire it unconditionally.
+ */
+export function onNativeMessage(
+  handler: (message: NativeToWebMessage) => void
+): () => void {
+  if (typeof window === "undefined") return () => {};
+  const listener = (event: Event) => {
+    const message = parseNativeToWebMessage(
+      (event as CustomEvent<unknown>).detail
+    );
+    if (message) handler(message);
+  };
+  window.addEventListener(NATIVE_MESSAGE_EVENT, listener);
+  return () => window.removeEventListener(NATIVE_MESSAGE_EVENT, listener);
 }

--- a/mobile/src/MobileWebView.tsx
+++ b/mobile/src/MobileWebView.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  AppState,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -23,7 +24,10 @@ import {
   handleWebToNativeMessage,
   shouldOpenExternally,
 } from "./bridge/nativeBridge";
-import { parseWebToNativeMessage } from "./bridge/messages";
+import {
+  parseWebToNativeMessage,
+  serializeNativeToWebMessage,
+} from "./bridge/messages";
 
 interface MobileWebViewProps {
   /** Web URL to load. Defaults to the configured Digital Garden origin. */
@@ -107,6 +111,34 @@ export function MobileWebView({ url = DEFAULT_WEB_URL }: MobileWebViewProps) {
   // silently. A second kill within 30s means the system is thrashing;
   // surface the error screen instead of fighting it.
   const lastTerminationAtRef = useRef(0);
+  // Report host-app lifecycle into the page. The web app can't infer this
+  // reliably on its own: iOS suspends the process seconds after backgrounding,
+  // so JS-side timers freeze mid-countdown while the OS tears down sockets
+  // anyway. The collaboration runtime uses this to sleep immediately on
+  // background and re-check the transport on return.
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (state) => {
+      // RN's AppStateStatus adds states iOS never emits here ("unknown",
+      // "extension"); the bridge contract covers the three real ones.
+      if (state !== "active" && state !== "background" && state !== "inactive") {
+        return;
+      }
+      const payload = serializeNativeToWebMessage({
+        type: "native:app-state",
+        state,
+      });
+      // JSON.stringify twice: once for the payload, once to embed it as a JS
+      // string literal in injected source. The trailing `true;` is required —
+      // WKWebView injection must evaluate to a non-object value.
+      webViewRef.current?.injectJavaScript(
+        `window.dispatchEvent(new CustomEvent('dg:native-message', { detail: ${JSON.stringify(
+          payload
+        )} })); true;`
+      );
+    });
+    return () => subscription.remove();
+  }, []);
+
   const handleContentProcessTerminated = useCallback(() => {
     const now = Date.now();
     if (now - lastTerminationAtRef.current < 30_000) {


### PR DESCRIPTION
## Sprint 1 — Host-app lifecycle reaches the collaboration runtime

**The gap.** iOS suspends the app process within seconds of backgrounding: JS stops dead, so the collaboration runtime's 3-minute visibility sleep countdown never fires — while the OS tears down the WebSocket regardless. The session is left believing it's connected over a socket that no longer exists, and nothing re-checks on return. On desktop that's a rare edge; **on a phone it's the normal usage pattern** (you background the app constantly), which makes it the gap most likely to cause quiet weirdness in notes.

The shell now reports `AppState` through the **already-declared** `native:app-state` contract (it shipped as a contract in the June spike; this wires it):

| State | Behavior | Why |
|---|---|---|
| `background` | Sleep **immediately** | No point scheduling a countdown the OS is about to freeze — and sleeping sooner is strictly cheaper. Sleep is a deliberate cost feature. |
| `active` | Same wake path a tab-visible transition runs | Includes its **topology guards**, so a solo editor still stays local-only and doesn't reconnect Cloud Run for nothing. |
| `inactive` | Ignored | iOS emits it for transient overlays (app switcher, Control Center, incoming call); sleeping on those would thrash the transport. |

**One definition of each concept.** The two branches of `handleVisibilityChange` are extracted to `enterDeepHidden` / `handleBecameVisible`, and both the browser signal and the native signal drive those same methods — so "went dark" and "came back" can't drift apart.

**Wiring.** Native→web delivery is a `CustomEvent` (not a global the page must register first, which would race). The runtime subscribes at **module scope**, alongside its existing `visibilitychange`/`online`/`offline` wiring — no surface has to remember to hook it up. Outside the native shell the event never fires, so it's inert.

**Gate:** `mobile` tsc clean; web tsc clean in changed files; lint 0 errors / 151 warnings (unchanged baseline).

## Notes for review
- Requires a **native rebuild** to reach the device (bridge change) — `mobile/scripts/install-device.sh`. Web-only changes still reach the phone with no rebuild.
- The cost model is deliberately unchanged on wake: `active` reuses the existing topology guards rather than force-connecting.

## Preflight
- [x] `pnpm typecheck` — no errors in changed files
- [x] `pnpm lint` — 0 errors, 151 warnings (unchanged)
- [x] `npx tsc --noEmit` in `mobile/` clean
- [ ] Device: open a note, background the app ~10s, return → editor still edits and content is current
- [ ] Device: background during an active collab session on another device → returning resyncs rather than sitting stale
- [ ] Device: app-switcher peek (inactive) does NOT drop the connection
- [ ] Desktop regression: tab hide/show still sleeps and wakes as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)