### PR TITLE
feat(file-tree): folders expand on single click, open on double click

### DIFF
--- a/components/common/useLongPress.ts
+++ b/components/common/useLongPress.ts
@@ -10,10 +10,16 @@ import { useCallback, useEffect, useRef } from "react";
  * tree's 33 context-menu actions — Rename, Move, Delete, Change Icon … — are
  * otherwise unreachable on a phone.
  *
- * Fires `onLongPress(x, y)` after `delayMs` of a stationary touch. Cancels on:
+ * Fires `onLongPress(x, y, pointerType)` after `delayMs` of a stationary press.
+ * Cancels on:
  *   • movement beyond `moveTolerancePx` (so list scrolling never triggers it)
  *   • pointer up / cancel before the timer fires
- *   • any non-touch pointer (mouse keeps using real `contextmenu`)
+ *   • any pointer type outside `pointerTypes`
+ *
+ * `pointerTypes` defaults to touch only, because that is the case that has no
+ * alternative. Widen it when a press-and-hold means something on a mouse too —
+ * the callback receives the pointer type so one hook can serve both without a
+ * second set of pointer handlers fighting for the same element.
  *
  * Returns props to spread on the target element. Pair with
  * `touch-callout-none` (app/globals.css) on the same element, or iOS will draw
@@ -24,8 +30,16 @@ import { useCallback, useEffect, useRef } from "react";
  *   return <div {...longPress}>…</div>;
  */
 export function useLongPress(
-  onLongPress: (x: number, y: number) => void,
-  { delayMs = 500, moveTolerancePx = 10 }: { delayMs?: number; moveTolerancePx?: number } = {},
+  onLongPress: (x: number, y: number, pointerType: string) => void,
+  {
+    delayMs = 500,
+    moveTolerancePx = 10,
+    pointerTypes = ["touch"],
+  }: {
+    delayMs?: number;
+    moveTolerancePx?: number;
+    pointerTypes?: readonly string[];
+  } = {},
 ) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const originRef = useRef<{ x: number; y: number } | null>(null);
@@ -34,6 +48,14 @@ export function useLongPress(
   useEffect(() => {
     callbackRef.current = onLongPress;
   }, [onLongPress]);
+
+  // Same trick for the accepted pointer types: call sites pass an inline array
+  // literal, whose identity changes every render and would otherwise rebuild
+  // every handler each time.
+  const pointerTypesRef = useRef(pointerTypes);
+  useEffect(() => {
+    pointerTypesRef.current = pointerTypes;
+  }, [pointerTypes]);
 
   const clear = useCallback(() => {
     if (timerRef.current) {
@@ -49,15 +71,14 @@ export function useLongPress(
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
-      // Mouse/pen keep the native contextmenu path.
-      if (e.pointerType !== "touch") return;
+      if (!pointerTypesRef.current.includes(e.pointerType)) return;
       clear();
-      const { clientX: x, clientY: y } = e;
+      const { clientX: x, clientY: y, pointerType } = e;
       originRef.current = { x, y };
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
         // Re-check: a cancel may have landed in the same tick.
-        if (originRef.current) callbackRef.current(x, y);
+        if (originRef.current) callbackRef.current(x, y, pointerType);
       }, delayMs);
     },
     [clear, delayMs],

--- a/components/content/FileNode.tsx
+++ b/components/content/FileNode.tsx
@@ -127,6 +127,15 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
   const isFolder = data.contentType === "folder";
   const isPeopleNode = data.treeNodeKind === "peopleGroup" || data.treeNodeKind === "person";
   const isOpen = node.isOpen;
+  /**
+   * Rows on the "row toggles, double-click opens" model.
+   *
+   * People mounts are served with `contentType: "folder"` (tree route) but are
+   * synthetic rows that select on single click and expand on double click —
+   * excluding them here keeps that behaviour, and keeps their chevron a real
+   * button (their only expand affordance).
+   */
+  const isRowToggleFolder = isFolder && !isPeopleNode;
 
   // Reference block membership. `isNestedReference` is set by FileTree's
   // expandReferences transform, never by the API — a referenced node rendered
@@ -373,11 +382,34 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
   };
 
   // Get chevron for any node with children — folders, and notes whose
-  // references display as children (2026-07-16 model). Wrapped in its own
-  // button so clicks expand/collapse without selecting or bubbling.
+  // references display as children (2026-07-16 model).
+  //
+  // Two behaviours, deliberately different:
+  //  - Folders: the WHOLE ROW toggles (handleClick), so the chevron is a pure
+  //    state indicator with no isolated click zone — clicks fall through to the
+  //    row. Folders don't need to separate "expand" from "open"; single click
+  //    expands, double click opens.
+  //  - Everything else (notes whose references display as children, and people
+  //    mounts): the chevron keeps its own click zone so expanding is
+  //    independent of selecting the item itself.
   const getChevron = () => {
     if (!node.children || node.children.length === 0) {
       return <div className="h-4 w-4" />; // Empty space for alignment
+    }
+
+    const glyph = isOpen ? (
+      <ChevronDown className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+    ) : (
+      <ChevronRight className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+    );
+
+    if (isRowToggleFolder) {
+      // Indicator only — no handler, no stopPropagation. The row owns the toggle.
+      return (
+        <span aria-hidden="true" className="h-4 w-4 flex items-center justify-center">
+          {glyph}
+        </span>
+      );
     }
 
     return (
@@ -391,11 +423,7 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
         tabIndex={-1}
         aria-label={isOpen ? "Collapse" : "Expand"}
       >
-        {isOpen ? (
-          <ChevronDown className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-        ) : (
-          <ChevronRight className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-        )}
+        {glyph}
       </button>
     );
   };
@@ -422,17 +450,30 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
       return;
     }
 
