### PR TITLE
fix(main-panel): keep the tab context menu inside the viewport

### DIFF
--- a/components/content/headers/MainPanelHeader.tsx
+++ b/components/content/headers/MainPanelHeader.tsx
@@ -8,6 +8,7 @@ import { requestOverlayOpen } from "@/lib/domain/browser-extension/panel-bridge"
 import { X } from "lucide-react";
 import { toast } from "sonner";
 import { getSurfaceStyles } from "@/lib/design/system";
+import { calculateMenuPosition } from "@/lib/core/menu-positioning";
 import {
   getPaneLabel,
   useContentStore,
@@ -302,6 +303,15 @@ export function MainPanelHeader({
     x: number;
     y: number;
   } | null>(null);
+  // Boundary-checked placement for the tab menu, filled in after the hidden
+  // measure pass below. Null means "not measured yet" — render hidden at the
+  // raw pointer position.
+  const [tabMenuPosition, setTabMenuPosition] = useState<{
+    x: number;
+    y: number;
+    maxHeight: number;
+  } | null>(null);
+  const tabMenuRef = useRef<HTMLDivElement>(null);
   const [presenceByContentId, setPresenceByContentId] = useState<
     Record<string, TabPresenceSession[]>
   >({});
@@ -594,6 +604,28 @@ export function MainPanelHeader({
     };
   }, [tabMenu]);
 
+  // Two-phase placement (same recipe as ContextMenu): the menu renders hidden
+  // at the raw pointer position, gets measured, then moves to a spot that
+  // clears the viewport edges. Anchoring a 224px-wide menu at the pointer put
+  // it off-screen for the rightmost tab, which is by definition within its own
+  // width of the right edge.
+  useEffect(() => {
+    if (!tabMenu) return;
+
+    const timeoutId = setTimeout(() => {
+      const menuRect = tabMenuRef.current?.getBoundingClientRect();
+      if (!menuRect) return;
+      setTabMenuPosition(
+        calculateMenuPosition({
+          triggerPosition: { x: tabMenu.x, y: tabMenu.y },
+          menuDimensions: { width: menuRect.width, height: menuRect.height },
+        })
+      );
+    }, 0);
+
+    return () => clearTimeout(timeoutId);
+  }, [tabMenu]);
+
   // Close the active tab. Cmd+W and Cmd+Shift+W never reach the page — browsers
   // reserve them for Close Tab / Close Window — so we bind the two W chords that
   // do survive:
@@ -743,6 +775,9 @@ export function MainPanelHeader({
                 onContextMenu={(event) => {
                   if (shellTabMenuSections.length === 0 && !isPanelEmbed) return;
                   event.preventDefault();
+                  // Clear the previous placement so the new menu measures from
+                  // scratch instead of flashing at the last tab's position.
+                  setTabMenuPosition(null);
                   setTabMenu({ tabId: tab.id, x: event.clientX, y: event.clientY });
                 }}
                 onDragStart={(event) => {
@@ -836,40 +871,55 @@ export function MainPanelHeader({
           ) : null}
         </div>
       </div>
-      {tabMenu && tabMenuTab ? (
-        <div
-          className="fixed z-50 min-w-56 rounded-md border border-white/10 bg-white/95 p-1 text-sm text-gray-900 shadow-lg backdrop-blur-sm dark:bg-gray-900/95 dark:text-gray-100"
-          style={{ left: tabMenu.x, top: tabMenu.y }}
-          onClick={(event) => event.stopPropagation()}
-        >
-          {/* Side panel only: project this tab onto the page. Drag-to-corner
-              gives precise placement; this is the one-click default. */}
-          {isPanelEmbed && tabMenuTab.contentId ? (
-            <>
-              <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                Page
-              </div>
-              <button
-                type="button"
-                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/10"
-                onClick={() => {
-                  requestOverlayOpen(tabMenuTab.contentId as string);
-                  setTabMenu(null);
-                }}
-              >
-                Open as overlay
-              </button>
-            </>
-          ) : null}
-          {shellTabMenuSections.map((Section) =>
-            createElement(Section, {
-              key: Section.displayName ?? Section.name,
-              tab: tabMenuTab,
-              closeMenu: () => setTabMenu(null),
-            })
-          )}
-        </div>
-      ) : null}
+      {/* Portalled to the body so the menu escapes the header's stacking
+          context — as a header child its z-50 could not paint above an
+          expanded right sidebar. */}
+      {tabMenu && tabMenuTab && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              ref={tabMenuRef}
+              className="fixed z-[120] min-w-56 overflow-y-auto rounded-md border border-white/10 bg-white/95 p-1 text-sm text-gray-900 shadow-lg backdrop-blur-sm dark:bg-gray-900/95 dark:text-gray-100"
+              style={
+                tabMenuPosition
+                  ? {
+                      left: tabMenuPosition.x,
+                      top: tabMenuPosition.y,
+                      maxHeight: tabMenuPosition.maxHeight,
+                    }
+                  : { left: tabMenu.x, top: tabMenu.y, visibility: "hidden" }
+              }
+              onClick={(event) => event.stopPropagation()}
+            >
+              {/* Side panel only: project this tab onto the page. Drag-to-corner
+                  gives precise placement; this is the one-click default. */}
+              {isPanelEmbed && tabMenuTab.contentId ? (
+                <>
+                  <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    Page
+                  </div>
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/10"
+                    onClick={() => {
+                      requestOverlayOpen(tabMenuTab.contentId as string);
+                      setTabMenu(null);
+                    }}
+                  >
+                    Open as overlay
+                  </button>
+                </>
+              ) : null}
+              {shellTabMenuSections.map((Section) =>
+                createElement(Section, {
+                  key: Section.displayName ?? Section.name,
+                  tab: tabMenuTab,
+                  closeMenu: () => setTabMenu(null),
+                })
+              )}
+            </div>,
+            document.body
+          )
+        : null}
     </>
   );
 }


### PR DESCRIPTION
## Bug Squash 2026-W36 — #188

Right-clicking the rightmost main-panel tab opened a 224px-wide menu anchored at the raw pointer x, so it ran off the right edge of the screen; it also painted behind the right sidebar when that was expanded. Both halves come from the same render, and both are fixed by portalling and delegating placement to the repo's existing positioning utility.

- Portal the menu to `document.body` so it escapes the header's stacking context, at `z-[120]` to match the shared `ContextMenu`.
- Two-phase measure-then-position: render hidden at the pointer, measure, then place via `calculateMenuPosition` (`lib/core/menu-positioning.ts:77`), which flips and shifts to clear the viewport edges.
- Apply the returned `maxHeight` with `overflow-y-auto`, so a tall menu scrolls rather than overflowing.
- Clear the stored placement when a new tab menu opens, so it measures from scratch instead of flashing at the previous tab's position.

Diagnosis: `components/content/headers/MainPanelHeader.tsx:746` stored the raw pointer coordinates (`x: event.clientX, y: event.clientY`) and `:839-843` rendered them straight into `style={{ left, top }}` on a `position: fixed`, `min-w-56` (224px) element — no measurement, no boundary detection, no flip, no clamp. The rightmost tab is by definition within 224px of the right edge, so the menu always overflowed there, and because it is `fixed` nothing clipped it: the failure was silent overflow rather than a visible cut-off. The stacking half is the same render's `z-50`, applied inside the header's stacking context and therefore unable to paint above a sidebar sitting higher in the tree. This is the same defect `0e541bd` (2026-08-27) fixed for the assistant detail card (#179); the recipe is copied from `components/content/context-menu/ContextMenu.tsx:503-526,617-627`.

### Deviations from the plan doc

- The plan suggested `anchorMenuAbove` for the vertical flip. I did not use it: it anchors a menu's *bottom* edge above a trigger rect and is built for bottom-of-screen composer pickers that open upward. `calculateMenuPosition` already does the vertical flip from a pointer position, which is what this menu needs, so it is used alone.
- Bumped `z-50` → `z-[120]` rather than leaving it: `z-[120]` is what the sibling portalled `ContextMenu` uses, and matching it is what actually settles the sidebar-stacking half of the report.
- Whitespace: the portal wrapper re-indents the existing menu JSX one level. No other reformatting.

**Gates:** typecheck ✅ · lint ✅ (151 warnings, unchanged from `main`, ratchet 175; the changed file lints clean) · `next build --turbopack` ✅ · **`pnpm build` ❌ — fails at `model-routing:check`, pre-existing on `main`** (see below) · browser smoke ⚠️ not run — no browser in this environment

`pnpm build` does not reach `next build` because `pnpm model-routing:check` (gate 15 of 20) fails. Verified pre-existing: the same assertion fails identically on a clean `main` checkout with my changes stashed —

```
scripts/validate-model-routing.ts:296
  actual:   'by charter "Job Hunt" (Phase 3)'
  expected: 'by playbook "Job Hunt" (Phase 3)'
```

That is fallout from the charters rename (`aec686f` / `53b3459`), unrelated to this PR and left alone per the minimal-change rule. `next build --turbopack` was run directly instead and passed. **Not fixed here — flagging for you.**

Least sure of: this is a positioning change that was never exercised in a browser here. Two things to watch in the smoke test — (a) the menu still closes on an outside click (it relies on `onClick` `stopPropagation` reaching the window listener at `:589`; React attaches listeners to the portal container, so this should be unchanged, but it is the behaviour a portal move most often breaks), and (b) light/dark both still read correctly, since the explicit theme classes moved with the element.

## Pre-merge checklist

- [ ] `pnpm build` green locally
- [ ] **Smoke #188:** with the right sidebar expanded, right-click the rightmost main-panel tab → the menu opens fully inside the viewport, flipped leftward from the pointer, and paints above the sidebar rather than behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYjfHSFyP8Q9MhzP9FQ9mR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYjfHSFyP8Q9MhzP9FQ9mR)_