### PR TITLE
Release 6: Chat control panel & workspace write-guard (AI 3.8)

### DIFF
--- a/app/api/content/content/duplicate/route.ts
+++ b/app/api/content/content/duplicate/route.ts
@@ -15,6 +15,33 @@ import { getSession } from "@/lib/infrastructure/auth/session";
 import { prisma } from "@/lib/database/client";
 import { logger, spanPayload, withRouteTrace, withSpan } from "@/lib/core/logger";
 import { regenerateAllBlockIds } from "@/lib/domain/blocks/block-id-walk";
+import { forkConversation } from "@/lib/features/conversations";
+
+/**
+ * Mac-style duplicate naming (owner, 2026-09-04): "T" → "T 2" → "T 3";
+ * duplicating "T 2" strips the trailing number and continues from the base —
+ * never "(Copy)" chains. Scoped to live siblings under the same parent.
+ */
+async function nextDuplicateTitle(
+  originalTitle: string,
+  parentId: string | null,
+  userId: string,
+): Promise<string> {
+  const base = originalTitle.replace(/ \d+$/, "");
+  const siblings = await prisma.contentNode.findMany({
+    where: {
+      ownerId: userId,
+      parentId,
+      deletedAt: null,
+      title: { startsWith: base },
+    },
+    select: { title: true },
+  });
+  const taken = new Set(siblings.map((s) => s.title));
+  let n = 2;
+  while (taken.has(`${base} ${n}`)) n += 1;
+  return `${base} ${n}`;
+}
 
 const ROUTE_PATH = "/api/content/content/duplicate";
 
@@ -63,6 +90,7 @@ export async function POST(request: NextRequest) {
                 codePayload: true,
                 externalPayload: true,
                 shortcutPayload: true,
+                chatPayload: true,
               },
             });
 
@@ -144,10 +172,20 @@ export async function POST(request: NextRequest) {
 async function duplicateNode(
   original: any,
   userId: string,
-  parentId: string | null = null
+  parentId: string | null = null,
+  /** Only the top-level node renames (mac semantics) — children inside a
+   *  duplicated folder keep their exact titles (their parent is new, so
+   *  there is nothing to collide with). */
+  rename = true,
 ): Promise<any> {
 /* eslint-enable @typescript-eslint/no-explicit-any */
-  const newTitle = `${original.title} (Copy)`;
+  const newTitle = rename
+    ? await nextDuplicateTitle(
+        original.title,
+        parentId ?? original.parentId,
+        userId,
+      )
+    : original.title;
 
   const duplicate = await prisma.contentNode.create({
     data: {
@@ -252,8 +290,47 @@ async function duplicateNode(
           },
         },
       }),
+
+      // Chats: copy the legacy payload verbatim; the LIVE transcript (the
+      // backing Conversation) is forked below.
+      ...(original.chatPayload && {
+        chatPayload: {
+          create: {
+            messages: original.chatPayload.messages || [],
+            metadata: original.chatPayload.metadata || {},
+          },
+        },
+      }),
     } as never,
   });
+
+  // Fork, don't blank (owner, 2026-09-04): a duplicated chat used to come
+  // out empty because the transcript lives in the backing Conversation,
+  // which this route never touched. Fork it (full message copy + mirrored
+  // associations) and point the fork at the NEW node. Best-effort: a fork
+  // failure still leaves the node copy (with the legacy payload above).
+  if (original.contentType === "chat") {
+    try {
+      const backing = await prisma.conversation.findFirst({
+        where: { archivedToContentNodeId: original.id },
+        select: { id: true },
+      });
+      if (backing) {
+        const forkedId = await forkConversation(userId, backing.id, undefined);
+        await prisma.conversation.update({
+          where: { id: forkedId },
+          data: { archivedToContentNodeId: duplicate.id, title: newTitle },
+        });
+      }
+    } catch (error) {
+      logger.warn({
+        layer: "content",
+        event: "duplicate:chat_fork_failed",
+        summary: "chat node copied but conversation fork failed",
+        error,
+      });
+    }
+  }
 
   if (original.contentType === "folder") {
     const children = await prisma.contentNode.findMany({
@@ -266,11 +343,12 @@ async function duplicateNode(
         codePayload: true,
         externalPayload: true,
         shortcutPayload: true,
+        chatPayload: true,
       },
     });
 
     for (const child of children) {
-      await duplicateNode(child, userId, duplicate.id);
+      await duplicateNode(child, userId, duplicate.id, false);
     }
   }
 