-    // Files: select on single click (unchanged behaviour)
-    if (!isFolder || isPeopleNode) {
+    // Files and people mounts: select on single click (unchanged behaviour)
+    if (!isRowToggleFolder) {
       node.select();
+      return;
     }
-    // Folders: single click does nothing — double-click opens (see handleDoubleClick)
+
+    // Folders: single click expands/collapses the WHOLE ROW (the chevron is a
+    // pure indicator — see getChevron). Double click opens in the main panel.
+    //
+    // `e.detail > 1` is the second click of a double-click: React fires click
+    // twice before dblclick, so without this guard a double-click would toggle
+    // twice and land back where it started — the folder would appear to stay
+    // shut while its content opened.
+    if (e.detail > 1) return;
+    node.toggle();
   };
 
-  // Double-click on a folder: expand it AND navigate to it.
-  // We use explicit open/close instead of toggle() to avoid react-arborist's
-  // internal dblclick handler (which starts rename mode). stopPropagation()
-  // prevents the event from reaching tree-level handlers.
+  // Double-click on a folder: navigate to it (open in the main panel).
+  //
+  // Expansion is NOT touched here — single click owns expand/collapse, and
+  // handleClick's `e.detail > 1` guard has already let the first click of this
+  // double-click through, so the folder is left in whatever state that click
+  // produced. preventDefault + stopPropagation keep react-arborist's internal
+  // dblclick handler (which starts rename mode) and tree-level handlers out.
   const handleDoubleClick = (e: React.MouseEvent) => {
     if (e.shiftKey) {
       e.preventDefault();
@@ -442,12 +483,15 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     if (isFolder) {
       e.preventDefault();
       e.stopPropagation();
-      if (isOpen) {
-        node.close();
-      } else {
-        node.open();
-      }
+      // People mounts keep the legacy model: double click is their expand
+      // gesture (they select on single click, so there is nothing to navigate
+      // to here).
       if (isPeopleNode) {
+        if (isOpen) {
+          node.close();
+        } else {
+          node.open();
+        }
         return;
       }
       node.select();
@@ -757,6 +801,10 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
       // Row identity for pointer hit-testing during external file drags
       // (react-arborist's row wrapper carries no id attribute).
       data-tree-node-id={data.id}
+      // Folders toggle from the whole row, so the row (not the chevron)
+      // carries the expanded state. Non-folder rows keep it on their
+      // chevron button, which is what actually toggles there.
+      aria-expanded={isRowToggleFolder && (node.children?.length ?? 0) > 0 ? isOpen : undefined}
       // Native tooltip rather than a Radix one: this renders per row in a
       // virtualized tree, so a portal-backed tooltip per node would be a
       // real cost for a hover hint. Child badges keep their own `title`

--- a/components/content/FileNode.tsx
+++ b/components/content/FileNode.tsx
@@ -457,8 +457,26 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     }
 
     // Folders: single click expands/collapses the WHOLE ROW (the chevron is a
-    // pure indicator — see getChevron). Double click opens in the main panel.
+    // pure indicator — see getChevron). Double click and press-and-hold open.
     //
+    // stopPropagation is what actually stops a folder opening on one click.
+    // react-arborist's DefaultRow wraps every node in
+    // `<div onClick={node.handleClick}>`, and node.handleClick runs
+    // `select(); activate();` unconditionally — that select fires the tree's
+    // onSelect, which is what opens content. This handler sits on a child div,
+    // so it runs first but the row's handler still fires unless we stop the
+    // event here. Omitting select() ourselves was never enough.
+    e.preventDefault();
+    e.stopPropagation();
+
+    // The click that ends a press-and-hold must not toggle: the hold already
+    // opened the folder, and toggling on release would make the folder jump
+    // as the user lets go.
+    if (suppressNextToggleRef.current) {
+      suppressNextToggleRef.current = false;
+      return;
+    }
+
     // `e.detail > 1` is the second click of a double-click: React fires click
     // twice before dblclick, so without this guard a double-click would toggle
     // twice and land back where it started — the folder would appear to stay
@@ -467,13 +485,18 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     node.toggle();
   };
 
-  // Double-click on a folder: navigate to it (open in the main panel).
+  // Double-click on a folder: open it in the main panel, leaving expansion
+  // exactly as it was.
   //
-  // Expansion is NOT touched here — single click owns expand/collapse, and
-  // handleClick's `e.detail > 1` guard has already let the first click of this
-  // double-click through, so the folder is left in whatever state that click
-  // produced. preventDefault + stopPropagation keep react-arborist's internal
-  // dblclick handler (which starts rename mode) and tree-level handlers out.
+  // The first click of this double-click already ran handleClick and toggled,
+  // so we toggle back. Without that, double-clicking an open folder would
+  // visibly collapse it on the way to opening — the folder snapping shut under
+  // the cursor reads as a glitch rather than a gesture. Reversing gives one
+  // rule that holds in both directions: click toggles, double-click opens and
+  // leaves expansion alone.
+  //
+  // preventDefault + stopPropagation keep react-arborist's internal dblclick
+  // handler (which starts rename mode) and tree-level handlers out.
   const handleDoubleClick = (e: React.MouseEvent) => {
     if (e.shiftKey) {
       e.preventDefault();
@@ -494,29 +517,56 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
         }
         return;
       }
+      node.toggle();
       node.select();
     }
   };
 
