### PR TITLE
fix(ai): keep OpenAI transcripts self-contained instead of item references

### DIFF
--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -57,6 +57,7 @@ import {
   getModelMeta,
 } from "@/lib/domain/ai/providers/catalog";
 import {
+  stripOpenAIItemReferences,
   stripReasoningForResend,
   supersedeIterationHistory,
 } from "@/lib/domain/ai/context-diet";
@@ -1390,10 +1391,16 @@ export async function POST(request: Request) {
       //     no resend value for non-Anthropic providers, yet
       //     convertToModelMessages forwards them as input verbatim (~100k
       //     chars replayed per request in the measured DeepSeek run).
+      //   - stripOpenAIItemReferences: dead `openai.itemId` pointers replay as
+      //     item_reference against an expired server-side store, 400ing every
+      //     send in the conversation (#193). Heals transcripts poisoned before
+      //     the `store: false` option below existed.
       const resolvedMessages = resolveAttachmentsForModel(
-        stripReasoningForResend(
-          supersedeIterationHistory(repairedMessages),
-          executedVendorId,
+        stripOpenAIItemReferences(
+          stripReasoningForResend(
+            supersedeIterationHistory(repairedMessages),
+            executedVendorId,
+          ),
         ),
         executedVendorId,
         audioCapable,
@@ -2186,8 +2193,21 @@ export async function POST(request: Request) {
         executedBareModelId,
         { mechanicalRun: itemIterationBudget != null },
       );
+      // OpenAI Responses stores every item server-side while `store` keeps its
+      // default of true, and @ai-sdk/openai then replays those items as
+      // { type: "item_reference" } instead of the text we hold verbatim in
+      // ConversationMessage.parts. Items expire after ~30 days (a key rotation
+      // re-scopes the store sooner), after which the reference resolves to
+      // nothing and the conversation is permanently unsendable (#193). Keep the
+      // request self-contained. Deliberately NOT a buildProviderOptions branch:
+      // that function's return doubles as the "this turn had a reasoning
+      // config" signal for describeReasoningConfig below, and a storage knob is
+      // not a reasoning config.
+      const storageProviderOptions: AIProviderOptions | undefined =
+        executedVendorId === "openai" ? { openai: { store: false } } : undefined;
       const providerOptions = mergeAIProviderOptions(
         reasoningProviderOptions,
+        storageProviderOptions,
         promptCachePolicy.providerOptions,
       );
 

--- a/lib/domain/ai/context-diet.ts
+++ b/lib/domain/ai/context-diet.ts
@@ -39,6 +39,84 @@ export function stripReasoningForResend(
   });
 }
 
+// ── OpenAI item references (#193) ───────────────────────────────────────────
+
+/** Provider-metadata namespace the OpenAI Responses API reads item ids from. */
+const OPENAI_METADATA_NAMESPACE = "openai";
+
+/**
+ * The metadata carriers convertToModelMessages forwards as `providerOptions`
+ * on assistant text/reasoning parts (`providerMetadata`), tool calls
+ * (`callProviderMetadata`) and tool results (`resultProviderMetadata`). All
+ * three can carry an `openai.itemId`, so all three have to be cleaned.
+ */
+const ITEM_ID_METADATA_FIELDS = [
+  "providerMetadata",
+  "callProviderMetadata",
+  "resultProviderMetadata",
+] as const;
+
+/** Returns a cleaned copy of `part`, or null when it carried no item id. */
+function withoutOpenAIItemId(
+  part: UIMessage["parts"][number],
+): UIMessage["parts"][number] | null {
+  let next: Record<string, unknown> | null = null;
+  for (const field of ITEM_ID_METADATA_FIELDS) {
+    const metadata = (part as Record<string, unknown>)[field];
+    if (!metadata || typeof metadata !== "object") continue;
+    const namespace = (metadata as Record<string, unknown>)[
+      OPENAI_METADATA_NAMESPACE
+    ];
+    if (!namespace || typeof namespace !== "object") continue;
+    if (!("itemId" in namespace)) continue;
+    const { itemId: _itemId, ...rest } = namespace as Record<string, unknown>;
+    next ??= { ...(part as Record<string, unknown>) };
+    next[field] = {
+      ...(metadata as Record<string, unknown>),
+      [OPENAI_METADATA_NAMESPACE]: rest,
+    };
+  }
+  return next as UIMessage["parts"][number] | null;
+}
+
+/**
+ * Drop `openai.itemId` from RESENT message parts so the transcript replays as
+ * the text we are holding rather than as a pointer to OpenAI's server-side
+ * item store.
+ *
+ * With the Responses API's `store` defaulting to true, @ai-sdk/openai emits
+ * `{ type: "item_reference", id }` for any part carrying an item id. Those
+ * items expire after ~30 days — and a key rotation or a ZDR policy kills them
+ * sooner — after which the reference resolves to nothing and every send in
+ * that conversation is rejected with `Item with id 'msg_…' not found` (#193).
+ *
+ * The chat route now also sends `store: false` for OpenAI, which stops NEW
+ * transcripts being poisoned; this heals the ones already carrying dead ids,
+ * which is every OpenAI conversation predating that change. Stripping is
+ * absence-safe in both directions: with `store: false` the id is never a
+ * usable reference, and no other vendor reads the `openai` namespace — so the
+ * transform is unconditional rather than gated on the executed vendor, and
+ * keeps healing a transcript whichever route later reaches it.
+ *
+ * Only `itemId` is removed; sibling keys in the namespace (`phase`, cache
+ * hints) are preserved.
+ *
+ * Model-path only, same contract as the transforms above: the persisted
+ * transcript and `originalMessages` keep every byte.
+ */
+export function stripOpenAIItemReferences(messages: UIMessage[]): UIMessage[] {
+  return messages.map((m) => {
+    let changed = false;
+    const parts = m.parts.map((part) => {
+      const stripped = withoutOpenAIItemId(part);
+      if (!stripped) return part;
+      changed = true;
+      return stripped;
+    });
+    return changed ? { ...m, parts } : m;
+  });
+}
+
 // ── Snapshot supersession (S8) ──────────────────────────────────────────────
 
 /** Raw-perception outputs eligible for supersession — bulky page data whose


### PR DESCRIPTION
## Bug Squash 2026-W36 — #193

OpenAI-backed conversations became permanently unsendable after ~30 days — every send returned an upstream 400, `Item with id 'msg_…' not found`. This sends `store: false` for OpenAI turns so new transcripts stay self-contained, and strips the dead `openai.itemId` pointers out of the resend path so already-poisoned conversations heal.

- `app/api/ai/chat/route.ts` — send `{ openai: { store: false } }` for OpenAI-executed turns, merged through `mergeAIProviderOptions` alongside the reasoning and prompt-cache options.
- `lib/domain/ai/context-diet.ts` — new `stripOpenAIItemReferences`, removing `openai.itemId` from `providerMetadata`, `callProviderMetadata` and `resultProviderMetadata`. Sibling keys in the namespace (`phase`, cache hints) are preserved.
- Wired into the model-message chain beside `stripReasoningForResend` / `supersedeIterationHistory`, under the same contract: **model path only** — the persisted transcript and `originalMessages` keep every byte.

Diagnosis: the Responses API's `store` option defaults to true, so `@ai-sdk/openai` replays any part carrying an item id as `{ type: "item_reference", id }` rather than the text held verbatim in `ConversationMessage.parts` — `node_modules/@ai-sdk/openai/dist/index.mjs:2733` (`if (store && id != null) input.push({ type: "item_reference", id })`), with the same guard on tool calls at `:2746` and tool results at `:2857`. Once OpenAI's ~30-day item retention expires — or a key rotation re-scopes the store — the reference resolves to nothing and the request is rejected. `buildProviderOptions` at `app/api/ai/chat/route.ts:83` had no `openai` branch, and its early return at `:98` (`if (!model || !model.reasoning) return undefined`) meant non-reasoning models could never reach one.

### Deviations from the plan doc

- The plan put the `store: false` branch **inside** `buildProviderOptions`, above the `:98` early return. I put it in a separate `storageProviderOptions` at the call site instead: that function's return doubles as the "this turn had a reasoning config" signal for `describeReasoningConfig` at `:2214` (`reasoningProviderOptions !== undefined`), so an `openai` branch there would have made every OpenAI turn falsely report `openai:reasoning` in its persisted segment diagnostics. `mergeAIProviderOptions` is variadic, so the merge is unchanged.
- The strip is **unconditional** rather than gated on the executed vendor. No other vendor reads the `openai` namespace, and with `store: false` the id is never a usable reference — so this keeps healing a transcript whichever route later reaches it (direct connection or namespaced gateway id).
- The plan named `providerMetadata` and `callProviderMetadata`; I also clean `resultProviderMetadata`, which `convertToModelMessages` forwards as `providerOptions` on tool-result parts (`node_modules/ai/dist/index.mjs:8566`). Leaving it would have left a third carrier of the poisoned id.

**Gates:** typecheck ✅ · lint ✅ (151 warnings, unchanged from `main`, ratchet 175; both changed files lint clean) · `ai:drift:check` ✅ · `ai:pricing:check` ✅ · `ai:matrix:check` ✅ · `next build --turbopack` ✅ · **`pnpm build` ❌ — fails at `model-routing:check`, pre-existing on `main`** (see below)

`pnpm build` does not reach `next build` because `pnpm model-routing:check` (gate 15 of 20) fails. Verified pre-existing: the same assertion fails identically on a clean `main` checkout with my changes stashed —

```
scripts/validate-model-routing.ts:296
  actual:   'by charter "Job Hunt" (Phase 3)'
  expected: 'by playbook "Job Hunt" (Phase 3)'
```

That is fallout from the charters rename (`aec686f` / `53b3459`), untouched by this PR and left alone per the minimal-change rule. I ran every remaining gate and `next build --turbopack` manually instead; all passed. **Not fixed here — flagging for you.**

Least sure of: whether `store: false` has a knock-on effect for OpenAI reasoning models, which lose server-side reasoning-state reuse across turns. The plan judged that acceptable (reasoning parts are already stripped on resend for non-Anthropic vendors), and I agree, but it is the part worth watching in the smoke test.

## Pre-merge checklist

- [ ] `pnpm build` green locally
- [ ] **Smoke #193:** rotate the OpenAI key in Settings → AI, then send a message into an OpenAI conversation that already has assistant replies → the reply streams normally instead of failing with "Item with id 'msg_…' not found"
- [ ] **Smoke #193b:** send into a brand-new OpenAI conversation, then reload the page and send again → both turns stream normally, and the second request carries full message text rather than item references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYjfHSFyP8Q9MhzP9FQ9mR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYjfHSFyP8Q9MhzP9FQ9mR)_