### PR TITLE
fix(file-tree): header + → File upload respects the view root

### DIFF
--- a/components/content/LeftSidebar.tsx
+++ b/components/content/LeftSidebar.tsx
@@ -24,6 +24,7 @@ import { PEOPLE_VIEW_KEY } from "@/extensions/people/manifest";
 import { useLeftPanelCollapseStore } from "@/state/left-panel-collapse-store";
 import { useLeftPanelViewStore } from "@/state/left-panel-view-store";
 import { useExtensionLeftSidebarPanel } from "@/lib/extensions/client-registry";
+import { useWorkspaceStore } from "@/extensions/workplaces/state/workspace-store";
 import { clientLogger } from "@/lib/core/logger/client";
 import { DataRailPanel } from "./data/DataRailPanel";
 
@@ -71,6 +72,21 @@ export function LeftSidebar() {
   }, []);
   const [showFileUpload, setShowFileUpload] = useState(false);
   const [fileUploadParentId, setFileUploadParentId] = useState<string | null>(null);
+  // In a view-scoped workspace the view root's own row is gone — its children
+  // ARE the top level — so a header-initiated write aimed at "the top" must be
+  // remapped onto the view root, exactly as the tree does with
+  // `scopedRootParentId` (LeftSidebarContent.tsx:323). Returns null outside a
+  // view workspace, i.e. the real vault root.
+  //
+  // NOTE: the header `+` and the tree's context menu open two *different*
+  // FileUploadDialog instances (this one, and LeftSidebarContent's at :2426).
+  // That duplication is the root cause of this class of bug — the tree path was
+  // fixed in 7497020 and this one was missed. Collapsing the two dialogs onto
+  // one owner is the real fix; see the follow-up noted in BACKLOG.md.
+  const viewRootParentId = useWorkspaceStore((state) => {
+    const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
+    return ws?.isView ? (ws.viewRootContentId ?? null) : null;
+  });
   const [draggedFiles, setDraggedFiles] = useState<File[] | null>(null);
   const [peopleMountParentId, setPeopleMountParentId] = useState<string | null | undefined>(undefined);
   // AI image-gen dialog state — open from "+ AI → Image Generation".
@@ -120,9 +136,14 @@ export function LeftSidebar() {
   }, []);
 
   const handleCreateFile = useCallback(() => {
-    setFileUploadParentId(null); // TODO: Get from current selection?
+    // Fall back to the view root so the upload lands inside the scope the user
+    // is looking at, not at the invisible vault root. Unlike the tree, this
+    // can't see the tree's ephemeral `scopeOverride`, so an upload started
+    // while the user has temporarily widened the scope to the whole tree still
+    // targets the workspace's own view root.
+    setFileUploadParentId(viewRootParentId);
     setShowFileUpload(true);
-  }, []);
+  }, [viewRootParentId]);
 
   // Trigger inline document creation (same pattern as folders/notes)
   const handleCreateDocument = useCallback(() => {


### PR DESCRIPTION
## Bug squash 2026-W35 — #85 (P0)

The sidebar header's `+ → File (upload)` opened its `FileUploadDialog` with an unconditional `parentId: null`, so in a view-scoped workspace the file landed at the real vault root — invisible from the view the user was looking at.

- read the workspace store's view root in `LeftSidebar` and seed `fileUploadParentId` from it instead of a literal `null`
- comment the duplicate-dialog structure that is the actual root cause, so the next reader lands on it rather than on the one-line diff

Diagnosis: `7497020` (PR #177) introduced `scopedRootParentId` and remapped top-level writes in a scoped tree onto the view root — creates, moves, drops, and the tree's own upload entry point (`components/content/content/LeftSidebarContent.tsx:323`, used at `:2426`). It did not touch `LeftSidebar.handleCreateFile`, which owns the header `+` and still carried the original `// TODO: Get from current selection?` null at `components/content/LeftSidebar.tsx:122-125`. That `null` became the dialog's `parentId` at `:346`, seeded `selectedFolderId` at `components/content/dialogs/FileUploadDialog.tsx:62`, was then omitted from the request body as falsy at `:200`, and `app/api/content/content/upload/simple/route.ts:292` resolved it to `parentId: null` — the vault root.

The header `+` was the last caller passing an unconditional `null`; the drag-and-drop path into the same dialog was already correctly targeted (`LeftSidebar.tsx:263-269`), because the tree resolves the destination before opening it.

### Where this departs from the plan doc

The plan proposed reading **two** workspace-store selectors (`activeWorkspaceIsView` and `activeViewRootContentId`). The code makes the first redundant: `activeViewRootContentId`'s own selector body already returns `null` when the workspace is not a view (`LeftSidebarContent.tsx:265-268`). This PR reads one selector with that same body.

### Known limitation (deliberate, not a regression)

`LeftSidebarContent` derives its `scopedRootParentId` from `effectiveViewRootContentId`, which also folds in the tree's **ephemeral `scopeOverride`** — local state one level below `LeftSidebar`. The header cannot see it, so an upload started while the user has temporarily widened the scope to the whole tree still targets the workspace's own view root. That is strictly better than today's unconditional vault root, and lifting `scopedRootParentId` into a shared hook was rejected in the plan as more surface than this bug needs. Noted in a code comment; the durable fix is collapsing the two `FileUploadDialog` instances onto one owner.

**Gates:** typecheck ✅ · lint ✅ (151 warnings, unchanged from `main` at the same commit — verified by re-running lint on a clean tree) · build ✅ (`NODE_OPTIONS='--max-old-space-size=8192' pnpm build`, completed, exit 0)

Not verified in a browser — this session is headless, so the smoke below is genuinely outstanding.

## Pre-merge checklist

- [ ] `pnpm build` green locally
- [ ] **Smoke #85:** in a workspace scoped to a view root, click the sidebar header `+` → File (upload) and upload a file → it appears at the top of the scoped tree, and in the unfiltered workspace it sits under the view root folder, not the vault root

---
_Generated by [Claude Code](https://claude.ai/code/session_012fT76TPBNYeYrA9oHKZenC)_