### PR TITLE
fix(file-tree): stop referenced content being captured by the folder it lands in

### DIFF
--- a/components/content/FileTree.tsx
+++ b/components/content/FileTree.tsx
@@ -136,11 +136,17 @@ export function FileTree({
 
     // Build a set of all valid IDs in current tree data
     const allIds = new Set<string>();
+    // Walks `references` as well as `children`: this set decides which
+    // persisted selections survive, and a row inside a reference block would
+    // otherwise be judged stale and silently deselected.
     const collectIds = (nodes: TreeNode[]) => {
       nodes.forEach(node => {
         allIds.add(node.id);
         if (node.children) {
           collectIds(node.children);
+        }
+        if (node.references) {
+          collectIds(node.references);
         }
       });
     };

--- a/components/content/content/LeftSidebarContent.tsx
+++ b/components/content/content/LeftSidebarContent.tsx
@@ -99,13 +99,20 @@ function patchTreeNodeTitle(
       return { ...node, title: newTitle };
     }
 
-    if (!node.children?.length) {
+    // Both arrays — a rename of content sitting in a parent's reference block
+    // has to patch there too, or the optimistic title never updates for it.
+    if (!node.children?.length && !node.references?.length) {
       return node;
     }
 
     return {
       ...node,
-      children: patchTreeNodeTitle(node.children, contentId, newTitle),
+      children: node.children?.length
+        ? patchTreeNodeTitle(node.children, contentId, newTitle)
+        : (node.children ?? []),
+      references: node.references?.length
+        ? patchTreeNodeTitle(node.references, contentId, newTitle)
+        : node.references,
     };
   });
 }