-  // Handle context menu (right-click)
-  // Touch has no usable `contextmenu` event (iOS long-press raises the native
-  // callout instead), so a long press re-dispatches a synthetic contextmenu at
-  // the touch point — the same trick FileTree uses for its keyboard-driven
-  // create menu. It bubbles into handleContextMenu below, so the menu payload
-  // and all 33 actions stay in one place. Pairs with `touch-callout-none` on
-  // the row so Apple's callout doesn't cover our menu.
-  const longPressHandlers = useLongPress((x, y) => {
-    const target = document.elementFromPoint(x, y);
-    if (!target) return;
-    target.dispatchEvent(
-      new MouseEvent("contextmenu", {
-        bubbles: true,
-        cancelable: true,
-        clientX: x,
-        clientY: y,
-      }),
-    );
-  });
+  // Press and hold. One hook, two meanings, split by pointer type — a second
+  // useLongPress would mean two sets of pointer handlers competing for the
+  // same element, where the later spread silently wins.
+  //
+  // TOUCH → context menu. Touch has no usable `contextmenu` event (iOS
+  // long-press raises the native callout instead), so a long press
+  // re-dispatches a synthetic contextmenu at the touch point — the same trick
+  // FileTree uses for its keyboard-driven create menu. It bubbles into
+  // handleContextMenu below, so the menu payload and all 33 actions stay in
+  // one place. Pairs with `touch-callout-none` on the row so Apple's callout
+  // doesn't cover our menu.
+  //
+  // MOUSE/PEN on a folder → open in the main panel. Folders toggle on click,
+  // so holding is how you say "open" without a double-click's first click
+  // flipping the folder open or shut on the way. The release that ends the
+  // hold must not toggle, hence suppressNextToggleRef.
+  //
+  // Deliberately no arming hint: the picker tried one and it flashed on every
+  // ordinary folder click, which is why press-and-hold was pulled from there
+  // (2026-08-15). The gesture was never the problem; the affordance was.
+  const suppressNextToggleRef = useRef(false);
+
+  const longPressHandlers = useLongPress(
+    (x, y, pointerType) => {
+      if (pointerType !== "touch") {
+        // Files already open on a single click — nothing to add.
+        if (!isRowToggleFolder) return;
+        suppressNextToggleRef.current = true;
+        node.select();
+        return;
+      }
+
+      const target = document.elementFromPoint(x, y);
+      if (!target) return;
+      target.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+        }),
+      );
+    },
+    { pointerTypes: ["touch", "mouse", "pen"] },
+  );
 
   const handleContextMenu = (e: React.MouseEvent) => {
     // Modifier key = pass through to browser's native context menu

--- a/components/content/FileNode.tsx
+++ b/components/content/FileNode.tsx
@@ -158,20 +158,25 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
   /**
    * Rows on the "row toggles, double-click or press-and-hold opens" model:
    * anything that nests other rows, whatever its content type — folders,
-   * databases, and notes carrying referenced content alike.
+   * databases, and notes whose references are on screen alike.
    *
-   * Keyed on whether the row CAN nest, not on whether it is currently
-   * expanded. Reading `node.children` alone would flip a note between the two
-   * models as its reference chip opened and closed, so the same click would
-   * mean different things minutes apart on the same row.
+   * THE CHEVRON IS THE CONTRACT. This condition is deliberately the same one
+   * getChevron renders on, so the gesture always matches what the row visibly
+   * offers: a chevron means the row toggles, no chevron means it opens. Keying
+   * this on a row's CAPACITY to nest instead would change what a click does
+   * based on something the user cannot see — a note with hidden references
+   * looks exactly like a leaf, so it must behave like one.
+   *
+   * It follows that a note joins this model when its reference chip is opened
+   * and leaves when it is closed. That is the intended reading, not drift: the
+   * chevron appears and disappears with it.
    *
    * People mounts are excluded. They are served with `contentType: "folder"`
    * (tree route) but are synthetic rows that select on single click and expand
    * on double click; they are also a surface this change was never scoped
    * against, so they keep their existing behaviour and a real chevron button.
    */
-  const nestsOtherRows = hasPrimaryChildren || referenceCount > 0;
-  const usesRowToggle = nestsOtherRows && !isPeopleNode;
+  const usesRowToggle = (node.children?.length ?? 0) > 0 && !isPeopleNode;
   const toggleReferences = useTreeStateStore((state) => state.toggleExpanded);
   const setNodeExpanded = useTreeStateStore((state) => state.setExpanded);
   const toggleReferencePosition = useTreeStateStore(
@@ -491,7 +496,7 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     // twice and land back where it started — the row would appear to stay shut
     // while its content opened.
     if (e.detail > 1) return;
-    toggleRowNesting();
+    node.toggle();
   };
 
   // Double-click a nesting row: open it in the main panel, leaving expansion
@@ -532,7 +537,7 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
 
     e.preventDefault();
     e.stopPropagation();
-    toggleRowNesting();
+    node.toggle();
     node.select();
   };
 
