### PR TITLE
fix(ai-chat): keep the assistant detail card inside the viewport

### DIFF
--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -53,6 +53,7 @@ import { AnomalySurfaces, deriveMessageAnomalies } from "./AnomalyChips";
 import { FlashcardDeckProposalCard } from "./FlashcardDeckProposalCard";
 import { FlashcardCardProposalList } from "./FlashcardCardProposalList";
 import { cn } from "@/lib/core/utils";
+import { calculateMenuPosition, type CalculatedPosition } from "@/lib/core/menu-positioning";
 import { useContentStore } from "@/state/content-store";
 import { ArtifactContextMenu, openArtifactInSplitPane } from "./artifact-open";
 import { useSettingsStore } from "@/state/settings-store";
@@ -1841,6 +1842,11 @@ function formatDuration(ms: number): string {
   return `${m}m ${s.toString().padStart(2, "0")}s`;
 }
 
+/** Gap between the avatar and its detail card, on whichever side it lands. */
+const GAP = 6;
+/** Keep the card this far clear of every viewport edge. */
+const VIEWPORT_PADDING = 8;
+
 function AssistantAvatar({
   providerId,
   modelId,
@@ -1850,11 +1856,18 @@ function AssistantAvatar({
   modelId?: string | null;
   metadata?: Record<string, unknown>;
 }) {
+  // The avatar's own rect, captured on hover. This is the MEASURE-phase
+  // anchor: the tooltip first renders here hidden so it can be measured, then
+  // `tooltipPosition` takes over with a boundary-aware placement.
   const [tooltipAnchor, setTooltipAnchor] = useState<{
     top: number;
+    bottom: number;
     left: number;
   } | null>(null);
+  const [tooltipPosition, setTooltipPosition] =
+    useState<CalculatedPosition | null>(null);
   const anchorRef = useRef<HTMLDivElement | null>(null);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [portalReady, setPortalReady] = useState(false);
 
@@ -1885,11 +1898,13 @@ function AssistantAvatar({
     timerRef.current = setTimeout(() => {
       const rect = anchorRef.current?.getBoundingClientRect();
       if (!rect) return;
-      // Anchor just below the avatar, aligned to its left — keeps the tooltip
-      // at the hover point instead of drifting off to the right in narrow
-      // surfaces like the browser side panel.
+      // Anchor to the avatar, aligned to its left — keeps the tooltip at the
+      // hover point instead of drifting off to the right in narrow surfaces
+      // like the browser side panel. Both vertical edges are kept so the
+      // positioning pass below can place the card above as well as below.
       setTooltipAnchor({
-        top: rect.bottom + 6,
+        top: rect.top,
+        bottom: rect.bottom,
         left: rect.left,
       });
     }, 1000);
@@ -1898,7 +1913,53 @@ function AssistantAvatar({
   const handleLeave = useCallback(() => {
     if (timerRef.current) clearTimeout(timerRef.current);
     setTooltipAnchor(null);
+    setTooltipPosition(null);
   }, []);
+
+  // Two-phase measure-then-position, the same shape ContextMenu uses
+  // (components/content/context-menu/ContextMenu.tsx:503-526): the card renders
+  // hidden at the raw anchor for one tick, gets measured, then
+  // `calculateMenuPosition` places it with viewport-edge detection.
+  //
+  // Without this the card was anchored once at `rect.bottom + 6`, downward
+  // only. In a long chat the newest avatar sits near the bottom of the scroll
+  // container, so that landed below the viewport — and because the portal is
+  // `position: fixed`, nothing clipped it to reveal the problem; it was simply
+  // painted off-screen.
+  useEffect(() => {
+    if (!tooltipAnchor) return;
+    const timeoutId = setTimeout(() => {
+      const el = tooltipRef.current;
+      if (!el) return;
+      const { width, height } = el.getBoundingClientRect();
+
+      // Choose the side before delegating, so the 6px gap is preserved
+      // whichever way it goes: `calculateMenuPosition` anchors the card's top
+      // at the trigger point when placing below and its bottom at the trigger
+      // point when placing above, so each side needs its own trigger edge.
+      // Everything else — horizontal flip, edge shifting, the fallback when
+      // neither side fits — comes from the shared utility.
+      const fitsBelow =
+        tooltipAnchor.bottom + GAP + height + VIEWPORT_PADDING <=
+        window.innerHeight;
+
+      setTooltipPosition(
+        calculateMenuPosition({
+          triggerPosition: {
+            x: tooltipAnchor.left,
+            y: fitsBelow
+              ? tooltipAnchor.bottom + GAP
+              : tooltipAnchor.top - GAP,
+          },
+          menuDimensions: { width, height },
+          viewportPadding: VIEWPORT_PADDING,
+          preferredPlacementX: "right",
+          preferredPlacementY: fitsBelow ? "bottom" : "top",
+        }),
+      );
+    }, 0);
+    return () => clearTimeout(timeoutId);
+  }, [tooltipAnchor]);
 
   useEffect(() => {
     return () => {
@@ -1926,14 +1987,22 @@ function AssistantAvatar({
       {portalReady && tooltipAnchor &&
         createPortal(
           <div
+            ref={tooltipRef}
             role="tooltip"
             // Fixed positioning relative to the viewport — no ancestor
-            // overflow / transform can clip or reflow this.
+            // overflow / transform can clip or reflow this. Until the measure
+            // pass lands, render at the raw anchor but hidden, so the card is
+            // never briefly visible in the wrong place.
             style={{
               position: "fixed",
-              top: tooltipAnchor.top,
-              left: tooltipAnchor.left,
               zIndex: 9999,
+              ...(tooltipPosition
+                ? { top: tooltipPosition.y, left: tooltipPosition.x }
+                : {
+                    top: tooltipAnchor.bottom + GAP,
+                    left: tooltipAnchor.left,
+                    visibility: "hidden" as const,
+                  }),
             }}
             className="pointer-events-none whitespace-nowrap rounded-md border border-black/10 bg-white text-gray-700 dark:border-white/10 dark:bg-[#1a1a1a] dark:text-gray-200 px-2.5 py-1.5 text-[10px] shadow-xl"
           >


### PR DESCRIPTION
## Bug squash 2026-W35 — #179 (P3)

Hovering an assistant avatar showed the provider/model/token card on short chats but nothing on long ones. The card was being painted off-screen.

- capture both vertical edges of the avatar rect on hover, not just the bottom
- add the two-phase measure-then-position pass `ContextMenu` already uses — render hidden at the raw anchor, measure, then place
- delegate placement to `calculateMenuPosition`, picking the trigger edge and preferred side so the 6px gap survives a flip to above

Diagnosis: `components/content/ai/ChatMessage.tsx:1888-1894` anchored the card once, downward only, at `rect.bottom + 6`, with no viewport-edge detection and no clamping. In a long chat the newest assistant avatar sits near the bottom of the scroll container, so that coordinate lands below the viewport. On a short chat the avatar is high enough that the same math stays on-screen. The comments at `:1931-1932` note that `position: fixed` immunises the portal from ancestor clipping — true, and exactly why the failure was silent: nothing clipped it, it was simply painted outside the viewport.

Per `CLAUDE.md`'s "prefer the existing library over a bespoke build", this reuses `lib/core/menu-positioning.ts` — the flip + shift utility the context menus and dropdowns already share — rather than adding a third copy of a `window.innerHeight` check.

### One deliberate departure from the plan doc

The plan suggested `anchorMenuAbove` for the flip case. It doesn't fit: it returns a CSS `bottom` and a `maxHeight` for menus that grow upward from a composer, whereas this card is content-sized, `pointer-events-none` (so it can't scroll a capped height), and needs the same top/left shape in both orientations. Using `calculateMenuPosition` for both sides keeps one code path.

That utility anchors the card's **top** at the trigger point when placing below and its **bottom** at the trigger point when placing above, so each side needs a different trigger edge for the gap to survive. Hence the single `fitsBelow` comparison before the call — it selects the trigger edge and `preferredPlacementY`. Everything else (horizontal flip, edge shifting, and the fallback when neither side fits) comes from the shared utility.

The returned `maxHeight` is intentionally not applied: the card is `pointer-events-none` and cannot scroll, so capping its height would clip content silently rather than reveal it. The utility's shift already keeps it on-screen.

**Gates:** typecheck ✅ · lint ✅ (151 warnings, unchanged from `main` at the same commit — verified by re-running lint on a clean tree) · build ✅ (`NODE_OPTIONS='--max-old-space-size=8192' pnpm build`, completed, exit 0)

Not verified in a browser — this session is headless, so the smoke below is genuinely outstanding. Worth checking the card in both themes while you're there: it carries explicit light/dark classes and the positioning change is inline style only, but the plan flagged it.

## Pre-merge checklist

- [ ] `pnpm build` green locally
- [ ] **Smoke #179:** in a chat long enough to fill the panel, hover the last assistant avatar for ~1s → the provider/model/token card appears fully on-screen, flipped above the avatar rather than clipped at the bottom edge

---
_Generated by [Claude Code](https://claude.ai/code/session_012fT76TPBNYeYrA9oHKZenC)_