--- a/components/content/FileNode.tsx
+++ b/components/content/FileNode.tsx
@@ -535,6 +535,10 @@ export function FileNode({ node, style, dragHandle, onRename, onCreate, onDelete
     if (e.metaKey || e.ctrlKey) {
       e.preventDefault();
       e.stopPropagation();
+      // Cmd/ctrl-click is a multi-select GESTURE, not navigation (owner,
+      // 2026-09-04) — same selection-only routing shift-click uses, so the
+      // tree's onSelect skips opening the content in the main panel.
+      onSelectionOnly?.();
       if (node.isSelected) {
         node.deselect();
       } else {

--- a/components/content/ai/ChatControlPanel.tsx
+++ b/components/content/ai/ChatControlPanel.tsx
@@ -10,11 +10,11 @@
  *
  * Composition notes:
  * - The hosted affordances (TargetFolderChip, OutputTargetChip,
- *   ChatContextPicker) open their OWN portaled menus. A click in those
- *   menus is outside this panel's DOM, so the panel deliberately does NOT
- *   close on outside clicks — explicit close only (✕, Escape, or the
- *   trigger toggling). Predictable for a settings surface, and immune to
- *   the nested-portal outside-click trap.
+ *   ChatContextPicker) open their OWN portaled menus at <body> level, so a
+ *   naive outside-click handler would close the panel mid-interaction.
+ *   Click-away dismissal (owner ask) therefore exempts any position:fixed
+ *   layer: hosted menus and toasts count as "inside"; true page clicks,
+ *   ✕, Escape, and the trigger all dismiss.
  * - Portaled + position:fixed, opening above the trigger (the composer
  *   sits at the viewport bottom; overflow-x-auto rails clip upward
  *   dropdowns — the recorded portal rule).
@@ -61,13 +61,12 @@ function PanelRow({
   hint: string;
   children: React.ReactNode;
 }) {
+  // Compact step (owner, 2026-09-04): the explanatory line lives behind a
+  // native tooltip on the row instead of visible text.
   return (
-    <div className="px-3 py-2">
+    <div className="px-3 py-2" title={hint}>
       <div className="text-[11px] font-medium text-gray-700 dark:text-gray-200">
         {label}
-      </div>
-      <div className="mt-0.5 text-[10.5px] leading-snug text-gray-500 dark:text-gray-400">
-        {hint}
       </div>
       <div className="mt-1.5 flex min-w-0 items-center">{children}</div>
     </div>
@@ -92,6 +91,7 @@ export function ChatControlPanel({
   const [open, setOpen] = useState(false);
   const [position, setPosition] = useState<CalculatedPosition | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const [portalReady, setPortalReady] = useState(false);
 
   useEffect(() => {
@@ -123,8 +123,36 @@ export function ChatControlPanel({
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") setOpen(false);
     };
+    // Click-away dismissal (owner, 2026-09-04) with the nested-portal trap
+    // handled: the hosted affordances (target pickers, context picker) open
+    // their OWN menus portaled to <body> as position:fixed layers — a click
+    // there is an interaction, not a dismissal. Clicks inside the panel or
+    // trigger keep it open; clicks inside ANY other fixed layer (a hosted
+    // menu, a toast) are ignored; true page clicks close.
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (
+        panelRef.current?.contains(target) ||
+        triggerRef.current?.contains(target)
+      ) {
+        return;
+      }
+      for (
+        let el: HTMLElement | null = target;
+        el && el !== document.body;
+        el = el.parentElement
+      ) {
+        if (getComputedStyle(el).position === "fixed") return;
+      }
+      setOpen(false);
+    };
     window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("pointerdown", onPointerDown);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("pointerdown", onPointerDown);
+    };
   }, [open]);
 
   return (
@@ -148,6 +176,7 @@ export function ChatControlPanel({
         position &&
         createPortal(
           <div
+            ref={panelRef}
             role="dialog"
             aria-label="Chat controls"
             style={{

--- a/components/content/ai/ChatControlPanel.tsx
+++ b/components/content/ai/ChatControlPanel.tsx
@@ -207,7 +207,7 @@ export function ChatControlPanel({
             </div>
             <div className="min-h-0 divide-y divide-black/[0.05] overflow-y-auto dark:divide-white/[0.06]">
               <PanelRow
-                label="File target"
+                label="Target folder"
                 hint="The folder this chat serves — run notes and ledgers file here."
               >
                 <TargetFolderChip
@@ -219,7 +219,7 @@ export function ChatControlPanel({
                 />
               </PanelRow>
               <PanelRow
-                label="Output target"
+                label="Target output"
                 hint="Where generated content (notes, documents) lands by default."
               >
                 <OutputTargetChip
@@ -236,9 +236,6 @@ export function ChatControlPanel({
                     : "Unpinned — charter per-phase routing applies. Pin to override."
                 }
               >
-                <span className="mr-0.5 text-[11px] text-gray-500 dark:text-gray-400">
-                  {modelPinned ? "Pinned" : "Unpinned"}
-                </span>
                 <ModelPinToggle pinned={modelPinned} onToggle={onModelPinnedChange} />
               </PanelRow>
               <PanelRow

--- a/components/content/ai/ChatControlPanel.tsx
+++ b/components/content/ai/ChatControlPanel.tsx
@@ -127,13 +127,15 @@ export function ChatControlPanel({
       if (event.key === "Escape") setOpen(false);
     };
     // Click-away dismissal (owner, 2026-09-04) with the nested-portal trap
-    // handled: the hosted affordances (target pickers, context picker) open
-    // their OWN menus portaled to <body> as position:fixed layers — a click
-    // there is an interaction, not a dismissal. Clicks inside the panel or
-    // trigger keep it open; clicks inside ANY other fixed layer (a hosted
-    // menu, a toast) are ignored; true page clicks close.
+    // handled by DOM ORDER, not position (a fixed-position test false-
+    // positived on the app shell's own fixed ancestors and nothing ever
+    // dismissed): the hosted affordances portal their menus to <body>
+    // AFTER this panel, so a click whose top-level ancestor FOLLOWS the
+    // panel is an interaction with a layer opened on top of us — ignore
+    // it. Everything else (the app content root precedes the panel)
+    // closes.
     const onPointerDown = (event: PointerEvent) => {
-      const target = event.target as HTMLElement | null;
+      const target = event.target as Node | null;
       if (!target) return;
       if (
         panelRef.current?.contains(target) ||
@@ -141,12 +143,19 @@ export function ChatControlPanel({
       ) {
         return;
       }
-      for (
-        let el: HTMLElement | null = target;
-        el && el !== document.body;
-        el = el.parentElement
-      ) {
-        if (getComputedStyle(el).position === "fixed") return;
+      const panel = panelRef.current;
+      if (panel && target instanceof Element) {
+        let top: Element = target;
+        while (top.parentElement && top.parentElement !== document.body) {
+          top = top.parentElement;
+        }
+        if (
+          top.parentElement === document.body &&
+          panel.compareDocumentPosition(top) &
+            Node.DOCUMENT_POSITION_FOLLOWING
+        ) {
+          return;
+        }
       }
       setOpen(false);
     };

--- a/components/content/ai/ChatControlPanel.tsx
+++ b/components/content/ai/ChatControlPanel.tsx
@@ -229,11 +229,11 @@ export function ChatControlPanel({
                 />
               </PanelRow>
               <PanelRow
-                label="Model pin"
+                label="Lock-in model"
                 hint={
                   modelPinned
-                    ? "Pinned — the selected model overrides charter per-phase routing."
-                    : "Unpinned — charter per-phase routing applies. Pin to override."
+                    ? "Locked in — the selected model overrides charter per-phase routing."
+                    : "Unlocked — charter per-phase routing applies. Lock in to override."
                 }
               >
                 <ModelPinToggle pinned={modelPinned} onToggle={onModelPinnedChange} />

--- a/components/content/ai/ChatControlPanel.tsx
+++ b/components/content/ai/ChatControlPanel.tsx
@@ -238,11 +238,11 @@ export function ChatControlPanel({
                 />
               </PanelRow>
               <PanelRow
-                label="Lock-in model"
+                label="Lock selected model"
                 hint={
                   modelPinned
-                    ? "Locked in — the selected model overrides charter per-phase routing."
-                    : "Unlocked — charter per-phase routing applies. Lock in to override."
+                    ? "Locked — the selected model overrides charter per-phase routing."
+                    : "Unlocked — charter per-phase routing applies. Lock to override."
                 }
               >
                 <ModelPinToggle pinned={modelPinned} onToggle={onModelPinnedChange} />

--- a/components/content/ai/ChatControlPanel.tsx
+++ b/components/content/ai/ChatControlPanel.tsx
@@ -12,9 +12,9 @@
  * - The hosted affordances (TargetFolderChip, OutputTargetChip,
  *   ChatContextPicker) open their OWN portaled menus at <body> level, so a
  *   naive outside-click handler would close the panel mid-interaction.
- *   Click-away dismissal (owner ask) therefore exempts any position:fixed
- *   layer: hosted menus and toasts count as "inside"; true page clicks,
- *   ✕, Escape, and the trigger all dismiss.
+ *   Click-away dismissal therefore exempts by DOM ORDER: layers portaled
+ *   to <body> AFTER the panel (the hosted menus) count as "inside"; true
+ *   page clicks, ✕, Escape, and the trigger all dismiss.
  * - Portaled + position:fixed, opening above the trigger (the composer
  *   sits at the viewport bottom; overflow-x-auto rails clip upward
  *   dropdowns — the recorded portal rule).
@@ -241,8 +241,8 @@ export function ChatControlPanel({
                 label="Lock selected model"
                 hint={
                   modelPinned
-                    ? "Locked — the selected model overrides charter per-phase routing."
-                    : "Unlocked — charter per-phase routing applies. Lock to override."
+                    ? "Locked — the selected model overrides charter-designated per-phase routing."
+                    : "Unlocked — charter-designated per-phase routing applies. Lock to override."
                 }
               >
                 <ModelPinToggle pinned={modelPinned} onToggle={onModelPinnedChange} />

--- a/components/content/ai/ChatControlPanel.tsx
+++ b/components/content/ai/ChatControlPanel.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+/**
+ * ChatControlPanel (AI 3.8) — one roomy, labeled home for the chat's
+ * calibrations. The footer rail had no room for labels, so pin-model and
+ * context lived as bare icons and the target affordances as terse header
+ * chips. The panel hosts all four WITH labels; the rail keeps only the
+ * make/model picker (the "condense the rail" backlog item, superseded);
+ * the header chips stay as at-a-glance state.
+ *
+ * Composition notes:
+ * - The hosted affordances (TargetFolderChip, OutputTargetChip,
+ *   ChatContextPicker) open their OWN portaled menus. A click in those
+ *   menus is outside this panel's DOM, so the panel deliberately does NOT
+ *   close on outside clicks — explicit close only (✕, Escape, or the
+ *   trigger toggling). Predictable for a settings surface, and immune to
+ *   the nested-portal outside-click trap.
+ * - Portaled + position:fixed, opening above the trigger (the composer
+ *   sits at the viewport bottom; overflow-x-auto rails clip upward
+ *   dropdowns — the recorded portal rule).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Feather, SlidersHorizontal, X } from "lucide-react";
+import {
+  calculateMenuPosition,
+  type CalculatedPosition,
+} from "@/lib/core/menu-positioning";
+import { TargetFolderChip } from "./TargetFolderChip";
+import { OutputTargetChip } from "./OutputTargetChip";
+import { ModelPinToggle } from "./ModelPinToggle";
+import { ChatContextPicker } from "./ChatContextPicker";
+import type { OutputTarget } from "@/lib/domain/ai/output-target";
+
+const PANEL_WIDTH = 340;
+const PANEL_MAX_HEIGHT = 420;
+
+interface ChatControlPanelProps {
+  targetFolder: { id: string; title: string | null } | null;
+  targetInherited: boolean;
+  targetLocation?: { id: string; title: string | null } | null;
+  onTargetChange: (next: { id: string; title: string | null } | null) => void;
+  targetDisabled?: boolean;
+  outputTarget: OutputTarget;
+  onOutputTargetChange: (next: OutputTarget) => void;
+  hasOrigin: boolean;
+  modelPinned: boolean;
+  onModelPinnedChange: (next: boolean) => void;
+  activeContextId: string | null;
+  onContextChange: (next: string | null) => void;
+  busy?: boolean;
+}
+
+function PanelRow({
+  label,
+  hint,
+  children,
+}: {
+  label: React.ReactNode;
+  hint: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="px-3 py-2">
+      <div className="text-[11px] font-medium text-gray-700 dark:text-gray-200">
+        {label}
+      </div>
+      <div className="mt-0.5 text-[10.5px] leading-snug text-gray-500 dark:text-gray-400">
+        {hint}
+      </div>
+      <div className="mt-1.5 flex min-w-0 items-center">{children}</div>
+    </div>
+  );
+}
+
+export function ChatControlPanel({
+  targetFolder,
+  targetInherited,
+  targetLocation = null,
+  onTargetChange,
+  targetDisabled = false,
+  outputTarget,
+  onOutputTargetChange,
+  hasOrigin,
+  modelPinned,
+  onModelPinnedChange,
+  activeContextId,
+  onContextChange,
+  busy = false,
+}: ChatControlPanelProps) {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<CalculatedPosition | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [portalReady, setPortalReady] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot post-mount marker (same pattern as AssistantAvatar)
+    setPortalReady(typeof document !== "undefined");
+  }, []);
+
+  const toggle = useCallback(() => {
+    setOpen((current) => {
+      if (current) return false;
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (rect) {
+        setPosition(
+          calculateMenuPosition({
+            triggerPosition: { x: rect.left, y: rect.top - 6 },
+            menuDimensions: { width: PANEL_WIDTH, height: PANEL_MAX_HEIGHT },
+            viewportPadding: 8,
+            preferredPlacementX: "right",
+            preferredPlacementY: "top",
+          }),
+        );
+      }
+      return true;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        title="Chat controls — file target, output target, model pin, context"
+        className={
+          open
+            ? "ml-1 inline-flex shrink-0 items-center rounded px-1 py-0.5 text-gold-primary bg-black/[0.05] dark:bg-white/10"
+            : "ml-1 inline-flex shrink-0 items-center rounded px-1 py-0.5 text-gray-400 hover:text-gray-600 hover:bg-black/[0.04] dark:text-gray-500 dark:hover:text-gray-300 dark:hover:bg-white/5"
+        }
+      >
+        <SlidersHorizontal className="h-3.5 w-3.5 shrink-0" />
+      </button>
+      {portalReady &&
+        open &&
+        position &&
+        createPortal(
+          <div
+            role="dialog"
+            aria-label="Chat controls"
+            style={{
+              position: "fixed",
+              zIndex: 130,
+              top: position.y,
+              left: position.x,
+              width: PANEL_WIDTH,
+              maxHeight: PANEL_MAX_HEIGHT,
+            }}
+            className="flex flex-col overflow-hidden rounded-xl border border-black/10 bg-white shadow-2xl dark:border-white/10 dark:bg-[#1c1c1e]"
+          >
+            <div className="flex items-center justify-between border-b border-black/[0.06] px-3 py-2 dark:border-white/[0.08]">
+              <span className="text-[12px] font-semibold text-gray-800 dark:text-gray-100">
+                Chat controls
+              </span>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close chat controls"
+                className="rounded p-1 text-gray-400 hover:bg-black/[0.05] hover:text-gray-600 dark:hover:bg-white/10 dark:hover:text-gray-200"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <div className="min-h-0 divide-y divide-black/[0.05] overflow-y-auto dark:divide-white/[0.06]">
+              <PanelRow
+                label="File target"
+                hint="The folder this chat serves — run notes and ledgers file here."
+              >
+                <TargetFolderChip
+                  target={targetFolder}
+                  inherited={targetInherited}
+                  location={targetLocation}
+                  disabled={targetDisabled}
+                  onChange={onTargetChange}
+                />
+              </PanelRow>
+              <PanelRow
+                label="Output target"
+                hint="Where generated content (notes, documents) lands by default."
+              >
+                <OutputTargetChip
+                  value={outputTarget}
+                  onChange={onOutputTargetChange}
+                  hasOrigin={hasOrigin}
+                />
+              </PanelRow>
+              <PanelRow
+                label="Model pin"
+                hint="Pinned: the selected model overrides charter per-phase routing."
+              >
+                <ModelPinToggle pinned={modelPinned} onToggle={onModelPinnedChange} />
+                <span className="ml-1.5 text-[11px] text-gray-600 dark:text-gray-300">
+                  {modelPinned ? "Pinned — routing overridden" : "Unpinned — charter routing applies"}
+                </span>
+              </PanelRow>
+              <PanelRow
+                label={
+                  <span className="inline-flex items-center gap-1">
+                    <Feather className="h-3 w-3 text-gray-500 dark:text-gray-400" />
+                    Context
+                  </span>
+                }
+                hint="Standing instructions layered onto this chat's system prompt."
+              >
+                <ChatContextPicker
+                  value={activeContextId}
+                  onChange={onContextChange}
+                  disabled={busy}
+                />
+              </PanelRow>
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/components/content/ai/ChatControlPanel.tsx
+++ b/components/content/ai/ChatControlPanel.tsx
@@ -61,14 +61,17 @@ function PanelRow({
   hint: string;
   children: React.ReactNode;
 }) {
-  // Compact step (owner, 2026-09-04): the explanatory line lives behind a
-  // native tooltip on the row instead of visible text.
+  // Settings-row layout (owner, 2026-09-04, second pass): label left,
+  // control right, one line per row — the macOS-settings shape. The
+  // explanatory line stays behind a native tooltip on the row.
   return (
-    <div className="px-3 py-2" title={hint}>
-      <div className="text-[11px] font-medium text-gray-700 dark:text-gray-200">
+    <div className="flex items-center gap-3 px-3 py-2" title={hint}>
+      <div className="w-24 shrink-0 text-[11px] font-medium text-gray-700 dark:text-gray-200">
         {label}
       </div>
-      <div className="mt-1.5 flex min-w-0 items-center">{children}</div>
+      <div className="flex min-w-0 flex-1 items-center justify-end">
+        {children}
+      </div>
     </div>
   );
 }
@@ -227,12 +230,16 @@ export function ChatControlPanel({
               </PanelRow>
               <PanelRow
                 label="Model pin"
-                hint="Pinned: the selected model overrides charter per-phase routing."
+                hint={
+                  modelPinned
+                    ? "Pinned — the selected model overrides charter per-phase routing."
+                    : "Unpinned — charter per-phase routing applies. Pin to override."
+                }
               >
-                <ModelPinToggle pinned={modelPinned} onToggle={onModelPinnedChange} />
-                <span className="ml-1.5 text-[11px] text-gray-600 dark:text-gray-300">
-                  {modelPinned ? "Pinned — routing overridden" : "Unpinned — charter routing applies"}
+                <span className="mr-0.5 text-[11px] text-gray-500 dark:text-gray-400">
+                  {modelPinned ? "Pinned" : "Unpinned"}
                 </span>
+                <ModelPinToggle pinned={modelPinned} onToggle={onModelPinnedChange} />
               </PanelRow>
               <PanelRow
                 label={

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -1290,10 +1290,28 @@ export const ChatMessage = memo(function ChatMessage({
                 key={i}
                 toolName={toolPart.toolName}
                 toolCallId={toolPart.toolCallId}
-                state={toolPart.state}
+                // A "running" part on a message that is no longer streaming
+                // is a contradiction — the turn ended, so the tool can never
+                // return (owner report, 2026-09-04: interrupts that bypass
+                // the engine's stop() left eternal spinners in the persisted
+                // transcript). Render it settled as an honest interruption;
+                // live streams are untouched.
+                state={
+                  !isStreaming &&
+                  (toolPart.state === "input-streaming" ||
+                    toolPart.state === "input-available")
+                    ? "output-error"
+                    : toolPart.state
+                }
                 args={toolPart.input}
                 result={toolPart.output}
-                errorText={toolPart.errorText}
+                errorText={
+                  !isStreaming &&
+                  (toolPart.state === "input-streaming" ||
+                    toolPart.state === "input-available")
+                    ? "Stopped by the user — the turn was interrupted before this tool returned."
+                    : toolPart.errorText
+                }
                 isRevertable={revertableToolIds?.has(toolPart.toolCallId) ?? false}
                 onRevertEdit={onRevertEdit}
               />

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -3187,21 +3187,35 @@ function ToolCallBubble({
   }, [hasError, hasResult, result, errorText]);
 
   // Rough token costs of this tool call, surfaced on the delayed hover
-  // tooltip (owner ask, 2026-09-04). Two directions, both chars/4
-  // ESTIMATES and labeled as such (providers report usage per request,
-  // never per call): the RESULT is context weight for later requests; the
-  // ARGUMENTS are the model's generated output for this call — the only
-  // per-call "output tokens" that exist to attribute.
+  // tooltip (owner ask, 2026-09-04). Two directions, both ESTIMATES and
+  // labeled as such (providers report usage per request, never per call):
+  // the RESULT is context weight for later requests; the ARGUMENTS are the
+  // model's generated output for this call — the only per-call "output
+  // tokens" that exist to attribute.
+  //
+  // Content-aware divisors (owner accuracy bar, 2026-09-04): BPE
+  // tokenizers average ~4 chars/token on prose but ~3.3 on compact JSON
+  // (punctuation/keys fragment) and ~3.7 on pretty-printed JSON (indent
+  // runs collapse). This puts mixed payloads at roughly ±15-20% vs the
+  // flat /4's ±30%-biased-low; anything tighter needs a bundled
+  // tokenizer, which a tooltip does not justify.
   const approxResultTokens = useMemo(() => {
-    const len = resultString?.length ?? 0;
-    return len > 0 ? Math.max(1, Math.round(len / 4)) : null;
+    const s = resultString;
+    if (!s) return null;
+    const divisor = s.startsWith("{") || s.startsWith("[")
+      ? s.includes("\n  ")
+        ? 3.7 // pretty-printed JSON
+        : 3.3 // compact JSON
+      : 4.0; // prose-ish
+    return s.length > 0 ? Math.max(1, Math.round(s.length / divisor)) : null;
   }, [resultString]);
   const approxArgsTokens = useMemo(() => {
     if (args === undefined || args === null) return null;
     try {
       const s = typeof args === "string" ? args : JSON.stringify(args);
-      const len = s?.length ?? 0;
-      return len > 2 ? Math.max(1, Math.round(len / 4)) : null;
+      if (!s || s.length <= 2) return null;
+      const divisor = s.startsWith("{") || s.startsWith("[") ? 3.3 : 4.0;
+      return Math.max(1, Math.round(s.length / divisor));
     } catch {
       return null;
     }
@@ -3415,7 +3429,7 @@ function ToolCallBubble({
         )}
         title={
           hasDetails
-            ? `${approxResultTokens ? `result ≈${approxResultTokens.toLocaleString()} tokens in context · ` : ""}${approxArgsTokens ? `call ≈${approxArgsTokens.toLocaleString()} tokens generated · ` : ""}(estimated) ${expanded ? "Hide details" : "Show details"}`
+            ? `${approxResultTokens ? `result ≈${approxResultTokens.toLocaleString()} tokens in context · ` : ""}${approxArgsTokens ? `call ≈${approxArgsTokens.toLocaleString()} tokens generated · ` : ""}(±20% est.) ${expanded ? "Hide details" : "Show details"}`
             : undefined
         }
       >

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -3186,6 +3186,15 @@ function ToolCallBubble({
       : JSON.stringify(result, null, 2);
   }, [hasError, hasResult, result, errorText]);
 
+  // Rough context cost of this tool's result, surfaced on the delayed
+  // hover tooltip (owner ask, 2026-09-04). chars/4 is an ESTIMATE and is
+  // labeled as one — providers report usage per request, never per call,
+  // so an exact figure does not exist to show.
+  const approxResultTokens = useMemo(() => {
+    const len = resultString?.length ?? 0;
+    return len > 0 ? Math.max(1, Math.round(len / 4)) : null;
+  }, [resultString]);
+
   // One-line summary used in the collapsed header. Tells the user what
   // came back without forcing them to expand — char counts for text,
   // item counts for arrays, "edit applied" for orchestrator payloads.
@@ -3392,7 +3401,11 @@ function ToolCallBubble({
           hasDetails && "hover:bg-black/[0.03] dark:hover:bg-white/[0.04] transition-colors cursor-pointer",
           !hasDetails && "cursor-default",
         )}
-        title={hasDetails ? (expanded ? "Hide details" : "Show details") : undefined}
+        title={
+          hasDetails
+            ? `${approxResultTokens ? `≈${approxResultTokens.toLocaleString()} tokens in context (estimated) · ` : ""}${expanded ? "Hide details" : "Show details"}`
+            : undefined
+        }
       >
         {isRunning ? (
           <Loader2 className="h-3 w-3 shrink-0 animate-spin text-amber-400" />

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -3186,14 +3186,26 @@ function ToolCallBubble({
       : JSON.stringify(result, null, 2);
   }, [hasError, hasResult, result, errorText]);
 
-  // Rough context cost of this tool's result, surfaced on the delayed
-  // hover tooltip (owner ask, 2026-09-04). chars/4 is an ESTIMATE and is
-  // labeled as one — providers report usage per request, never per call,
-  // so an exact figure does not exist to show.
+  // Rough token costs of this tool call, surfaced on the delayed hover
+  // tooltip (owner ask, 2026-09-04). Two directions, both chars/4
+  // ESTIMATES and labeled as such (providers report usage per request,
+  // never per call): the RESULT is context weight for later requests; the
+  // ARGUMENTS are the model's generated output for this call — the only
+  // per-call "output tokens" that exist to attribute.
   const approxResultTokens = useMemo(() => {
     const len = resultString?.length ?? 0;
     return len > 0 ? Math.max(1, Math.round(len / 4)) : null;
   }, [resultString]);
+  const approxArgsTokens = useMemo(() => {
+    if (args === undefined || args === null) return null;
+    try {
+      const s = typeof args === "string" ? args : JSON.stringify(args);
+      const len = s?.length ?? 0;
+      return len > 2 ? Math.max(1, Math.round(len / 4)) : null;
+    } catch {
+      return null;
+    }
+  }, [args]);
 
   // One-line summary used in the collapsed header. Tells the user what
   // came back without forcing them to expand — char counts for text,
@@ -3403,7 +3415,7 @@ function ToolCallBubble({
         )}
         title={
           hasDetails
-            ? `${approxResultTokens ? `≈${approxResultTokens.toLocaleString()} tokens in context (estimated) · ` : ""}${expanded ? "Hide details" : "Show details"}`
+            ? `${approxResultTokens ? `result ≈${approxResultTokens.toLocaleString()} tokens in context · ` : ""}${approxArgsTokens ? `call ≈${approxArgsTokens.toLocaleString()} tokens generated · ` : ""}(estimated) ${expanded ? "Hide details" : "Show details"}`
             : undefined
         }
       >

--- a/components/content/ai/ChatMessage.tsx
+++ b/components/content/ai/ChatMessage.tsx
@@ -4133,8 +4133,11 @@ function WorkingIndicator() {
   // pointless "0:01"; once it's clearly a wait, the counter reassures.
   const showTime = elapsed >= 3;
   return (
+    // Borderless (owner, 2026-09-04, with the reasoning de-boxing): status
+    // is text, boxes are content — the claude.ai/ChatGPT idiom for
+    // transient signals.
     <div
-      className="inline-flex items-center gap-2 rounded-xl bg-black/[0.03] dark:bg-white/5 border border-black/10 dark:border-white/10 px-3.5 py-2 text-xs text-gray-500"
+      className="inline-flex items-center gap-2 px-1 py-0.5 text-xs text-gray-500 dark:text-gray-400"
       aria-live="polite"
       aria-label={`Working${showTime ? `, ${elapsed} seconds elapsed` : ""}`}
     >
@@ -4157,7 +4160,7 @@ function WorkingIndicator() {
 /** Thinking indicator — shown while tools are executing */
 function ThinkingIndicator() {
   return (
-    <div className="inline-flex items-center gap-2 rounded-xl bg-indigo-500/10 border border-indigo-500/20 px-3.5 py-2 text-xs text-indigo-300">
+    <div className="inline-flex items-center gap-2 px-1 py-0.5 text-xs text-indigo-500 dark:text-indigo-300">
       <BrainCircuit className="h-3.5 w-3.5 animate-pulse" />
       <span>Thinking</span>
       <span className="inline-flex gap-0.5">

--- a/components/content/ai/ChatPanel.tsx
+++ b/components/content/ai/ChatPanel.tsx
@@ -39,6 +39,7 @@ import { aggregateSessionUsage } from "@/lib/features/ai-connections/usage/prici
 import { REVERT_SNAPSHOT_KEY } from "@/lib/domain/ai/compact-tool-outputs";
 import { TargetFolderChip } from "./TargetFolderChip";
 import { OutputTargetChip } from "./OutputTargetChip";
+import { deriveTargetSeed } from "@/lib/domain/ai/output-target";
 import { ChatInput } from "./ChatInput";
 import { FolderContextChips } from "@/components/content/ai/FolderContextChips";
 import { FollowUpsStrip } from "./FollowUpsStrip";
@@ -369,14 +370,14 @@ export function ChatPanel({
 
   const effectiveLocation = initialTargetLocation ?? locationFallback;
   useEffect(() => {
-    if (initialTargetFolder) {
-      setTargetFolder(initialTargetFolder);
-      setTargetInherited(initialTargetInherited);
-    } else if (effectiveLocation) {
-      // No explicit target: inherit the chat's location instead of
-      // rendering blank.
-      setTargetFolder(effectiveLocation);
-      setTargetInherited(true);
+    const seed = deriveTargetSeed({
+      explicit: initialTargetFolder,
+      explicitInherited: initialTargetInherited,
+      location: effectiveLocation,
+    });
+    if (seed.target) {
+      setTargetFolder(seed.target);
+      setTargetInherited(seed.inherited);
     } else if (isPanelEmbed) {
       // Browser panel: no conversation and nothing to inherit from, so fall
       // back to the last target the user picked here. Browser chats aren't

--- a/components/content/ai/ChatPanel.tsx
+++ b/components/content/ai/ChatPanel.tsx
@@ -32,7 +32,7 @@ import {
   ModelSwitchDivider,
   ModelRouteNotices,
 } from "./ModelSwitchDivider";
-import { ModelPinToggle } from "./ModelPinToggle";
+import { ChatControlPanel } from "./ChatControlPanel";
 import { computeModelRouteDecorations } from "@/lib/domain/ai/model-directive";
 import { findIterationFoldBoundary } from "@/lib/domain/ai/context-diet";
 import { aggregateSessionUsage } from "@/lib/features/ai-connections/usage/pricing";
@@ -45,7 +45,6 @@ import { FolderContextChips } from "@/components/content/ai/FolderContextChips";
 import { FollowUpsStrip } from "./FollowUpsStrip";
 import { ChatErrorBanner } from "./ChatErrorBanner";
 import { MakeAndModelPicker } from "./MakeAndModelPicker";
-import { ChatContextPicker } from "./ChatContextPicker";
 import {
   useConversationEngine,
   type ClientEditOutcome,
@@ -1193,12 +1192,21 @@ export function ChatPanel({
               contributors={mixed.contributors as AIProviderId[]}
               compact
             />
-            <ModelPinToggle pinned={modelPinned} onToggle={setModelPinned} />
-            <ChatContextPicker
-              value={activeContextId}
-              onChange={handleContextChange}
-              disabled={isActive}
-              compact
+            {/* AI 3.8: pin + context moved into the labeled control panel —
+                the rail keeps only the model picker (condensed by design). */}
+            <ChatControlPanel
+              targetFolder={targetFolder}
+              targetInherited={targetInherited}
+              targetLocation={effectiveLocation}
+              onTargetChange={handleTargetChange}
+              outputTarget={outputTarget}
+              onOutputTargetChange={setOutputTarget}
+              hasOrigin={Boolean(contentId)}
+              modelPinned={modelPinned}
+              onModelPinnedChange={setModelPinned}
+              activeContextId={activeContextId}
+              onContextChange={handleContextChange}
+              busy={isActive}
             />
           </div>
         }

--- a/components/content/ai/ChatPanel.tsx
+++ b/components/content/ai/ChatPanel.tsx
@@ -37,8 +37,6 @@ import { computeModelRouteDecorations } from "@/lib/domain/ai/model-directive";
 import { findIterationFoldBoundary } from "@/lib/domain/ai/context-diet";
 import { aggregateSessionUsage } from "@/lib/features/ai-connections/usage/pricing";
 import { REVERT_SNAPSHOT_KEY } from "@/lib/domain/ai/compact-tool-outputs";
-import { TargetFolderChip } from "./TargetFolderChip";
-import { OutputTargetChip } from "./OutputTargetChip";
 import { deriveTargetSeed } from "@/lib/domain/ai/output-target";
 import { ChatInput } from "./ChatInput";
 import { FolderContextChips } from "@/components/content/ai/FolderContextChips";
@@ -1017,22 +1015,9 @@ export function ChatPanel({
       <div className="flex shrink-0 flex-wrap items-center justify-between gap-y-1 border-b border-black/10 dark:border-white/10 px-3 py-2">
         <div className="flex min-w-0 flex-wrap items-center gap-2 gap-y-1">
           <HeaderTitle providerId={providerId} modelId={modelId} />
-          <TargetFolderChip
-            target={targetFolder}
-            inherited={targetInherited}
-            location={effectiveLocation}
-            // Selectable before the conversation exists: the pick is held in
-            // local state, carried into the POST that creates the conversation,
-            // and (in the browser panel) remembered for the next chat.
-            disabled={false}
-            onChange={handleTargetChange}
-          />
-          {/* WS7: where generated content lands by default. */}
-          <OutputTargetChip
-            value={outputTarget}
-            onChange={setOutputTarget}
-            hasOrigin={Boolean(contentId)}
-          />
+          {/* AI 3.8 (owner): the target chips moved into the ChatControlPanel
+              wholesale — duplicating them here as header affordances was
+              retired with the rail condensation. */}
         </div>
         <div className="ml-auto flex items-center gap-1">
           {conversationId && (

--- a/components/content/ai/ModelPinToggle.tsx
+++ b/components/content/ai/ModelPinToggle.tsx
@@ -30,8 +30,8 @@ export function ModelPinToggle({
       aria-pressed={pinned}
       title={
         pinned
-          ? "Model locked in — this model overrides charter per-phase routing. Click to unlock."
-          : "Lock in this model so it overrides any charter per-phase model routing."
+          ? "Model locked — the selected model overrides charter per-phase routing. Click to unlock."
+          : "Lock the selected model so it overrides any charter per-phase model routing."
       }
       className={
         pinned

--- a/components/content/ai/ModelPinToggle.tsx
+++ b/components/content/ai/ModelPinToggle.tsx
@@ -30,8 +30,8 @@ export function ModelPinToggle({
       aria-pressed={pinned}
       title={
         pinned
-          ? "Model locked — the selected model overrides charter per-phase routing. Click to unlock."
-          : "Lock the selected model so it overrides any charter per-phase model routing."
+          ? "Model locked — the selected model overrides charter-designated per-phase routing. Click to unlock."
+          : "Lock the selected model so it overrides any charter-designated per-phase model routing."
       }
       className={
         pinned

--- a/components/content/ai/ModelPinToggle.tsx
+++ b/components/content/ai/ModelPinToggle.tsx
@@ -1,16 +1,20 @@
 /**
- * ModelPinToggle (AI 3.4) — explicit pin control in the chat footer.
+ * ModelPinToggle (AI 3.4; re-skinned "Lock-in model" 2026-09-04) — the
+ * explicit lock-in control, hosted in the ChatControlPanel.
  *
- * Pinning the model makes the currently-selected model win over any playbook
- * phase directive for this conversation. It is an EXPLICIT toggle (not a side
- * effect of picking a model), always visible so it's discoverable in every
- * flow — including rooted "run this playbook" chats, where there is no
- * client-side attached-playbook state to gate on.
+ * Locking in the model makes the currently-selected model win over any
+ * charter phase directive for this conversation. It is an EXPLICIT toggle
+ * (not a side effect of picking a model) so it's discoverable in every
+ * flow — including rooted "run this charter" chats, where there is no
+ * client-side attached-charter state to gate on.
+ *
+ * Icon semantics (owner): locked-in = closed lock; off = open lock
+ * (lucide ships no slashed lock — the open lock is the off state).
  */
 
 "use client";
 
-import { Pin, PinOff } from "lucide-react";
+import { Lock, LockOpen } from "lucide-react";
 
 export function ModelPinToggle({
   pinned,
@@ -26,8 +30,8 @@ export function ModelPinToggle({
       aria-pressed={pinned}
       title={
         pinned
-          ? "Model pinned — this model overrides charter per-phase routing. Click to unpin."
-          : "Pin this model so it overrides any charter per-phase model routing."
+          ? "Model locked in — this model overrides charter per-phase routing. Click to unlock."
+          : "Lock in this model so it overrides any charter per-phase model routing."
       }
       className={
         pinned
@@ -36,9 +40,9 @@ export function ModelPinToggle({
       }
     >
       {pinned ? (
-        <Pin className="h-3.5 w-3.5 shrink-0 fill-current" />
+        <Lock className="h-3.5 w-3.5 shrink-0" />
       ) : (
-        <PinOff className="h-3.5 w-3.5 shrink-0" />
+        <LockOpen className="h-3.5 w-3.5 shrink-0" />
       )}
     </button>
   );

--- a/components/content/ai/OutputTargetChip.tsx
+++ b/components/content/ai/OutputTargetChip.tsx
@@ -17,7 +17,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Crosshair, MessageSquare, CornerDownRight, FolderOpen, Check } from "lucide-react";
+import { MessageSquare, CornerDownRight, FolderOpen, Check } from "lucide-react";
 import { cn } from "@/lib/core/utils";
 import { calculateMenuPosition } from "@/lib/core/menu-positioning";
 import {
@@ -182,7 +182,8 @@ export function OutputTargetChip({
             : "hover:bg-black/[0.04] dark:hover:bg-white/[0.06] cursor-pointer",
         )}
       >
-        <Crosshair className="h-3 w-3 shrink-0" />
+        {/* Crosshair icon removed for now (owner, 2026-09-04) — may return
+            if label-icon affordances become a pattern. */}
         {!compact && (
           <span className="truncate">{getOutputTargetLabel(value)}</span>
         )}

--- a/components/content/ai/OutputTargetChip.tsx
+++ b/components/content/ai/OutputTargetChip.tsx
@@ -182,8 +182,15 @@ export function OutputTargetChip({
             : "hover:bg-black/[0.04] dark:hover:bg-white/[0.06] cursor-pointer",
         )}
       >
-        {/* Crosshair icon removed for now (owner, 2026-09-04) — may return
-            if label-icon affordances become a pattern. */}
+        {/* Chip icon mirrors the SELECTED option's icon (owner: congruence
+            with the menu; the old crosshair was mode-blind). */}
+        {value.mode === "chat" ? (
+          <MessageSquare className="h-3 w-3 shrink-0 text-indigo-400" />
+        ) : value.mode === "underContent" ? (
+          <CornerDownRight className="h-3 w-3 shrink-0 text-indigo-400" />
+        ) : (
+          <FolderOpen className="h-3 w-3 shrink-0" />
+        )}
         {!compact && (
           <span className="truncate">{getOutputTargetLabel(value)}</span>
         )}

--- a/components/content/ai/TargetFolderChip.tsx
+++ b/components/content/ai/TargetFolderChip.tsx
@@ -20,6 +20,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { FolderOpen, X, Search, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/core/utils";
 
@@ -85,6 +86,17 @@ export function TargetFolderChip({
   const [folders, setFolders] = useState<FlatFolder[] | null>(null);
   const [filter, setFilter] = useState("");
   const rootRef = useRef<HTMLDivElement | null>(null);
+  // Menu is PORTALED to <body> (position:fixed) so clipping ancestors —
+  // the ChatControlPanel's rounded container was cutting it off — can't
+  // truncate it (the recorded portal rule; same pattern as
+  // OutputTargetChip/ChatContextPicker). menuRef counts as "inside" for
+  // the click-away check.
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [menuPos, setMenuPos] = useState<{
+    left: number;
+    top: number;
+    maxHeight: number;
+  } | null>(null);
 
   // Lazy tree fetch — only when the picker opens, cached for the mount.
   useEffect(() => {
@@ -114,13 +126,13 @@ export function TargetFolderChip({
     };
   }, [open, folders]);
 
-  // Click-away close.
+  // Click-away close — the portaled menu counts as inside.
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      const t = e.target as Node;
+      if (rootRef.current?.contains(t) || menuRef.current?.contains(t)) return;
+      setOpen(false);
     };
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
@@ -147,7 +159,29 @@ export function TargetFolderChip({
       <button
         type="button"
         disabled={disabled}
-        onClick={() => setOpen((v) => !v)}
+        onClick={() =>
+          setOpen((v) => {
+            if (!v) {
+              const rect = rootRef.current?.getBoundingClientRect();
+              if (rect) {
+                const left = Math.max(
+                  8,
+                  Math.min(rect.left, window.innerWidth - 264),
+                );
+                const top = rect.bottom + 4;
+                setMenuPos({
+                  left,
+                  top,
+                  maxHeight: Math.max(
+                    160,
+                    Math.min(320, window.innerHeight - top - 8),
+                  ),
+                });
+              }
+            }
+            return !v;
+          })
+        }
         title={
           disabled
             ? "Save the chat to set an operating folder"
@@ -180,9 +214,21 @@ export function TargetFolderChip({
         </span>
       </button>
 
-      {open && (
-        <div className="absolute left-0 top-full z-50 mt-1 w-64 rounded-lg border border-black/10 dark:border-white/10 bg-white dark:bg-neutral-900 shadow-lg text-xs overflow-hidden">
-          <div className="flex items-center gap-1.5 border-b border-black/5 dark:border-white/10 px-2 py-1.5">
+      {open &&
+        menuPos &&
+        createPortal(
+        <div
+          ref={menuRef}
+          style={{
+            position: "fixed",
+            left: menuPos.left,
+            top: menuPos.top,
+            width: 256,
+            maxHeight: menuPos.maxHeight,
+          }}
+          className="z-[130] flex flex-col rounded-lg border border-black/10 dark:border-white/10 bg-white dark:bg-neutral-900 shadow-lg text-xs overflow-hidden"
+        >
+          <div className="flex shrink-0 items-center gap-1.5 border-b border-black/5 dark:border-white/10 px-2 py-1.5">
             <Search className="h-3 w-3 shrink-0 text-gray-400" />
             <input
               autoFocus
@@ -192,7 +238,7 @@ export function TargetFolderChip({
               className="w-full bg-transparent outline-none placeholder:text-gray-400"
             />
           </div>
-          <div className="max-h-56 overflow-y-auto py-1">
+          <div className="min-h-0 flex-1 overflow-y-auto py-1">
             {folders === null && (
               <div className="px-3 py-2 text-gray-400">Loading folders…</div>
             )}
@@ -238,7 +284,8 @@ export function TargetFolderChip({
               {inherited ? "Clear" : "Clear target"}
             </button>
           )}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/components/content/ai/reasoning/ReasoningBlockChatGPT.tsx
+++ b/components/content/ai/reasoning/ReasoningBlockChatGPT.tsx
@@ -29,12 +29,12 @@ export function ReasoningBlockChatGPT({ text, streaming }: ReasoningBlockProps) 
   }, [text]);
 
   return (
-    <div className="my-2 rounded-lg border border-[#10A37F]/25 bg-[#10A37F]/[0.04]">
+    <div className="my-1.5">
       <button
         ref={headerRef}
         type="button"
         onClick={toggle}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-[#0B7A5E] dark:text-[#10A37F] hover:bg-[#10A37F]/[0.08] transition-colors rounded-lg"
+        className="inline-flex items-center gap-1.5 rounded px-1 py-0.5 text-[12px] font-medium text-[#0B7A5E] dark:text-[#10A37F] hover:opacity-80 transition-opacity"
       >
         {open ? (
           <ChevronDown className="h-3 w-3 opacity-70" />
@@ -47,7 +47,7 @@ export function ReasoningBlockChatGPT({ text, streaming }: ReasoningBlockProps) 
         <span className={streaming ? "animate-pulse" : undefined}>
           {streaming ? "Reasoning…" : "Reasoning"}
         </span>
-        <span className="ml-auto inline-flex items-center gap-2 text-[10px] font-normal opacity-60">
+        <span className="inline-flex items-center gap-2 text-[10px] font-normal opacity-60">
           {!streaming && (
             <span>
               {steps.length} step{steps.length === 1 ? "" : "s"}
@@ -57,7 +57,7 @@ export function ReasoningBlockChatGPT({ text, streaming }: ReasoningBlockProps) 
         </span>
       </button>
       {open && (
-        <ol className="space-y-1.5 px-3 pb-3 pt-1">
+        <ol className="space-y-1.5 pl-6 pb-1 pt-1">
           {steps.map((step, i) => (
             <li
               key={i}

--- a/components/content/ai/reasoning/ReasoningBlockClaude.tsx
+++ b/components/content/ai/reasoning/ReasoningBlockClaude.tsx
@@ -25,14 +25,14 @@ export function ReasoningBlockClaude({ text, streaming }: ReasoningBlockProps) {
 
   return (
     <div
-      className="my-2 rounded-lg border border-[#D4A574]/25 bg-[#D4A574]/[0.06]"
+      className="my-1.5"
       style={{ color: "#D4A574" }}
     >
       <button
         ref={headerRef}
         type="button"
         onClick={toggle}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide hover:bg-[#D4A574]/[0.08] transition-colors rounded-lg"
+        className="inline-flex items-center gap-1.5 rounded px-1 py-0.5 text-[12px] font-medium hover:opacity-80 transition-opacity"
       >
         {open ? (
           <ChevronDown className="h-3 w-3 opacity-70" />
@@ -46,14 +46,14 @@ export function ReasoningBlockClaude({ text, streaming }: ReasoningBlockProps) {
           {streaming ? "Thinking…" : "Thought"}
         </span>
         {elapsedLabel && (
-          <span className="ml-auto tabular-nums text-[10px] font-normal opacity-60">
+          <span className="tabular-nums text-[10px] font-normal opacity-60">
             {elapsedLabel}
           </span>
         )}
       </button>
       {open && (
         <div
-          className="px-3.5 pb-2.5 pt-1 text-xs italic leading-relaxed whitespace-pre-wrap"
+          className="pl-6 pb-1 pt-0.5 text-xs italic leading-relaxed whitespace-pre-wrap"
           style={{ color: "rgba(212, 165, 116, 0.85)" }}
         >
           {text}

--- a/components/content/ai/reasoning/ReasoningBlockGemini.tsx
+++ b/components/content/ai/reasoning/ReasoningBlockGemini.tsx
@@ -64,18 +64,13 @@ export function ReasoningBlockGemini({ text, streaming }: ReasoningBlockProps) {
 
   return (
     <div
-      className="my-2 rounded-lg border bg-gradient-to-br"
-      style={{
-        borderColor: "rgba(66, 133, 244, 0.25)",
-        backgroundImage:
-          "linear-gradient(135deg, rgba(66,133,244,0.06), rgba(124,77,255,0.04))",
-      }}
+      className="my-1.5"
     >
       <button
         ref={headerRef}
         type="button"
         onClick={toggle}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[#1967D2] dark:text-[#4285F4] hover:bg-black/[0.03] dark:hover:bg-white/[0.04] transition-colors rounded-lg"
+        className="inline-flex items-center gap-1.5 rounded px-1 py-0.5 text-[12px] font-medium text-[#1967D2] dark:text-[#4285F4] hover:opacity-80 transition-opacity"
       >
         {open ? (
           <ChevronDown className="h-3 w-3 opacity-70" />
@@ -89,13 +84,13 @@ export function ReasoningBlockGemini({ text, streaming }: ReasoningBlockProps) {
           {streaming ? "Thinking process…" : "Thinking process"}
         </span>
         {elapsedLabel && (
-          <span className="ml-auto tabular-nums text-[10px] font-normal opacity-60">
+          <span className="tabular-nums text-[10px] font-normal opacity-60">
             {elapsedLabel}
           </span>
         )}
       </button>
       {open && (
-        <div className="space-y-2.5 px-3.5 pb-3 pt-1 text-xs leading-relaxed text-gray-700 dark:text-gray-300">
+        <div className="space-y-2.5 pl-6 pb-1 pt-1 text-xs leading-relaxed text-gray-700 dark:text-gray-300">
           {sections.map((s, i) => (
             <div key={i}>
               {s.heading && (

--- a/components/content/ai/reasoning/ReasoningBlockGeneric.tsx
+++ b/components/content/ai/reasoning/ReasoningBlockGeneric.tsx
@@ -19,12 +19,12 @@ export function ReasoningBlockGeneric({ text, streaming }: ReasoningBlockProps) 
   const elapsedLabel = formatReasoningElapsed(elapsed, streaming);
 
   return (
-    <div className="my-2 rounded-lg border border-black/10 bg-black/[0.02] dark:border-white/10 dark:bg-white/[0.03]">
+    <div className="my-1.5">
       <button
         ref={headerRef}
         type="button"
         onClick={toggle}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 hover:bg-black/[0.03] dark:hover:bg-white/[0.04] transition-colors rounded-lg"
+        className="inline-flex items-center gap-1.5 rounded px-1 py-0.5 text-[12px] font-medium text-gray-500 dark:text-gray-400 hover:opacity-80 transition-opacity"
       >
         {open ? (
           <ChevronDown className="h-3 w-3 opacity-70" />
@@ -38,13 +38,13 @@ export function ReasoningBlockGeneric({ text, streaming }: ReasoningBlockProps) 
           {streaming ? "Thinking…" : "Reasoning"}
         </span>
         {elapsedLabel && (
-          <span className="ml-auto tabular-nums text-[10px] font-normal opacity-60">
+          <span className="tabular-nums text-[10px] font-normal opacity-60">
             {elapsedLabel}
           </span>
         )}
       </button>
       {open && (
-        <div className="px-3.5 pb-2.5 pt-1 text-xs leading-relaxed text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
+        <div className="pl-6 pb-1 pt-0.5 text-xs leading-relaxed text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
           {text}
           {streaming && <span className="ml-0.5 inline-block animate-pulse">▍</span>}
         </div>

--- a/components/content/context-menu/file-tree-actions.tsx
+++ b/components/content/context-menu/file-tree-actions.tsx
@@ -761,17 +761,24 @@ export const fileTreeActionProvider: ContextMenuActionProvider = (ctx) => {
 
   // Section 5: Organization actions
   if (selectedIds.length > 0) {
-    const itemLabel = isMultiSelection ? `${selectedIds.length} items` : "item";
+    // Duplicate is SINGLE-select only (owner, 2026-09-04), and for chats it
+    // reads as "Fork chat" — the server deep-forks the backing conversation
+    // so the copy carries the full transcript, never a blank chat.
+    const isChat = clickedNode?.contentType === "chat";
     sections.push({
       title: "Organize",
       actions: [
-        {
-          id: "duplicate",
-          label: `Duplicate ${itemLabel}`,
-          shortcut: "⌘D",
-          onClick: async () => await onDuplicate?.(selectedIds),
-          disabled: (!onDuplicate) || isMirrorRow,
-        },
+        ...(isSingleSelection
+          ? [
+              {
+                id: "duplicate",
+                label: isChat ? "Fork chat" : "Duplicate item",
+                shortcut: "⌘D",
+                onClick: async () => await onDuplicate?.(selectedIds),
+                disabled: (!onDuplicate) || isMirrorRow,
+              },
+            ]
+          : []),
         {
           id: "star",
           label: `Toggle Star`,

--- a/components/content/viewer/ChatViewer.tsx
+++ b/components/content/viewer/ChatViewer.tsx
@@ -26,8 +26,6 @@ import { ChatControlPanel } from "../ai/ChatControlPanel";
 function formatTokenCount(n: number): string {
   return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
 }
-import { TargetFolderChip } from "../ai/TargetFolderChip";
-import { OutputTargetChip } from "../ai/OutputTargetChip";
 import { deriveTargetSeed } from "@/lib/domain/ai/output-target";
 import { ChatInput } from "../ai/ChatInput";
 import { FolderContextChips } from "@/components/content/ai/FolderContextChips";
@@ -850,20 +848,9 @@ function ChatViewerInner({
             nothing unless the chat is Conversation-backed with at least
             one association. */}
         <div className="flex flex-wrap items-center gap-2">
-          <TargetFolderChip
-            target={targetFolder}
-            inherited={targetInherited}
-            location={initialTargetLocation}
-            disabled={!conversationId}
-            onChange={handleTargetChange}
-          />
-          {/* WS7: where generated content lands by default. A full-page chat
-              IS the content, so there's no distinct "next to this chat". */}
-          <OutputTargetChip
-            value={outputTarget}
-            onChange={setOutputTarget}
-            hasOrigin={false}
-          />
+          {/* AI 3.8 (owner): target chips live in the ChatControlPanel now —
+              the header keeps only the association chips, which the panel
+              does not host. */}
           {conversationId && (
             <AssociatedContentChips conversationId={conversationId} />
           )}

--- a/components/content/viewer/ChatViewer.tsx
+++ b/components/content/viewer/ChatViewer.tsx
@@ -801,7 +801,10 @@ function ChatViewerInner({
                 {displayTitle}
               </h1>
             )}
-            <p className="relative text-xs text-gray-500">
+            {/* Subheader line — stats, with the pinned-content affordance
+                inline to the RIGHT of it (owner, 2026-09-04). */}
+            <div className="relative flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-gray-500">
+              <span>
               {hasMessages ? (
                 <>
                   {messages.length} message{messages.length !== 1 ? "s" : ""}
@@ -841,19 +844,12 @@ function ChatViewerInner({
               ) : (
                 "New conversation"
               )}
-            </p>
+              </span>
+              {conversationId && (
+                <AssociatedContentChips conversationId={conversationId} />
+              )}
+            </div>
           </div>
-        </div>
-        {/* Reverse-view: which content this chat is pinned to. Renders
-            nothing unless the chat is Conversation-backed with at least
-            one association. */}
-        <div className="flex flex-wrap items-center gap-2">
-          {/* AI 3.8 (owner): target chips live in the ChatControlPanel now —
-              the header keeps only the association chips, which the panel
-              does not host. */}
-          {conversationId && (
-            <AssociatedContentChips conversationId={conversationId} />
-          )}
         </div>
       </div>
 

--- a/components/content/viewer/ChatViewer.tsx
+++ b/components/content/viewer/ChatViewer.tsx
@@ -20,7 +20,7 @@ import {
 import { computeModelRouteDecorations } from "@/lib/domain/ai/model-directive";
 import { findIterationFoldBoundary } from "@/lib/domain/ai/context-diet";
 import { aggregateSessionUsage } from "@/lib/features/ai-connections/usage/pricing";
-import { ModelPinToggle } from "../ai/ModelPinToggle";
+import { ChatControlPanel } from "../ai/ChatControlPanel";
 
 /** Compact token formatting for the header meter (v3.1 R5). */
 function formatTokenCount(n: number): string {
@@ -34,7 +34,6 @@ import { FolderContextChips } from "@/components/content/ai/FolderContextChips";
 import { FollowUpsStrip } from "../ai/FollowUpsStrip";
 import { ChatErrorBanner } from "../ai/ChatErrorBanner";
 import { MakeAndModelPicker } from "../ai/MakeAndModelPicker";
-import { ChatContextPicker } from "../ai/ChatContextPicker";
 import { AssociatedContentChips } from "../ai/AssociatedContentChips";
 import { useConversationEngine } from "@/lib/domain/ai/use-conversation-engine";
 import {
@@ -987,11 +986,21 @@ function ChatViewerInner({
               disabled={isActive}
               contributors={mixed.contributors as AIProviderId[]}
             />
-            <ModelPinToggle pinned={modelPinned} onToggle={setModelPinned} />
-            <ChatContextPicker
-              value={activeContextId}
-              onChange={handleContextChange}
-              disabled={isActive}
+            {/* AI 3.8: pin + context moved into the labeled control panel. */}
+            <ChatControlPanel
+              targetFolder={targetFolder}
+              targetInherited={targetInherited}
+              targetLocation={initialTargetLocation}
+              onTargetChange={handleTargetChange}
+              targetDisabled={!conversationId}
+              outputTarget={outputTarget}
+              onOutputTargetChange={setOutputTarget}
+              hasOrigin={false}
+              modelPinned={modelPinned}
+              onModelPinnedChange={setModelPinned}
+              activeContextId={activeContextId}
+              onContextChange={handleContextChange}
+              busy={isActive}
             />
           </div>
         }

--- a/components/content/viewer/ChatViewer.tsx
+++ b/components/content/viewer/ChatViewer.tsx
@@ -28,6 +28,7 @@ function formatTokenCount(n: number): string {
 }
 import { TargetFolderChip } from "../ai/TargetFolderChip";
 import { OutputTargetChip } from "../ai/OutputTargetChip";
+import { deriveTargetSeed } from "@/lib/domain/ai/output-target";
 import { ChatInput } from "../ai/ChatInput";
 import { FolderContextChips } from "@/components/content/ai/FolderContextChips";
 import { FollowUpsStrip } from "../ai/FollowUpsStrip";
@@ -331,9 +332,17 @@ function ChatViewerInner({
   } | null>(null);
   const [targetInherited, setTargetInherited] = useState(false);
   useEffect(() => {
-    setTargetFolder(initialTargetFolder);
-    setTargetInherited(initialTargetInherited);
-  }, [initialTargetFolder, initialTargetInherited]);
+    // Single-source with ChatPanel (AI 3.8 fix): no explicit target
+    // inherits the chat's location, so expanding a panel chat to full
+    // view keeps the inherited chip instead of dropping it.
+    const seed = deriveTargetSeed({
+      explicit: initialTargetFolder,
+      explicitInherited: initialTargetInherited,
+      location: initialTargetLocation,
+    });
+    setTargetFolder(seed.target);
+    setTargetInherited(seed.inherited);
+  }, [initialTargetFolder, initialTargetInherited, initialTargetLocation]);
   const handleTargetChange = useCallback(
     (next: { id: string; title: string | null } | null) => {
       if (next) {

--- a/components/content/viewer/ChatViewer.tsx
+++ b/components/content/viewer/ChatViewer.tsx
@@ -39,6 +39,7 @@ import {
   type PersistFinishPayload,
 } from "@/lib/domain/ai/use-conversation-binding";
 import { useContentStore } from "@/state/content-store";
+import { useIsMobile } from "@/components/common/useIsMobile";
 import { toast } from "sonner";
 import {
   buildSurfaceBackground,
@@ -192,6 +193,9 @@ function ChatViewerInner({
 }: ChatViewerInnerProps) {
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isBound = Boolean(conversationId);
+  // Same gate that mounts MobileNotesLayout/bottom nav — the composer's
+  // provider strip collapses with it.
+  const isMobileNav = useIsMobile();
 
   // Initial messages: in bound mode the binding hook hydrates from the
   // Conversation, so we start empty; in legacy mode we seed from the
@@ -968,6 +972,11 @@ function ChatViewerInner({
               onChange={handleModelChange}
               disabled={isActive}
               contributors={mixed.contributors as AIProviderId[]}
+              // Mobile nav engaged (same gate that mounts MobileNotesLayout):
+              // fold the provider quick-icons into the single ⋯ menu — the
+              // strip otherwise overflows the phone composer (owner,
+              // 2026-09-04).
+              compact={isMobileNav}
             />
             {/* AI 3.8: pin + context moved into the labeled control panel. */}
             <ChatControlPanel

--- a/docs/notes-feature/guides/ui/CHAT-UI-CONVENTIONS.md
+++ b/docs/notes-feature/guides/ui/CHAT-UI-CONVENTIONS.md
@@ -1,0 +1,24 @@
+# Chat UI conventions
+
+Owner-set rules for the chat transcript surfaces (ChatPanel, full-page ChatViewer, extension panel embed). Established 2026-09-04 during the AI 3.8 control-panel pass; apply to every new chat-surface element.
+
+## Status is text, boxes are content
+
+**The rule:** a bordered/boxed container promises *content* — something that persists and is worth framing. A transient signal styled as content reads heavier than it is. This is also the platform idiom (claude.ai and ChatGPT both render thinking/working/searching states as quiet inline text with motion, and reserve frames for artifacts).
+
+**Status layer — borderless, inline, muted, with motion as the liveness cue:**
+- Reasoning/thinking disclosures (all four provider renderers): ghost chevron + icon + label + elapsed, expanded thought text indented beneath — no border, no background. Provider accent survives as text/icon color only.
+- "Working…" (between-token proof-of-life): inline gray text + pulse icon + bouncing dots + the elapsed counter (the counter is load-bearing — a ticking number proves a minutes-long reasoning model is alive; a static spinner can't).
+- "Thinking…" (tools executing): same, keeping its indigo tint so tool activity reads distinct.
+
+**Content layer — framed:**
+- Tool result bubbles, approval cards, proposal cards (generation, column options, flashcards), batch gallery cards, artifact/note cards. These persist and act; they get borders.
+
+**Litmus test for a new element:** will this row still mean something when the turn is over? Yes → it may be a card. No (it describes what is happening *right now*) → borderless text.
+
+## Related conventions (same pass)
+
+- **One labeled home for chat calibrations:** the ChatControlPanel hosts target folder, target output, model lock, and context as single-line settings rows (label left, control right, hints behind tooltips). Rail and header stay minimal — no duplicated affordances.
+- **Toolbar actions are icon-only** with the label as tooltip (Export, Export Chat).
+- **Chip icons mirror state**, never decorate: the output-target chip shows the *selected* mode's icon (chat/under-content/folder), not a generic glyph.
+- **Portaled floating layers, dismissed by DOM order:** menus/panels portal to `<body>`; click-away handlers exempt layers appended *after* themselves (portal append order is the z-stack's chronological record) rather than inspecting `position` styles, which false-positive on the app shell.

--- a/docs/notes-feature/work-tracking/AI-ROADMAP.md
+++ b/docs/notes-feature/work-tracking/AI-ROADMAP.md
@@ -25,7 +25,7 @@ authoritative category map is an enhancement, not a blocker.
 
 ## Planned (owner-ordered 2026-07-25)
 
-### 3.6 — Playbook completeness  ← BUILT (pre-PR, branch `feat/ai-v3.6-playbook-completeness`)
+### 3.6 — Playbook completeness  ← SHIPPED (verified on main 2026-09-04: `charters/render.ts` carries the v3.6 lossless upgrade, DELETE unmark route live; the pre-PR branch was folded in and no longer exists)
 Scope correction from the original T3-deferral list: the **SKILL.md import
 adapter already shipped with T3** (`playbooks/import/skill-md.ts` +
 `ImportSkillDialog`) and is **already lossless on the way in** — `markdownToTiptap`
@@ -56,7 +56,15 @@ was rewired to `markdownToTiptapRich` in T2. So 3.6 reduced to two real items:
   /api/content/playbooks/mark?contentId=…` + `stripPlaybookMetadata` (idempotent,
   preserves other metadata); mark/edit reuse the idempotent POST upsert.
 
-### 3.7 — Resource governance
+### 3.7 — Resource governance  ← LARGELY SUPERSEDED BY JUDGMENT (2026-09-04)
+**The enforcement centerpiece (token/step caps, decrement + stop) was
+deliberately NOT built** — owner + judgment recorded in
+EXTRACTION-TO-DATABASE-PLAN §9.2: the existing item caps / batch checkpoints /
+step caps ARE the graceful budgets, and §9.1's production measurements show
+them working. Remaining rows re-scoped: sub-agent isolation → rides the P6
+deferred-batch runner (structurally free there); loop guards + effort
+allocation → revisit only if real usage produces the failure mode. Build
+token caps only if a runaway appears that the existing caps miss.
 The **enforcement** half of agentic discipline (we shipped the observability —
 token meter, Run Ledger, `phase_checkpoint` — not the enforcement). From
 [AGENTIC-RESOURCE-DISCIPLINE.md](../guides/ai/AGENTIC-RESOURCE-DISCIPLINE.md)
@@ -67,7 +75,7 @@ governance" from the resource-discipline doc — NOT the v3.2 "T4" (resumable
 streams, shipped as 3.3). Its per-run compaction sub-item stays backlogged with
 R5b (same machinery).
 
-### ~3.8 — Chat control panel + chat-surface fixes  (right before T6)
+### ~3.8 — Chat control panel + chat-surface fixes  ← BUILT (2026-09-04, branch `feat/ai-v38-control-panel`: ChatControlPanel hosts file-target/output-target/model-pin/context with labels, Feather context icon, rail condensed to the model picker; deriveTargetSeed single-sources the inherited-target chip across ChatPanel/ChatViewer so expand is loss-less)
 Two sprints, one milestone:
 - **Control panel** — one panel hosting the file-target, output-target, and
   pin-model affordances **with real labels** (the footer rail has no room

--- a/extensions/workplaces/server/service.ts
+++ b/extensions/workplaces/server/service.ts
@@ -1033,13 +1033,15 @@ export async function saveWorkspaceState(
       : { status: "ok", workspace: await readFormatted() };
   }
 
-  const updatedWorkspace = await prisma.contentWorkspace.update({
-    where: { id: workspaceId },
-    data,
-    include: stateInclude,
-  });
-
-  return { status: "ok", workspace: formatWorkspace(updatedWorkspace) };
+  // No compare base = this writer never loaded the record it is about to
+  // overwrite. Every legitimate client primes its base at load / create /
+  // 409-adoption; the observed null-base writers were stale clients whose
+  // module-scope base map had been wiped (dev Fast Refresh) — and the old
+  // unconditional last-writer-wins update here let them clobber fresh
+  // arrangements (owner D+D revert report, 2026-09-04). Reconcile instead:
+  // hand back the current row as a conflict; the client adopts it and
+  // retries with a real base, converging in one round.
+  return { status: "conflict", workspace: await readFormatted() };
 
   async function readFormatted() {
     const current = await prisma.contentWorkspace.findFirstOrThrow({

--- a/lib/domain/ai/output-target.ts
+++ b/lib/domain/ai/output-target.ts
@@ -194,3 +194,31 @@ export function renderOutputTargetInstruction(target: OutputTarget): string {
     "Use parentId only for a specifically resolved folder UUID. Otherwise omit both placement fields — do not substitute the active file's parent, the operating-context folder, or another inferred location."
   );
 }
+
+// ── Target-folder chip seed (AI 3.8 fix sprint) ───────────────────────────
+
+export interface TargetSeed {
+  target: { id: string; title: string | null } | null;
+  inherited: boolean;
+}
+
+/**
+ * Single-source seed for the target-folder chip: an explicit target wins;
+ * otherwise the chat's LOCATION is inherited. ChatPanel and the full-page
+ * ChatViewer both derive through this, so expand-to-full-view can never
+ * drop an inherited chip again (the viewer used to seed only from the
+ * persisted target and rendered blank where the panel showed inheritance).
+ */
+export function deriveTargetSeed(input: {
+  explicit: { id: string; title: string | null } | null;
+  explicitInherited: boolean;
+  location: { id: string; title: string | null } | null;
+}): TargetSeed {
+  if (input.explicit) {
+    return { target: input.explicit, inherited: input.explicitInherited };
+  }
+  if (input.location) {
+    return { target: input.location, inherited: true };
+  }
+  return { target: null, inherited: false };
+}

--- a/lib/domain/tools/registry.ts
+++ b/lib/domain/tools/registry.ts
@@ -85,6 +85,9 @@ const TOOL_REGISTRY: ToolDefinition[] = [
     contentTypes: ["chat"],
     order: 100,
     group: "export",
+    // Icon-only like its sibling export tool (owner, 2026-09-04) — the
+    // label survives as the hover tooltip.
+    iconOnly: true,
   },
 
   // ─── TOOLBELT: Text formatting (matches current BubbleMenu) ───


### PR DESCRIPTION
# Release 6: Chat control panel & workspace write-guard (AI 3.8)

Two lanes in one stretch, one smoke session (owner direction): the AI 3.8 milestone plus the workspace fan-in hardening that closes the D+D revert mechanism.

## Lane 2 — AI 3.8 (roadmap)
- **Chat control panel** — a `SlidersHorizontal` trigger in the composer rail opens a portaled panel (upward, viewport-bottom aware) hosting the four chat calibrations **with real labels + hints**: File target, Output target, Model pin (with pinned/unpinned state text), and Context — which gets its writing-themed **Feather** icon. One component, two mounts (sidebar ChatPanel + full-page ChatViewer). Dismisses on click-away (fixed-layer exemption handles the nested-portal trap: hosted pickers' menus and toasts count as inside), plus ✕ / Escape / trigger. Row hints live behind native tooltips (first compact step).
- **Rail condensed** — pin + context icons leave the rail (moved into the panel); the rail keeps the make/model picker. Supersedes the "condense the rail" backlog item. **Header target chips retired too** (owner direction): the panel is the chips' single home; headers keep only title, association chips, and window actions.
- **Fix sprint: expand is loss-less** — `deriveTargetSeed` (lib/domain/ai/output-target) single-sources the target-chip seed: explicit target wins, else the chat's location inherits. ChatViewer previously seeded only from the persisted target and dropped the inherited chip on expand-to-full-view.
- Roadmap updated: 3.6 marked shipped (verified on main), 3.7 annotated largely-superseded (graceful-budgets judgment), 3.8 as-built.

## Lane 1 — workspace fan-in hardening
- **Null-base state writes reconcile instead of clobbering.** A writer with no compare base never loaded the record it's overwriting (all legitimate clients prime their base at load/create/409-adoption; the observed null-base writers had their base map wiped by dev Fast Refresh). The old unconditional last-writer-wins tail let stale clients silently revert fresh drag-and-drop arrangements. Null base on an existing record now returns `conflict` with the current row — the existing adopt-and-retry client loop converges in one round. Closes the D+D backlog wound at the mechanism.

## Gates
`pnpm typecheck` ✅ · `pnpm lint` (151, no growth) ✅ · **full `pnpm build`** ✅

## Pre-merge checklist (owner verdicts — one smoke session)
- [x] **Smoke (panel):** open the sliders trigger in the sidebar chat → panel opens upward with four labeled rows; each affordance works (pick a file target, change output target, toggle pin, switch context); clicking INSIDE a picker's own menu does NOT dismiss the panel; clicking the page background DOES; ✕/Escape also close; hover a row for its tooltip hint
- [x] **Smoke (full view):** same panel works in a full-page chat
- [x] **Smoke (rail + header):** composer rail shows only the model picker + sliders trigger (pin/context icons gone); chat header no longer shows the file/output target chips (they live in the panel)
- [x] **Smoke (expand loss-less):** sidebar chat with an inherited target chip (no explicit target) → expand to full view → the chip survives, marked inherited
- [x] **Smoke (D+D guard):** split panes, drag a tab between panes, work normally for a few minutes → arrangement holds; if you can reproduce the old revert (second window/stale client), it should now self-correct in one reconcile instead of reverting your drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)