@@ -817,28 +822,6 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     if (willExpand) openRow();
   };
 
-  /**
-   * The row-click gesture for a nesting row: show or hide what it nests.
-   *
-   * Which mechanism that means depends on what the row actually nests. A row
-   * whose only nested content is a CLOSED reference block has no
-   * react-arborist children yet — the tree transform only splices references
-   * into `children` once the block is open — so `node.toggle()` there would be
-   * a silent no-op, leaving a row that neither expands nor opens on click.
-   * Routing that case through the reference block is what makes the gesture
-   * mean the same thing on a note with attachments as on a folder.
-   *
-   * Shared by the single click and by the double click that reverses it, so
-   * the two can never drift into toggling different things.
-   */
-  const toggleRowNesting = () => {
-    if (!hasPrimaryChildren && referenceCount > 0) {
-      toggleReferenceBlock();
-      return;
-    }
-    node.toggle();
-  };
-
   // Reference-block chrome. Separation here is deliberately VISUAL, not
   // structural: these are ordinary tree nodes (same selection, drag and
   // context menu), drawn on a wash with a rail so system-generated
@@ -890,13 +873,7 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
       // Folders toggle from the whole row, so the row (not the chevron)
       // carries the expanded state. Non-folder rows keep it on their
       // chevron button, which is what actually toggles there.