@@ -777,6 +784,11 @@ export function LeftSidebarContent({
       string,
       { currentParentId: string | null; currentIndex: number }
     >();
+    // Walks both arrays: a row inside a parent's reference block is a
+    // perfectly ordinary drag source, and skipping `references` left it
+    // without a recorded position. The index it yields is within whichever
+    // array held it — only consulted for same-parent reordering, where the
+    // server re-sorts by displayOrder anyway.
     const findPositions = (nodes: TreeNode[], parent: string | null = null) => {
       for (let i = 0; i < nodes.length; i++) {
         if (dragIds.includes(nodes[i].id)) {
@@ -784,6 +796,9 @@ export function LeftSidebarContent({
         }
         if (nodes[i].children && nodes[i].children.length > 0) {
           findPositions(nodes[i].children, nodes[i].id);
+        }
+        if (nodes[i].references && nodes[i].references.length > 0) {
+          findPositions(nodes[i].references, nodes[i].id);
         }
       }
     };

--- a/lib/domain/content/tree-drop-target.ts
+++ b/lib/domain/content/tree-drop-target.ts
@@ -35,10 +35,22 @@ export const ROOT_DROP_TARGET: UploadDropTarget = {
   source: "root",
 };
 
+/**
+ * Depth-first lookup across BOTH child arrays.
+ *
+ * Referenced children are partitioned out of `children` into `references` by
+ * the tree API, so searching `children` alone makes anything inside a
+ * reference block invisible to every caller of this helper. That included the
+ * drag handler's pre-flight resolve, which bails when a dragged id can't be
+ * found — so a reference dropped into a folder became unmovable: the guard
+ * rejected it before any request was sent.
+ */
 export function findTreeNodeById(nodes: TreeNode[], id: string): TreeNode | null {
   for (const node of nodes) {
     if (node.id === id) return node;
-    const found = node.children ? findTreeNodeById(node.children, id) : null;
+    const found =
+      (node.children ? findTreeNodeById(node.children, id) : null) ??
+      (node.references ? findTreeNodeById(node.references, id) : null);
     if (found) return found;
   }
   return null;

--- a/scripts/validate-reference-block.ts
+++ b/scripts/validate-reference-block.ts
@@ -28,6 +28,7 @@ import {
   expandReferences,
   referenceGroupKey,
 } from "@/lib/features/content/reference-group";
+import { findTreeNodeById } from "@/lib/domain/content/tree-drop-target";
 import type { TreeNode } from "@/lib/domain/content/types";
 
 let failures = 0;
@@ -212,6 +213,55 @@ const EMPTY = new Set<string>();
     "inner block opens independently",
     ids(both[0].children[0].children) === "deliverable",
     ids(both[0].children[0].children),
+  );
+}
+
+// --- Lookup reaches into reference blocks --------------------------------
+//
+// Shared tree walkers must search `references` as well as `children`. The
+// drag handler resolves every dragged id through findTreeNodeById and BAILS
+// when one is missing ("could not be found in the current tree"), so a
+// children-only walk made anything inside a reference block permanently
+// unmovable — the move request was never even sent. Same omission silently
+// pruned referenced rows from the persisted selection and skipped optimistic
+// renames. Any new tree walker has to handle both arrays.
+{
+  const data = fixture();
+  check(
+    "findTreeNodeById finds a node inside references",
+    findTreeNodeById(data, "ref-2")?.id === "ref-2",
+    "children-only walk — reference block is unreachable",
+  );
+  check(
+    "findTreeNodeById still finds primary children",
+    findTreeNodeById(data, "note-b")?.id === "note-b",
+  );
+  check(
+    "findTreeNodeById returns null for an absent id",
+    findTreeNodeById(data, "nope") === null,
+  );
+}
+
+{
+  // A reference that itself owns references — the deliverable-under-side-chat
+  // shape. Lookup has to recurse through a references array, not just into one.
+  const data = [
+    node("folder", {
+      contentType: "folder",
+      children: [],
+      references: [
+        node("chat", {
+          contentType: "chat",
+          role: "referenced",
+          children: [],
+          references: [node("deliverable", { role: "referenced" })],
+        }),
+      ],
+    }),
+  ];
+  check(
+    "findTreeNodeById recurses through nested references",
+    findTreeNodeById(data, "deliverable")?.id === "deliverable",
   );
 }
 


### PR DESCRIPTION
## Sprint 59 — File tree: reference-block walkers

Follow-up to #169, which merged before this landed. Referenced content dropped into a folder became **permanently unmovable**.

### Symptom

Drag a reference into a folder, then try to move it again:

> **Failed to move item** — One or more dragged items could not be found in the current tree.

No request ever reached `/move`.

### Root cause

`handleMove` resolves every dragged node through `findTreeNodeById` before doing anything, and bails when one is missing. That helper recursed `node.children` only — but #169 made the tree API partition referenced children out of `children` into a new `references` array. Once a node sat in a reference block the lookup returned `null`, and the guard rejected the drag up front.

#169's optimistic-update fix taught `applyMoveToTree` about `references`, but that runs **after** this guard and could never be reached.

### The real lesson

Partitioning children into a second array is something **every** tree walker has to know about. Sweeping for the same omission found four more that didn't:

| Walker | Consequence |
|---|---|
| `findTreeNodeById` (`tree-drop-target.ts`) | The capture. Also backs `resolveDropParentNode`, so an OS file dropped onto a reference row resolved to the **wrong destination folder**. |
| `findPositions` (`LeftSidebarContent`) | No recorded position for a reference being dragged. |
| `patchTreeNodeTitle` (`LeftSidebarContent`) | Optimistic rename silently skipped referenced rows. |
| `collectIds` (`FileTree`) | This set decides which persisted selections survive — a selected reference was judged stale and **silently deselected**. |

### Gate

`reference-block:check` now pins the lookup invariant: `findTreeNodeById` must reach into reference blocks, including nested ones (a deliverable under a side chat under a folder). Verified the gate **fails on the children-only form** — 2 checks, exit 1 — before restoring the fix.

**Gate:** typecheck · lint (0 errors, 151 = main's ratchet) · `reference-block:check` · `pnpm build` exit 0, all against current `main`

## Pre-merge checklist
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build` green on current `main`
- [x] `pnpm reference-block:check` green, and verified to fail on the regression it protects
- [x] No schema change → no migration
- [x] **Smoke:** drag a reference from root into a folder, then drag it **out again** — it moves, no "could not be found" toast
- [x] **Smoke:** drag that reference on to a third folder — still movable, not captured
- [x] **Smoke:** rename a row inside a reference block → title updates without a reload
- [x] **Smoke:** select a row inside a reference block, reload → selection survives
- [ ] **Smoke:** drop an OS file onto a row inside a reference block → lands in that block's owning folder, not the root

🤖 Generated with [Claude Code](https://claude.com/claude-code)