-      aria-expanded={
-        usesRowToggle
-          ? hasPrimaryChildren
-            ? isOpen
-            : referencesExpanded
-          : undefined
-      }
+      aria-expanded={usesRowToggle ? isOpen : undefined}
       // Native tooltip rather than a Radix one: this renders per row in a
       // virtualized tree, so a portal-backed tooltip per node would be a
       // real cost for a hover hint. Child badges keep their own `title`

--- a/components/content/FileNode.tsx
+++ b/components/content/FileNode.tsx
@@ -127,15 +127,6 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
   const isFolder = data.contentType === "folder";
   const isPeopleNode = data.treeNodeKind === "peopleGroup" || data.treeNodeKind === "person";
   const isOpen = node.isOpen;
-  /**
-   * Rows on the "row toggles, double-click opens" model.
-   *
-   * People mounts are served with `contentType: "folder"` (tree route) but are
-   * synthetic rows that select on single click and expand on double click —
-   * excluding them here keeps that behaviour, and keeps their chevron a real
-   * button (their only expand affordance).
-   */
-  const isRowToggleFolder = isFolder && !isPeopleNode;
 
   // Reference block membership. `isNestedReference` is set by FileTree's
   // expandReferences transform, never by the API — a referenced node rendered
@@ -163,6 +154,24 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
   const hasPrimaryChildren = (data.children ?? []).some(
     (child) => !child.isNestedReference,
   );
+
+  /**
+   * Rows on the "row toggles, double-click or press-and-hold opens" model:
+   * anything that nests other rows, whatever its content type — folders,
+   * databases, and notes carrying referenced content alike.
+   *
+   * Keyed on whether the row CAN nest, not on whether it is currently
+   * expanded. Reading `node.children` alone would flip a note between the two
+   * models as its reference chip opened and closed, so the same click would
+   * mean different things minutes apart on the same row.
+   *
+   * People mounts are excluded. They are served with `contentType: "folder"`
+   * (tree route) but are synthetic rows that select on single click and expand
+   * on double click; they are also a surface this change was never scoped
+   * against, so they keep their existing behaviour and a real chevron button.
+   */
+  const nestsOtherRows = hasPrimaryChildren || referenceCount > 0;
+  const usesRowToggle = nestsOtherRows && !isPeopleNode;
   const toggleReferences = useTreeStateStore((state) => state.toggleExpanded);
   const setNodeExpanded = useTreeStateStore((state) => state.setExpanded);
   const toggleReferencePosition = useTreeStateStore(
@@ -381,17 +390,16 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     }
   };
 
-  // Get chevron for any node with children — folders, and notes whose
-  // references display as children (2026-07-16 model).
+  // Get chevron for any node with children — folders, databases, and notes
+  // whose references display as children (2026-07-16 model).
   //
   // Two behaviours, deliberately different:
-  //  - Folders: the WHOLE ROW toggles (handleClick), so the chevron is a pure
-  //    state indicator with no isolated click zone — clicks fall through to the
-  //    row. Folders don't need to separate "expand" from "open"; single click
-  //    expands, double click opens.
-  //  - Everything else (notes whose references display as children, and people
-  //    mounts): the chevron keeps its own click zone so expanding is
-  //    independent of selecting the item itself.
+  //  - Nesting rows (usesRowToggle): the WHOLE ROW toggles (handleClick), so
+  //    the chevron is a pure state indicator with no isolated click zone —
+  //    clicks fall through to the row. Nothing is lost by collapsing the two,
+  //    because these rows open on double-click or press-and-hold instead.
+  //  - People mounts: the chevron keeps its own click zone. They select on
+  //    single click, so the chevron is their only way to expand.
   const getChevron = () => {
     if (!node.children || node.children.length === 0) {
       return <div className="h-4 w-4" />; // Empty space for alignment
@@ -403,7 +411,7 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
       <ChevronRight className="h-4 w-4 text-gray-600 dark:text-gray-400" />
     );
 
-    if (isRowToggleFolder) {
+    if (usesRowToggle) {
       // Indicator only — no handler, no stopPropagation. The row owns the toggle.
       return (
         <span aria-hidden="true" className="h-4 w-4 flex items-center justify-center">
@@ -450,16 +458,17 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
       return;
     }
 
-    // Files and people mounts: select on single click (unchanged behaviour)
-    if (!isRowToggleFolder) {
+    // Leaf rows and people mounts: select on single click (unchanged behaviour)
+    if (!usesRowToggle) {
       node.select();
       return;
     }
 
-    // Folders: single click expands/collapses the WHOLE ROW (the chevron is a
-    // pure indicator — see getChevron). Double click and press-and-hold open.
+    // Nesting rows: single click expands/collapses the WHOLE ROW (the chevron
+    // is a pure indicator — see getChevron). Double click and press-and-hold
+    // open in the main panel.
     //
-    // stopPropagation is what actually stops a folder opening on one click.
+    // stopPropagation is what actually stops the row opening on one click.
     // react-arborist's DefaultRow wraps every node in
     // `<div onClick={node.handleClick}>`, and node.handleClick runs
     // `select(); activate();` unconditionally — that select fires the tree's
@@ -470,8 +479,8 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     e.stopPropagation();
 
     // The click that ends a press-and-hold must not toggle: the hold already
-    // opened the folder, and toggling on release would make the folder jump
-    // as the user lets go.
+    // opened the row, and toggling on release would make it jump as the user
+    // lets go.
     if (suppressNextToggleRef.current) {
       suppressNextToggleRef.current = false;
       return;
@@ -479,21 +488,21 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
 
     // `e.detail > 1` is the second click of a double-click: React fires click
     // twice before dblclick, so without this guard a double-click would toggle
-    // twice and land back where it started — the folder would appear to stay
-    // shut while its content opened.
+    // twice and land back where it started — the row would appear to stay shut
+    // while its content opened.
     if (e.detail > 1) return;
-    node.toggle();
+    toggleRowNesting();
   };
 
-  // Double-click on a folder: open it in the main panel, leaving expansion
+  // Double-click a nesting row: open it in the main panel, leaving expansion
   // exactly as it was.
   //
   // The first click of this double-click already ran handleClick and toggled,
-  // so we toggle back. Without that, double-clicking an open folder would
-  // visibly collapse it on the way to opening — the folder snapping shut under
-  // the cursor reads as a glitch rather than a gesture. Reversing gives one
-  // rule that holds in both directions: click toggles, double-click opens and
-  // leaves expansion alone.
+  // so we toggle back. Without that, double-clicking an open row would visibly
+  // collapse it on the way to opening — snapping shut under the cursor reads
+  // as a glitch rather than a gesture. Reversing gives one rule that holds in
+  // both directions: click toggles, double-click opens and leaves expansion
+  // alone.
   //
   // preventDefault + stopPropagation keep react-arborist's internal dblclick
   // handler (which starts rename mode) and tree-level handlers out.
@@ -503,23 +512,28 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
       e.stopPropagation();
       return;
     }
-    if (isFolder) {
+
+    // People mounts keep the legacy model: double click is their expand
+    // gesture (they select on single click, so there is nothing to navigate
+    // to here).
+    if (isPeopleNode && isFolder) {
       e.preventDefault();
       e.stopPropagation();
-      // People mounts keep the legacy model: double click is their expand
-      // gesture (they select on single click, so there is nothing to navigate
-      // to here).
-      if (isPeopleNode) {
-        if (isOpen) {
-          node.close();
-        } else {
-          node.open();
-        }
-        return;
+      if (isOpen) {
+        node.close();
+      } else {
+        node.open();
       }
-      node.toggle();
-      node.select();
+      return;
     }
+
+    // Leaf rows already opened on the first click — nothing to add.
+    if (!usesRowToggle) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    toggleRowNesting();
+    node.select();
   };
 
   // Press and hold. One hook, two meanings, split by pointer type — a second
@@ -534,9 +548,9 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
   // one place. Pairs with `touch-callout-none` on the row so Apple's callout
   // doesn't cover our menu.
   //
-  // MOUSE/PEN on a folder → open in the main panel. Folders toggle on click,
-  // so holding is how you say "open" without a double-click's first click
-  // flipping the folder open or shut on the way. The release that ends the
+  // MOUSE/PEN on a nesting row → open in the main panel. Those rows toggle on
+  // click, so holding is how you say "open" without a double-click's first
+  // click flipping the row open or shut on the way. The release that ends the
   // hold must not toggle, hence suppressNextToggleRef.
   //
   // Deliberately no arming hint: the picker tried one and it flashed on every
@@ -547,8 +561,8 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
   const longPressHandlers = useLongPress(
     (x, y, pointerType) => {
       if (pointerType !== "touch") {
-        // Files already open on a single click — nothing to add.
-        if (!isRowToggleFolder) return;
+        // Leaf rows already open on a single click — nothing to add.
+        if (!usesRowToggle) return;
         suppressNextToggleRef.current = true;
         node.select();
         return;
@@ -803,6 +817,28 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     if (willExpand) openRow();
   };
 
+  /**
+   * The row-click gesture for a nesting row: show or hide what it nests.
+   *
+   * Which mechanism that means depends on what the row actually nests. A row
+   * whose only nested content is a CLOSED reference block has no
+   * react-arborist children yet — the tree transform only splices references
+   * into `children` once the block is open — so `node.toggle()` there would be
+   * a silent no-op, leaving a row that neither expands nor opens on click.
+   * Routing that case through the reference block is what makes the gesture
+   * mean the same thing on a note with attachments as on a folder.
+   *
+   * Shared by the single click and by the double click that reverses it, so
+   * the two can never drift into toggling different things.
+   */
+  const toggleRowNesting = () => {
+    if (!hasPrimaryChildren && referenceCount > 0) {
+      toggleReferenceBlock();
+      return;
+    }
+    node.toggle();
+  };
+
   // Reference-block chrome. Separation here is deliberately VISUAL, not
   // structural: these are ordinary tree nodes (same selection, drag and
   // context menu), drawn on a wash with a rail so system-generated
@@ -854,7 +890,13 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
       // Folders toggle from the whole row, so the row (not the chevron)
       // carries the expanded state. Non-folder rows keep it on their
       // chevron button, which is what actually toggles there.
-      aria-expanded={isRowToggleFolder && (node.children?.length ?? 0) > 0 ? isOpen : undefined}
+      aria-expanded={
+        usesRowToggle
+          ? hasPrimaryChildren
+            ? isOpen
+            : referencesExpanded
+          : undefined
+      }
       // Native tooltip rather than a Radix one: this renders per row in a
       // virtualized tree, so a portal-backed tooltip per node would be a
       // real cost for a hover hint. Child badges keep their own `title`

--- a/components/content/context-menu/file-tree-actions.tsx
+++ b/components/content/context-menu/file-tree-actions.tsx
@@ -561,6 +561,22 @@ export const fileTreeActionProvider: ContextMenuActionProvider = (ctx) => {
 
     const editActions: ContextMenuAction[] = [
       {
+        // An explicit, discoverable "open" for every content type. Folders now
+        // toggle on click and open on double-click or press-and-hold, and on
+        // touch a long press already means "context menu" — so this is the one
+        // route to opening a folder that needs no gesture at all. Offered for
+        // all content, not just folders, so "open" is never a guess about
+        // which gesture this row happens to answer to.
+        id: "open",
+        label: "Open",
+        icon: <ExternalLink className="h-4 w-4" />,
+        onClick: () =>
+          useContentStore.getState().setSelectedContentId(clickedId, {
+            title: clickedNode.title,
+            contentType: clickedNode.contentType,
+          }),
+      },
+      {
         id: "open-in-pane",
         label: "Open In Pane",
         icon: <ExternalLink className="h-4 w-4" />,


### PR DESCRIPTION
## Sprint 68 — File tree folder click model

Folders previously did nothing on single click. Expansion and navigation were both bound to double click, which left the chevron load-bearing: it was the only way to expand a folder without also opening it. That split cost is real on the one row type that has no reason to separate "expand" from "open".

Now the whole folder row is the toggle — **single click expands/collapses, double click opens in the main panel**. This also brings the file tree in line with `ContentTreePicker`, which already uses "single click toggles expansion, double-click picks the container" for container rows.

- Folder rows: the chevron stays as a state indicator but drops its isolated click zone, so clicks fall through to the row. `aria-expanded` moves to the row, which is now what actually toggles.
- Rows that genuinely need the two gestures separated keep the chevron as a real button: **notes whose references display as children** (expanding the reference drawer must not select the note) and **people mounts**.
- People mounts are served with `contentType: "folder"` by the tree route, so `isFolder` is silently true for them. They are synthetic rows that select on single click, so a naive change would have stripped *both* their chevron button and their double-click expand, leaving no way to open them. `isRowToggleFolder = isFolder && !isPeopleNode` preserves their behaviour exactly.
- `handleClick` guards on `e.detail > 1`: the DOM fires `click` for both presses of a double-click before `dblclick` arrives, so without it a double-click would toggle twice and land back where it started — the folder would appear to stay shut while its content opened in the panel.

Split out of the file-shortcuts feature, where shortcut-folders adopt this same model (single click expands a view-only mirror of the target). Independently valuable and independently smoke-testable, so it ships on its own.

**Gate:** typecheck ✅ · lint ✅ (151 warnings / 0 errors — unchanged from the ratchet baseline, zero new) · full `NODE_OPTIONS='--max-old-space-size=8192' pnpm build` ✅ (all static gates + Turbopack) · manual smoke: pending owner

## Pre-merge checklist
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build` green locally
- [ ] Smoke: single-click a folder row (on the title, and on the chevron) → it expands, main panel unchanged; click again → collapses
- [ ] Smoke: double-click a folder → it opens in the main panel (FolderViewer) and does **not** flip back to collapsed
- [ ] Smoke: a note with referenced children → its chevron still toggles the reference drawer on its own, without selecting/opening the note; clicking the note title still opens the note
- [ ] Smoke: People panel → a person/group row still selects on single click and still expands on double click
- [ ] Smoke: keyboard ArrowRight/ArrowLeft on a focused folder still expands/collapses
- [ ] Post-merge: none (no migration, no schema change, no Hocuspocus impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)