### PR TITLE
Idle gating: engagement core, polling scheduler, and a 401 interceptor

### DIFF
--- a/components/content/AuthSessionSync.tsx
+++ b/components/content/AuthSessionSync.tsx
@@ -10,24 +10,24 @@ import {
   subscribeAuthSessionEvents,
 } from "@/lib/infrastructure/auth/client-session-events";
 import { clientLogger } from "@/lib/core/logger/client";
+import { registerPollingTask } from "@/lib/core/polling/scheduler";
+import { installSessionInterceptor } from "@/lib/infrastructure/auth/session-interceptor";
 
-// 60 s, and only while the tab is visible.
+// A slow SAFETY NET, not the detection mechanism.
 //
-// This poll drives *proactive* UI sign-out only. Authorization itself happens
-// server-side on every real API call, so a revoked session can never actually
-// do anything — a slower poll just means a stale UI for longer, and only in a
-// tab nobody is looking at.
+// Detection now happens three other ways, all of them instant and all of them
+// free (D15 in POLLING-DISCIPLINE-PLAN.md):
 //
-// The cost matters because this component mounts app-wide: its interval
-// multiplies by every open tab, and each call validates the session against
-// Postgres. At 10 s ungated it was the single largest source of idle database
-// load in the app, which on metered infrastructure is billed twice — once for
-// the function that serves it and once for the database that never gets to
-// sleep. See docs/notes-feature/infrastructure/PLATFORM-PORTABILITY.md.
+//   another tab signed out   -> BroadcastChannel, via subscribeAuthSessionEvents
+//   the user does anything   -> the 401 interceptor installed below
+//   actively collaborating   -> Hocuspocus push
 //
-// Paired with an immediate re-check on tab-visible, so someone returning to a
-// backgrounded tab never waits a full minute to learn they were signed out.
-const AUTH_STATUS_INTERVAL_MS = 60_000;
+// So this poll exists only to catch the case where a session dies and the user
+// then does nothing at all — which by definition nobody is waiting on. Ten
+// minutes is deliberately longer than Neon's 5-minute autosuspend window, so an
+// untouched app leaves the database genuinely contiguous quiet rather than
+// prodding it awake every minute.
+const AUTH_STATUS_INTERVAL_MS = 10 * 60 * 1000;
 const SIGNED_OUT_MESSAGE = "You were signed out. Sign in again to continue editing.";
 // Require this many consecutive 401s before triggering sign-out.
 // Three in a row is authoritative: at a 60 s cadence every check is far past
@@ -65,28 +65,13 @@ export function AuthSessionSync() {
     const unsubscribe = subscribeAuthSessionEvents(handleSignedOut);
     let isCancelled = false;
     let consecutiveFailures = 0;
+    // Assigned below; referenced from verifySession, which only runs once the
+    // scheduler ticks — long after this closure is fully initialised.
+    let unregisterPoll: (() => void) | null = null;
 
-    // When the tab becomes visible again after a sleep/suspend, the frozen
-    // interval timer fires immediately on wake. Any cached null from the moment
-    // the computer slept carries forward into the first post-wake poll, making
-    // a transient DB reconnection error look like two consecutive 401s.
-    // Resetting here ensures the post-wake count always starts at 0.
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== "visible") return;
-      if (consecutiveFailures > 0) {
-        clientLogger.info({
-          layer: "ui",
-          event: "session_check:counter_reset_on_wake",
-          summary: `Resetting ${consecutiveFailures} consecutive failure(s) after tab visibility restored`,
-        });
-        consecutiveFailures = 0;
-      }
-      // The interval does not run while hidden, so the session state may be up
-      // to AUTH_STATUS_INTERVAL_MS stale on return. Check immediately rather
-      // than making the user wait out the remainder of the cycle.
-      void verifySession();
-    };
-    document.addEventListener("visibilitychange", handleVisibilityChange);
+    // Learn about revocation from requests we were already making. This is the
+    // primary detection path; everything below is a fallback.
+    const uninstallInterceptor = installSessionInterceptor();
 
     const verifySession = async () => {
       // Guard at entry: if sign-out has already been triggered (isCancelled),
@@ -116,7 +101,7 @@ export function AuthSessionSync() {
             // log noise and duplicate publishSignedOut calls seen when the interval
             // keeps firing during the router.replace transition.
             isCancelled = true;
-            window.clearInterval(interval);
+            unregisterPoll?.();
             clientLogger.warn({
               layer: "ui",
               event: "session_check:signing_out",
@@ -140,21 +125,27 @@ export function AuthSessionSync() {
       }
     };
 
-    // Gate inside the callback rather than tearing the timer down and rebuilding
-    // it on every visibility flip — same pattern as
-    // extensions/workplaces/state/workspace-sync.ts, which is the reference
-    // implementation for polling discipline in this codebase.
-    const interval = window.setInterval(() => {
-      if (document.visibilityState === "visible") {
-        void verifySession();
-      }
-    }, AUTH_STATUS_INTERVAL_MS);
+    // Registered with the shared scheduler rather than owning a timer. Gating
+    // (hidden and idle both pause) lives in the scheduler, so there is nothing
+    // to check here.
+    //
+    // scope: "leader" matters more than the interval does. This component mounts
+    // app-wide, so before leader election five open tabs meant five independent
+    // session checks for one human. Now exactly one tab asks, and the answer
+    // reaches the others over the BroadcastChannel this component already
+    // subscribes to above.
+    unregisterPoll = registerPollingTask({
+      id: "auth-session-check",
+      intervalMs: AUTH_STATUS_INTERVAL_MS,
+      scope: "leader",
+      run: verifySession,
+    });
 
     return () => {
       isCancelled = true;
-      window.clearInterval(interval);
+      unregisterPoll?.();
+      uninstallInterceptor();
       unsubscribe();
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [pathname, router, searchParams]);
 

--- a/components/content/headers/MainPanelHeader.tsx
+++ b/components/content/headers/MainPanelHeader.tsx
@@ -28,6 +28,7 @@ import { getTabIcon, getTabIconGroupKey } from "./tab-icons";
 import { PaneTabAddButton } from "./PaneTabAddButton";
 import { useExtensionShellTabMenuSections } from "@/lib/extensions/client-registry";
 import { getCollaborationBrowserSessionId } from "@/lib/domain/collaboration/runtime";
+import { registerPollingTask } from "@/lib/core/polling/scheduler";
 import { prefetchContent } from "@/lib/domain/content/prefetch";
 import { BorrowedTabBadge } from "@/extensions/workplaces/components/BorrowedTabBadge";
 
@@ -590,11 +591,13 @@ export function MainPanelHeader({
     // looking at the tab strip in a backgrounded window. Each call is a
     // Postgres read, so an ungated 10 s interval keeps the database from ever
     // reaching its autosuspend threshold.
-    const interval = window.setInterval(() => {
-      if (document.visibilityState === "visible") {
-        void fetchPresence();
-      }
-    }, PRESENCE_POLL_INTERVAL_MS);
+    // per-tab: this polls THIS tab's open contentIds, so another tab's answer
+    // would be the wrong one.
+    const unregisterPoll = registerPollingTask({
+      id: "main-panel-tab-presence",
+      intervalMs: PRESENCE_POLL_INTERVAL_MS,
+      run: fetchPresence,
+    });
     // Catch up immediately on return rather than making someone stare at stale
     // tab chrome for up to a full interval.
     const handleVisibilityChange = () => {
@@ -604,7 +607,7 @@ export function MainPanelHeader({
 
     return () => {
       isCancelled = true;
-      window.clearInterval(interval);
+      unregisterPoll();
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [tabContentIds]);

--- a/components/share/SharedContentViewer.tsx
+++ b/components/share/SharedContentViewer.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { registerPollingTask } from "@/lib/core/polling/scheduler";
 
 import type { JSONContent } from "@tiptap/core";
 import Link from "next/link";
@@ -336,19 +337,25 @@ export function SharedContentViewer({ content }: SharedContentViewerProps) {
     // Bundling both into one `tick` is what forced the read to run at the
     // write's cadence. Splitting them cuts reads by 6x while leaving the
     // freshness contract intact.
-    const heartbeatInterval = window.setInterval(() => {
-      if (document.visibilityState === "visible") void heartbeat();
-    }, SHARE_HEARTBEAT_INTERVAL_MS);
-    const presenceInterval = window.setInterval(() => {
-      if (document.visibilityState === "visible") void fetchPresence();
-    }, SHARE_PRESENCE_READ_INTERVAL_MS);
+    // Both idle-gated: an idle viewer is arguably not "present", so letting the
+    // heartbeat lapse is correct rather than merely cheap.
+    const unregisterHeartbeat = registerPollingTask({
+      id: `share-presence-heartbeat:${content.id}`,
+      intervalMs: SHARE_HEARTBEAT_INTERVAL_MS,
+      run: heartbeat,
+    });
+    const unregisterRead = registerPollingTask({
+      id: `share-presence-read:${content.id}`,
+      intervalMs: SHARE_PRESENCE_READ_INTERVAL_MS,
+      run: fetchPresence,
+    });
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") void tick();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
-      window.clearInterval(heartbeatInterval);
-      window.clearInterval(presenceInterval);
+      unregisterHeartbeat();
+      unregisterRead();
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [content.id]);

--- a/docs/notes-feature/work-tracking/AI-TOOLING-ROUND-PLAN.md
+++ b/docs/notes-feature/work-tracking/AI-TOOLING-ROUND-PLAN.md
@@ -1,0 +1,439 @@
+---
+last_updated: 2026-09-06
+status: planned — no build started
+---
+
+# AI Tooling Round — choice card, capability-true gating, server-side edits, URL hygiene, deferred batch
+
+The work selected from the AI backlog after the 3.x line closed (PR #211). Five build
+items, one design-of-record, one new backlog entry. Written after a code investigation
+on 2026-09-05/06; every anchor below was verified against `main` at writing time.
+
+## Scope and verdicts
+
+| # | Item | Verdict from investigation | Size |
+|---|---|---|---|
+| 1 | `ask_user_choice` tool + card | Does not exist in any form. Build, Claude-style restraint contract | 1 session |
+| 2 | Capability-true web-search gating | Gate is per-provider at `route.ts:1439-1456`. Fix is small and non-regressive | ½ session |
+| 3 | Full-page chat targeted edits | **Not a gate removal** — edit tools are client-executed against a live editor. But the server write-through machinery already exists | 1 session |
+| 4 | URL hygiene (ClearURLs + canonical) | Vendor confirmed: 37 KB, 206 providers, LGPL-3.0. Local additions layer is **required**, not optional — data below | 1 session |
+| 5 | SKILL.md import interface | **Already shipped** — backlog line was stale. Tick it | — |
+| 6 | Deferred batch runner | Design of record only; build gated on volume | — |
+| 7 | Model-capability spine ("master class") | New backlog entry; extends the existing catalog + drift-gate spine | — |
+| 8 | HTML/content fluff pass | Reframed as a **periodic audit**, not a one-time build | recurring |
+
+---
+
+## 1. `ask_user_choice` — the restrained choice card
+
+**Confirmed absent.** The app's existing cards (`propose_item_iteration`,
+`propose_research_run`, `propose_column_options`, `propose_output_database`,
+`phase_checkpoint`) all present *one* fully-formed action for approval. None can offer
+alternatives and take a selection. The multiple-choice cards seen in planning sessions
+are rendered by Claude Code, not by this application.
+
+**Design — must work with any model.** No provider-specific structured output, no
+constrained decoding: it is an ordinary tool with a Zod input schema, so any model that
+can call tools can call it. It follows the established sentinel/card contract — the tool
+has **no server `execute`**; the card renders the options; the user's click is submitted
+as the next user turn. A model too weak to call it simply asks in prose, which is
+today's behavior — no regression path.
+
+```
+ask_user_choice({
+  question: string,              // one sentence, ends in a question mark
+  options: Array<{               // 2-4, mutually exclusive unless multiSelect
+    label: string,               // 1-5 words
+    description: string,         // what happens if chosen
+  }>,
+  multiSelect?: boolean,
+})
+```
+
+**Restraint is the whole design problem** (owner's stated concern: a naive version fires
+on every ambiguity). Three mechanisms, defense in depth:
+
+1. **Description-level policy**, phrased as a prohibition rather than an invitation:
+   *"Use only when you are blocked on a decision that is genuinely the user's to make —
+   one you cannot resolve from the request, the content, or a sensible default. Do not
+   use it for choices with a conventional default, for facts you can verify yourself, or
+   to confirm a plan you have already been asked to carry out. When one option is clearly
+   right, take it and say so."*
+2. **Harness guard:** at most one call per turn, and suppressed entirely while another
+   proposal card is pending approval (two stacked cards is the failure mode that makes it
+   feel nagging). A second call in the same turn returns a refusal string telling the
+   model to proceed with its best option.
+3. **Free-text escape** on the card: the user can always answer in their own words
+   instead of clicking, so the tool never narrows the conversation.
+
+**Deliberately NOT the original use case.** The backlog framed this as a
+disambiguator for "note body vs row cells / which of two databases" — owner rejected
+that framing (2026-09-05): building it around routine ambiguity guarantees over-firing.
+Row/database ambiguity stays with the existing prompt-level "ask, name both options"
+guidance.
+
+## 2. Capability-true tool gating
+
+Today `search_web` is attached when the *provider* is a native-search vendor
+([route.ts:1439-1456](../../../app/api/ai/chat/route.ts)). Models that don't support the
+server tool then fail: Anthropic 400s on older Claude models, and OpenAI's
+`web_search_preview` **hangs the turn silently** on `gpt-4` (the worse failure — same
+bug class, same fix).
+
+**Rule (owner-specified, non-regressive by construction):**
+
+- Model's effective capabilities say it **supports** search → attach (as today).
+- Model's effective capabilities say it **does not** → skip.
+- Model is **unknown** to the catalog (a fetched connection model with no capability
+  data) → fall back to today's provider-level behavior, unchanged.
+
+Only the middle branch is new, so nothing that works today can break. `effectiveCapabilities`
+already merges catalog data by bare id at read time, which is what makes the unknown case
+rare rather than routine.
+
+**One addition beyond the stated rule:** when the tool is skipped for a known-incapable
+model, emit a one-line disclosure in the turn's receipts. Silent absence is how the
+original bug hid for months — a user asking "why didn't it search?" currently gets
+nothing to read. Same treatment for the OpenAI preview-tool hang.
+
+## 3. Targeted edits from a full-page chat
+
+**The investigation corrected the premise.** This is not a gate to delete. The edit
+tools are **client-executed**: `apply_diff` has no server `execute` at all
+([editor-tools.ts:432](../../../lib/domain/ai/tools/editor-tools.ts)), and the header
+comment records why — running in the browser against the live ProseMirror document means
+the tool validates in the same representation it applies to, and its result is the edit's
+*real* outcome rather than a pre-announcement. `editableContentId`
+([route.ts:996](../../../app/api/ai/chat/route.ts)) therefore encodes a physical
+dependency, not a permission: there must be a live editor bound to that document in the
+same view. A full-page chat has none. Removing the gate would ship tools that no-op while
+reporting success — the exact bug that motivated client execution.
+
+**The good news, and why this is still one session.** The server-side write-through path
+already exists and is production-hardened:
+[note-edit-ops.ts](../../../lib/domain/collaboration/note-edit-ops.ts) is the sanctioned
+"only place that mutates a collaborative document from outside the editor" — it applies a
+**minimal diff** via `updateYFragment` (untouched blocks keep their Y identity, concurrent
+cursors survive), carries shrink guards (`SHRINK_RETAIN_FLOOR`, `SHRINK_HARD_REFUSE_FLOOR`),
+and persists through the normal collaboration store hook. Its single caller is
+[`writeNoteContent`](../../../lib/domain/content/write-note-content.ts) (line 160). The
+hard parts — Y.Doc identity, minimal diffing, refusal semantics — are done and battle-tested.
+
+**Remaining work, precisely:**
+
+- A third `NoteEditMode` beside `"append" | "replace"` — a targeted find/replace applied
+  to the document JSON before the existing minimal-diff path takes over. The shrink
+  guards apply unchanged and are exactly the right safety net.
+- **Target resolution**, the real design question: a full-page chat has no open document,
+  so the tool needs an explicit target. Resolution order: an explicitly named/mentioned
+  note → the note this turn just wrote (the receipt envelope already carries it) → refuse
+  and ask which note. Never a silent guess.
+- Server-executed variants registered *only* when `editableContentId` is undefined, so
+  the sidebar keeps client execution (still the better path when a live editor exists).
+- Honest results: the outcome reports what actually applied, per the standing
+  tools-report-real-outcomes rule.
+
+## 4. URL hygiene
+
+### 4a. Vendored ClearURLs catalog + local additions
+
+Measured 2026-09-05 from `rules2.clearurls.xyz`: **37 KB minified, 206 providers,
+LGPL-3.0**, 48 global parameter patterns, 15 providers carrying exceptions. Per provider:
+`urlPattern` (regex selecting which URLs it governs), `rules` (parameter-name regexes),
+`exceptions` (URL regexes that bypass processing entirely), plus `redirections`/`rawRules`
+we deliberately ignore. Consumption from TypeScript and the extension's plain JS is one
+vendored JSON plus a ~40-line matcher.
+
+**Why a local additions layer is required — measured, not defensive.** Our 14 hand-named
+parameters tested against the catalog:
+
+| Hand-named parameter | Covered by ClearURLs |
+|---|---|
+| `gclid`, `fbclid`, `mc_cid`, `mc_eid`, `_hsenc`, `vero_id`, `utm_*` | ✅ global rules |
+| `trackingId`, `refId` | ✅ LinkedIn provider |
+| `igshid`, `_hsmi`, `ref_src` | ✅ expected via their own site providers (verify per-URL, not per-parameter) |
+| **`eBP`, `origin`, `originToLandingJobPostings`** | ❌ **absent from the catalog entirely** |
+
+Those three came from our own co-browse audit of LinkedIn job pages. They are the answer
+to "why not just use ClearURLs?" — the upstream catalog does not know them, and (see
+cadence below) will not learn them soon.
+
+**Adopt their provider scoping for our own rules too — it is a safety upgrade.** Our
+current `TRACKING_PARAMS` is a flat `Set` applied to every URL
+([co-browse-tools.ts:31](../../../lib/domain/ai/tools/co-browse-tools.ts)), which means we
+strip the bare parameter `origin` **globally**. That name is generic and functional
+elsewhere (OAuth flows, redirect targets, API calls). Moving our additions into a
+LinkedIn-scoped local provider fixes a real latent hazard we introduced ourselves.
+
+**Exceptions: yes, and they are hand-named per provider** (owner's guess was right). An
+`exceptions` array of URL regexes; on match, *no processing at all* happens for that URL.
+The upstream entries read as a catalogue of things stripping has broken in the wild —
+Google OAuth and Gmail, Amazon cart-ajax endpoints, YouTube sign-in. Our additions file
+carries exceptions in the identical shape.
+
+**Update cadence — the answer to "is ClearURLs not reliable?"** Reliability splits in two.
+The *catalog* is correct and stable: tracking parameter names barely churn (`utm_*` has
+been stable for over a decade). The *project* is close to dormant — the rules repository's
+most recent commit is **2026-03-25**, and the one before it **2025-07-29**. Consequences,
+which settle the update question exactly as the owner intuited:
+
+- A vendored snapshot refreshed by a manual `pnpm tracking:rules:sync` script is right.
+  A scheduled cron would poll a file that changes roughly twice a year.
+- **Our additions file is where the value accrues**, and it is the thing that actually
+  gets updated — new parameters discovered by session audits, reviewed before landing.
+  Tracking parameters we discover *are* the exception that requires updating.
+
+**License note that reinforces the architecture:** LGPL-3.0 on a data file means vendoring
+it **unmodified** with its notice intact, and keeping our changes in a separate file we
+own. The clean-license path and the good-engineering path are the same two-file split.
+
+**Where stripping applies (recommended, D1 below):** model-facing context and ledger
+identity keys only — never URLs the agent navigates to. The breakage risk lives entirely
+in that second variant: a stripped parameter can be functional (session, filter,
+pagination, presigned), and the upstream exceptions list is empirical proof that
+browser-style stripping breaks real flows. Cleaning context and identity keys cannot break
+navigation because navigation never reads them.
+
+**Investigation finding — identity keys are not stripped at all today.**
+`stripTrackingParams` has exactly **one** app call site
+([use-conversation-engine.ts:2188](../../../lib/domain/ai/use-conversation-engine.ts),
+open-tab listing) plus the extension's mirror. The quest ledger keys url-tier items on the
+**raw trimmed URL**, so every tracking-parameter variant of one posting currently mints a
+**separate ledger row** — a live correctness defect in cross-sitting dedup, which is the
+largest measured token saving in the arc. Extending normalization to identity is therefore
+a fix, not hygiene.
+
+**Normalize on comparison, not only on write — this is what makes healing retroactive.**
+The ledger already stores the item's URL in its own column alongside the key
+([quests.ts:92](../../../lib/domain/ai/quests.ts)), so the raw truth survives. If dedup
+compares `normalize(candidate)` against `normalize(row.URL)` at read time, then improving
+a rule **retroactively repairs rows already written** — no key migration, no backfill, and
+a bad rule is revertible because nothing lossy was ever persisted. Standing principle:
+**store raw, normalize at use.** Any design that overwrites the stored URL with its
+stripped form forecloses every healing loop below.
+
+### 4b. Canonical-URL surfacing
+
+Worth building, with three guards. The extension reports `<link rel="canonical">`
+alongside the address-bar URL; it is a **display and dedup hint only**, never a navigation
+substitute.
+
+- Read **after navigation settles** (single-page apps leave stale canonicals) — the
+  extension's settle-then-associate step is the existing hook.
+- Accept only **same registrable domain, non-root path** (AMP and mirror pages point
+  cross-host; a canonical pointing at `/` is a site-wide default, not an identity).
+- **Never** for pagination pages, which routinely canonicalize to page 1.
+
+Long-run reliability is good for the sites that matter, because their search ranking
+depends on the tag being accurate — that incentive is durable. Its distinct value is as a
+remainder-catcher: parameter rules collapse query-string variants, while canonical
+additionally collapses *path and host* variants (mobile subdomains, locale prefixes) that
+no parameter list can reach. LinkedIn is the flagship case — tracking-laden job URLs
+canonicalize to a bare `/jobs/view/<id>`, exactly the quest-ledger identity key.
+
+### 4c. Self-healing loops
+
+The vendored catalog is the floor, not the product. What makes the ruleset an asset is
+that real work teaches it. Two failure modes are worth naming, because a loop that watches
+only one of them is how rulesets rot:
+
+- **Under-stripping** → the same item is captured twice under different keys. Cost:
+  re-reading a page the quest already judged (3–10k tokens), plus a duplicate row.
+- **Over-stripping** → two genuinely different items collapse onto one key. Cost:
+  silent data corruption, which is strictly worse. Upstream has made this mistake — a
+  2025-06-21 commit in the rules repository reads *"remove the `q` parameter"*, i.e.
+  retiring a rule that had been stripping a functional search term.
+
+Four loops, ordered by evidence quality. None of them applies a rule automatically.
+
+**Loop A — canonical delta (authority-driven, highest precision).** When the extension
+reports `<link rel="canonical">` alongside the observed URL, the parameters present in the
+observed URL and absent from the canonical are the **site's own declaration** that they do
+not bear identity. This is not inference; it is the publisher telling us. Candidates are
+automatically scoped to that site's provider, which is exactly the shape our local
+additions need. This makes canonical surfacing (§4b) load-bearing infrastructure rather
+than a nicety: it is the training signal for the ruleset, not just a dedup hint.
+
+**Loop B — ledger reconciliation (outcome-driven, bidirectional).** An audit pass over
+quest-ledger rows, and the only loop that sees the real cost of a miss:
+
+- *Under-strip detection:* rows whose URLs are identical after path and host comparison but
+  differ in query parameters. The differing parameter names are candidates, ranked by how
+  many duplicate rows and re-reads they caused — a token figure you can put in the report.
+- *Over-strip detection:* rows sharing one normalized key whose captured content diverges
+  (different titles, different verdict fingerprints). That is proof a stripped parameter
+  was identity-bearing, and it emits an **exception proposal**, not a rule.
+
+Because normalization happens at comparison time, this loop can be run over history the
+day it is written — it does not have to wait for new data.
+
+**Loop C — upstream sync reconciliation (keeps the layers deduped).** Part of
+`pnpm tracking:rules:sync`: diff the incoming snapshot against the current one and against
+our additions, then (i) **retire local rules the catalog has absorbed**, so our file shrinks
+as upstream grows, (ii) flag conflicts where an upstream exception contradicts one of our
+rules — upstream wins by default, since an exception encodes someone's breakage, and
+(iii) report coverage. Given the repository's ~twice-yearly cadence, this runs on demand,
+not on a schedule.
+
+**Loop D — session-audit ranking (discovery, never authoritative alone).** The scripted
+audit harness ranks query parameters seen across recent sessions by frequency and by bytes
+consumed. Its output is a **priority queue for investigation**, not a proposal: a parameter
+graduates only when Loop A or Loop B corroborates it. This is the guard against fuzzy
+inference, which stays banned.
+
+**Governance — the loops propose, a human accepts.** All four write into one review file
+rather than the live ruleset; `pnpm tracking:rules:audit` runs them and prints the report.
+Every accepted addition records its **provenance** — which loop, what evidence, what date —
+directly in the additions file, so a rule that later causes a collision can be traced and
+reverted rather than archaeologically re-derived. Two standing rails: a **never-strip
+allowlist** (`q`, `id`, `page`, `sort`, `filter`, `token`, and anything an item's own
+identity depends on), and a promotion ladder (candidate → corroborated across ≥2 hosts or
+≥3 items → proposed → accepted). Contributing confirmed rules back upstream is optional
+and low-yield while that project is dormant.
+
+**Why this satisfies "self-maintaining" without auto-discovery.** The system detects its
+own failures, quantifies them in tokens, proposes the specific fix, and gates it — the same
+posture chosen for the capability spine in §6: make gaps *visible and gated* rather than
+silently patched.
+
+## 5. Deferred batch execution — design of record
+
+Not built. Recorded so the shape is settled before volume justifies it.
+
+**Two consumption models, and they differ structurally.**
+
+*Model A — vendor batch APIs (≈50% discount, ≤24h).* The catch is that batch endpoints
+process single request→response calls, **not agentic loops**. A sitting today is a loop
+(fetch, judge, write a row, repeat) and each tool round-trip would cost a batch cycle —
+worst case a day per turn. Batch APIs therefore only fit work split into **acquisition
+first, judgment second**: fetch page content synchronously (cheap, no model involved),
+then batch the pure-LLM steps (scoring, tailoring against already-fetched content). That
+split is natural for stage-2 row passes, where items are rows the system already holds,
+and unnatural for stage-1 discovery.
+
+*Model B — off-peak scheduling through the live path.* DeepSeek has no batch API but
+discounts 50–75% during its off-peak window (16:30–00:30 UTC). A cron running queued row
+work through the ordinary synchronous path during that window gets batch-class savings
+with **zero new substrate** and the full agentic loop intact. Lowest-effort first
+increment; build this before any async-batch machinery.
+
+**How approvals work.** Consent must travel, so the grant needs a durable home the
+executing job rediscovers:
+
+- The existing proposal card gains a **"run deferred"** option showing the discounted
+  estimate beside the live one. Approval enqueues row-work units instead of executing them.
+- **The approval record IS the grant.** The queue row stores the approved capture config,
+  charter identity, quest identity, and the row set — the same envelope that rides ledger
+  metadata today. The runner never re-derives permission from ambient context, because it
+  has none.
+- **Scope is frozen at approval.** The job may only touch the rows named in the grant. New
+  rows discovered later require a new approval; a vanished row rejects and the run moves on
+  (the existing rows-pass semantics).
+- Results land through the **same validate-all upsert path** as live capture — cells
+  stamped, quest-ledger rows updated, one reconciliation entry in the quest log.
+  Per-row failures are independent and restartable.
+- **Completion announcement:** the Connections/Inbox event log is the existing surface;
+  the reconciliation entry in the quest log is the durable record.
+- Recurring schedules ("re-score all Screened rows nightly") are **out of scope** — that
+  crosses from deferral into standing automation and needs its own consent model.
+
+**How the system knows which models support batch.** Batch is a property of the
+*endpoint*, not the model family, so it must be resolved at the connection level, not
+inferred from a model id:
+
+- A **direct-vendor BYOK connection** may advertise batch; a **gateway connection never
+  does** — the gateway does not broker batch jobs, so a gateway-routed model with an
+  otherwise batch-capable id must resolve to "not available."
+- Express it as a capability on the provider catalog entry so the existing
+  `ai:drift:check` gate enforces it the way it enforces context windows and reasoning
+  config — a new vendor template with no batch declaration fails the gate rather than
+  silently defaulting.
+- `pricing.ts` must gain a **tier flag** before any of this ships: batch/flex tiers are
+  explicitly unmodeled today, and the turn accumulator prices per-request, so batch
+  results would be mispriced at full rate.
+
+## 6. New backlog entry — the model-capability spine
+
+Owner-identified recurring problem (2026-09-05): tracking the quirks of an
+any-make-and-model multiplex is a persistent tax — capability gaps surface as production
+failures (search on incapable models, DeepSeek missing from role menus, batch availability
+next) rather than as something the system knows about itself.
+
+The spine already half-exists and should be extended rather than replaced:
+`PROVIDER_CATALOG` + `ModelMeta.capabilities`
+([providers/types.ts:27](../../../lib/domain/ai/providers/types.ts)), the generated
+`AI-CAPABILITY-MATRIX.md` (`pnpm ai:matrix`, guarded by `ai:matrix:check`), the five
+`ai:drift:check` gates, and read-time `effectiveCapabilities` merging. What is missing is
+**gap awareness**: capability dimensions that exist in the world but nowhere in the
+tables (batch APIs, structured output, tool-use quality tiers, vision, audio), and any
+signal when a fetched model lands with no capability data at all. Proposed shape: extend
+the capability enum, have the matrix generator emit an explicit **"unknown / unverified"**
+column rather than silently omitting, and surface at-use-time provider errors as
+capability corrections. Deliberately **not** a runtime probing system — the owner's
+"self-maintaining" framing is satisfied by making gaps *visible and gated*, not by
+auto-discovery.
+
+## 7. HTML/content fluff pass — reframed as periodic
+
+Owner call (2026-09-05): this is not a one-time build but a recurring audit. The
+scripted session-audit harness (the loop that discovered tracking parameters as a bloat
+class) is the durable artifact; each run's findings graduate into either the local
+additions file or a structural filter rule. Standing constraint unchanged: cut only what
+classifies as chrome by **role and structure**, never by content similarity — fuzzy
+removal of content text stays banned.
+
+## 8. Decisions needed
+
+- **D1 — stripping posture.** Recommended: context + identity keys only; navigation URLs
+  untouched. (Default recorded; flip if you want browser-style cleaning.)
+- **D2 — affiliate/referral class** (`ref=`, partner tags; ClearURLs marks these
+  separately). Recommended: strip in context and identity keys like any tracker — for our
+  purposes they are identity noise. No revenue interest is at stake.
+- **D3 — target resolution for server-side edits** when a full-page chat names no note:
+  refuse and ask (recommended) versus defaulting to the turn's last written note.
+- **D4 — `ask_user_choice` free-text escape:** always present (recommended) versus
+  options-only for genuinely closed sets.
+- **D5 — which healing loops ship in this round.** Recommended: **C** (free, part of the
+  sync script) and **B** (highest value, runs over existing history immediately), with
+  **A** following the canonical work and **D** left to the periodic audit cadence of §7.
+
+## 9. Sequencing and PR shape
+
+One release train, one PR, per the release-PR consolidation rule; fixes ride as commits.
+
+1. Capability-true gating (½ session) — smallest, independently verifiable.
+2. `ask_user_choice` (1 session) — new tool + card + restraint guards.
+3. URL hygiene (1 session) — vendored catalog, local additions with provider scoping,
+   read-side normalization extended to ledger identity, canonical surfacing,
+   `tracking:rules:sync` with Loop C, and `tracking:rules:audit` with Loop B.
+4. Server-executed targeted edits (1 session) — the largest; lands last so a schedule
+   overrun does not block the rest.
+
+This plan document rides that PR (no standalone docs-only PRs).
+
+## 10. Chips and traceability
+
+- **`ask_user_choice`** renders as a card, and the user's selection persists as a visible
+  chip on the resulting user turn — so a reloaded conversation still shows *which* option
+  was chosen, not just the resulting text. Applied-state keyed by proposal **content**,
+  never message id.
+- **Skipped-tool disclosure** (item 2) appears in the turn's receipts, one line, naming
+  the model and the capability that was absent.
+- **Server-executed edits** attach the existing content-write receipt envelope, so an
+  edit made from a full-page chat is as traceable as one made in the sidebar — clickable
+  affordance, effective destination named.
+- **URL hygiene** is invisible by design (context-only), with one exception: when a
+  canonical URL replaces a captured item's identity key, the quest ledger row records
+  both, so a surprising dedup can be explained after the fact.
+- **Deferred batch** (when built): the queue entry is the chip — approved scope, model,
+  window, and current state visible while it waits, not just after it finishes.
+
+## 11. Gates
+
+`pnpm typecheck` → `pnpm lint` (175 ratchet) → `pnpm build`, plus `pnpm ai:drift:check`
+for anything touching capability tables and `pnpm ai:matrix` regeneration if the enum
+changes. New gate: `pnpm tracking:rules:check` (vendored snapshot parses; hash matches;
+local additions do not duplicate an upstream rule) — **mutation-test it before trusting
+it**, per standing practice. Browser smoke for the choice card and for a full-page-chat
+targeted edit against a note open in another window (the concurrent-cursor case the
+minimal-diff path is designed to survive).

--- a/docs/notes-feature/work-tracking/POLLING-DISCIPLINE-PLAN.md
+++ b/docs/notes-feature/work-tracking/POLLING-DISCIPLINE-PLAN.md
@@ -1,8 +1,8 @@
 # Polling Discipline — decisions, shipped work, and what remains
 
 **Last updated:** 2026-09-09
-**Status:** Phase 0 shipped (PR #213). Phases 1–4 not started.
-**⚠ Phase 0 does NOT address an always-open PWA** — every gate it shipped keys on visibility, and a visible-but-idle PWA never triggers one. See "The dominant case" below. Phase 2 is the fix.
+**Status:** Phases 0, 2, 2b and 4 shipped. Phase 1 (Hocuspocus awareness) forked; Phase 3 partially absorbed into Phase 2.
+**Always-open PWA: FIXED.** Idle gating now exists and all ten pollers are on the shared scheduler, so an untouched PWA goes quiet on every meter within ~60 s. The warning that used to live here — that Phase 0 only handled *hidden* tabs — no longer applies.
 **Invariant:** *the page goes cold when nobody is actively using it.*
 
 ---
@@ -152,9 +152,17 @@ gating endangers them:
 polls*. Push transports (SSE, WebSocket, streaming HTTP) and UI-only timers are
 untouched by design. That is the payoff of keeping the distinction sharp.
 
-**TODO before Phase 2 ships:** trace co-browse and extraction/quest status polling
-and classify them. Both are long-running surfaces a user plausibly watches without
-touching anything.
+**RESOLVED 2026-09-09.** Both traced, and neither is a risk:
+
+- **Co-browse / agentic browsing** — the only timer is `CoBrowseIndicator`'s 1 s
+  elapsed-time tick, verified to make no network calls. The agent drives the page
+  via CDP in the extension and results arrive over the chat stream, so there is
+  no status polling to gate.
+- **Extraction / quest sittings** — **no timers at all** in the quest or sitting
+  UI. Generation progress arrives over the chat stream, which is push.
+
+Both are structurally safe for the same reason the rest of the passive-watch list
+is: idle gating applies only to network polls, and neither surface has one.
 
 ### D2a — Could `MainPanelHeader` / `presence-poll` move to Hocuspocus after all?
 
@@ -234,6 +242,46 @@ So the interceptor must act only on 401s from **our own routes**, and only when 
 `AuthSessionSync` mounts app-wide and is the **last-man-standing poller** — gate everything else perfectly and it alone still keeps Neon from ever suspending. Gating it helps; **removing its job** is better. With push and piggyback carrying detection, the poll becomes a fallback nobody relies on, and can run slowly enough to leave Neon the contiguous quiet it needs.
 
 **The reframe: an idle user does not need to know they are signed out.** Nothing can happen to them — the server rejects everything. The instant they act, the interceptor fires. Detection latency only matters if harm can occur in the gap, and none can.
+
+### D16 — `scope: "leader"` requires the RESULT to propagate cross-tab
+
+Found while migrating, before it shipped. The notification badge and
+`workspace-sync` were both first written as `scope: "leader"`, on the reasoning
+that an unread count is identical in every tab. **That is true and irrelevant.**
+
+Leader election means the elected tab fetches and **every other tab fetches
+nothing**. If the result lands only in the leader's own store, every follower
+starves — a frozen bell, a stale list — and it presents as a caching bug rather
+than a scheduling one, which is the worst kind to debug.
+
+`workspace-sync` fails the same test more subtly: it *has* a BroadcastChannel,
+but it carries *"a mutation happened, go refetch"*, not the answer. **A nudge is
+not propagation** — it just restores per-tab polling under another name.
+
+**The bar:** a real cross-tab channel carrying the *answer*. Today only
+`auth-session-check` clears it, because `publishSignedOut()` broadcasts over
+BroadcastChannel with a localStorage fallback. The constraint is documented on
+the `scope` field itself, where someone reaching for `"leader"` will read it.
+
+### D17 — `ui-only` must not be a hiding place
+
+`ui-only` skips every other check, which makes it the obvious place to park a
+network poller — deliberately, or by drift when someone later adds a `fetch` to a
+file that used to be a pure animation.
+
+The gate now asserts a `ui-only` file makes **no network calls at all**. That is
+blunt, and deliberately so: a file whose timers are genuinely local has no reason
+to contain any.
+
+For the legitimate exception — a local timer in a file with unrelated network
+code — set `networkUnrelated: true` with a note saying what was traced. The first
+real instance was `app/(public)/layout.tsx`: a 4 s carousel timer alongside an
+email-form submit handler, event-driven and unrelated.
+
+**Honest limitation:** `networkUnrelated` is an escape hatch, and mutation
+testing confirms a determined person can walk through it by asserting something
+false. The mitigation is that it requires a human to write the assertion and it
+shows up in the diff. That is the trade, not a claim of airtightness.
 
 ### D14a — "Zero background pinging" is per-meter, not global
 

--- a/extensions/studio/components/RunsPanel.tsx
+++ b/extensions/studio/components/RunsPanel.tsx
@@ -12,6 +12,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { CheckCircle2, Loader2, XCircle } from "lucide-react";
 import { useContentStore } from "@/state/content-store";
+import { registerPollingTask } from "@/lib/core/polling/scheduler";
 
 export interface RunDtoClient {
   id: string;
@@ -71,17 +72,21 @@ export function RunsPanel({
   // cutting request volume by 40%.
   useEffect(() => {
     if (!anyRunning) return;
-    const timer = setInterval(() => {
-      if (document.visibilityState === "visible") {
-        void fetchRuns(folderId);
-      }
-    }, POLL_MS);
+    // keepAliveWhile: someone watching a progress bar without touching the mouse
+    // is at their MOST attentive, so idle must not freeze the display. It goes
+    // quiet the moment the run finishes, even if they are still sitting there.
+    const unregisterPoll = registerPollingTask({
+      id: `studio-runs:${folderId}`,
+      intervalMs: POLL_MS,
+      keepAliveWhile: () => anyRunning,
+      run: () => fetchRuns(folderId),
+    });
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") void fetchRuns(folderId);
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
-      clearInterval(timer);
+      unregisterPoll();
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [anyRunning, folderId, fetchRuns]);

--- a/extensions/workflows/components/RunDetail.tsx
+++ b/extensions/workflows/components/RunDetail.tsx
@@ -18,6 +18,7 @@ import {
 import { deriveChain } from "../graph/chain";
 import { workflowGraphSchema } from "../graph/schema";
 import { getAnyNodeMetadata } from "../nodes/triggers";
+import { registerPollingTask } from "@/lib/core/polling/scheduler";
 
 /** Live-run refresh cadence. Only armed while a run is non-terminal and the tab is visible. */
 const RUN_POLL_MS = 5000;
@@ -300,15 +301,18 @@ export function RunDetail({
   // imperceptible to a watcher and cuts request volume by 40%.
   useEffect(() => {
     if (!active) return;
-    const timer = setInterval(() => {
-      if (document.visibilityState === "visible") void load();
-    }, RUN_POLL_MS);
+    const unregisterPoll = registerPollingTask({
+      id: "workflow-run-detail",
+      intervalMs: RUN_POLL_MS,
+      keepAliveWhile: () => active,
+      run: load,
+    });
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") void load();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
-      clearInterval(timer);
+      unregisterPoll();
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [active, load]);

--- a/extensions/workplaces/state/workspace-sync.ts
+++ b/extensions/workplaces/state/workspace-sync.ts
@@ -2,13 +2,15 @@ import type { ContentWorkspaceResponse } from "@/extensions/workplaces/server";
 import { useWorkspaceStore, registerMutationBroadcast } from "./workspace-store";
 import { configurePendingIntentBackstop } from "@/state/content-store";
 import { warmContentSummaryCache } from "@/lib/domain/content/content-summary-cache";
+import { registerPollingTask } from "@/lib/core/polling/scheduler";
 
 const SYNC_CHANNEL_NAME = "dg-workspace-sync";
 const POLL_INTERVAL_MS = 15_000;
 const MENU_OPEN_DEBOUNCE_MS = 2_000;
 
 let channel: BroadcastChannel | null = null;
-let pollTimer: ReturnType<typeof setInterval> | null = null;
+/** Holds an UNREGISTER function now, not a timer id. */
+let pollTimer: (() => void) | null = null;
 let menuOpenTimer: ReturnType<typeof setTimeout> | null = null;
 let installed = false;
 
@@ -60,11 +62,17 @@ export function installWorkspaceSync(): () => void {
 
   registerMutationBroadcast(() => broadcastWorkspaceMutation());
 
-  pollTimer = setInterval(() => {
-    if (document.visibilityState === "visible") {
-      void fetchAndApply();
-    }
-  }, POLL_INTERVAL_MS);
+  // This file was the reference implementation for hand-rolled visibility
+  // gating. It now demonstrates the successor: gating is declared, not written.
+  // per-tab, NOT leader. The BroadcastChannel here signals "a mutation
+  // happened", prompting each tab to fetch its own copy — it does not carry the
+  // RESULT. A leader-elected poll would therefore update only the leader and
+  // leave every other tab stale.
+  pollTimer = registerPollingTask({
+    id: "workspace-sync",
+    intervalMs: POLL_INTERVAL_MS,
+    run: fetchAndApply,
+  });
 
   const handleOnline = () => {
     void fetchAndApply();
@@ -85,7 +93,7 @@ export function installWorkspaceSync(): () => void {
     channel?.close();
     channel = null;
     if (pollTimer) {
-      clearInterval(pollTimer);
+      pollTimer();
       pollTimer = null;
     }
     if (menuOpenTimer) {

--- a/lib/core/engagement/index.ts
+++ b/lib/core/engagement/index.ts
@@ -65,15 +65,18 @@ const TRANSITION_CHECK_MS = 5_000;
  * so no separate mousedown/touchstart pairs are needed. Scroll and wheel are
  * registered passive so they never block the compositor.
  */
-const ACTIVITY_EVENTS = [
-  "pointerdown",
-  "pointermove",
-  "keydown",
-  "wheel",
-  "scroll",
-] as const;
+const ACTIVITY_EVENTS = ["pointerdown", "keydown", "wheel", "scroll"] as const;
+
+/**
+ * How long the cursor must remain over the page before `pointermove` counts as
+ * engagement. Comfortably longer than any crossing, far shorter than any real
+ * hover.
+ */
+export const POINTER_DWELL_MS = 3_000;
 
 let lastInputAt = Date.now();
+/** When the cursor most recently entered the page; null while outside. */
+let pointerEnteredAt: number | null = null;
 let current: Engagement = "active";
 let listenersAttached = false;
 let transitionTimer: ReturnType<typeof setInterval> | null = null;
@@ -86,21 +89,54 @@ const subscribers = new Set<(state: Engagement) => void>();
  * would thrash. An assignment is effectively free, and it moves all the actual
  * decision-making to the moment someone asks — which is where it is needed.
  */
+/**
+ * Deliberate input. Any of these is unambiguous engagement, so they stamp
+ * immediately — nobody presses a key or scrolls a window by accident.
+ */
 function markInput() {
-  // Input to an UNFOCUSED window does not count.
-  //
-  // An unfocused window receives no keyboard events, but it does still receive
-  // `pointermove` when the cursor crosses it — which on a multi-monitor setup
-  // happens constantly on the way somewhere else. Without this guard a PWA
-  // parked on a second monitor would have its idle countdown reset by a mouse
-  // passing over it, and could stay "active" indefinitely without anyone ever
-  // using it. That is the exact scenario this module exists to catch.
-  //
-  // Clicking an unfocused window to use it is unaffected: the `focus` event
-  // fires first and stamps activity through handleFocusOrVisibility below.
-  if (typeof document !== "undefined" && !document.hasFocus()) return;
   lastInputAt = Date.now();
   if (current !== "active") recompute();
+}
+
+/**
+ * `pointermove` is the one AMBIGUOUS signal, so it is gated on dwell.
+ *
+ * It fires only while the cursor is physically over this window — but that
+ * covers two very different things:
+ *
+ *   TRANSIT   the cursor crossing this window on its way to another monitor,
+ *             the dock, or an adjacent app. Sub-second, and not engagement.
+ *   HOVERING  reading a visible-but-unfocused window on a second monitor.
+ *             Minutes, and absolutely engagement.
+ *
+ * Requiring the cursor to have been present for POINTER_DWELL_MS separates them
+ * cleanly, because no crossing lasts three seconds and no reading session is
+ * shorter.
+ *
+ * This distinction is not cosmetic. Neon needs five CONTIGUOUS query-free
+ * minutes to autosuspend, so a single incidental crossing every four minutes
+ * resets the idle countdown often enough that the database never sleeps — the
+ * full cost of polling nonstop, for a window nobody looked at. The meter does
+ * not reward mostly-quiet, only contiguously-quiet.
+ *
+ * Note this deliberately does NOT require focus. An unfocused window being read
+ * on a second monitor is real engagement, and an earlier version of this guard
+ * got that wrong.
+ */
+function markPointerMove() {
+  if (pointerEnteredAt === null) {
+    // First move since entering (or since page load with the cursor already
+    // inside, where no enter event fires) — start the dwell clock.
+    pointerEnteredAt = Date.now();
+    return;
+  }
+  if (Date.now() - pointerEnteredAt < POINTER_DWELL_MS) return;
+  markInput();
+}
+
+/** Cursor left the page: any accumulated dwell is void. */
+function handlePointerLeave() {
+  pointerEnteredAt = null;
 }
 
 function computeEngagement(): Engagement {
@@ -143,6 +179,10 @@ function attach() {
   for (const event of ACTIVITY_EVENTS) {
     window.addEventListener(event, markInput, { passive: true });
   }
+  window.addEventListener("pointermove", markPointerMove, { passive: true });
+  document.documentElement.addEventListener("pointerleave", handlePointerLeave, {
+    passive: true,
+  });
   window.addEventListener("focus", handleFocusOrVisibility);
   document.addEventListener("visibilitychange", handleFocusOrVisibility);
   transitionTimer = setInterval(recompute, TRANSITION_CHECK_MS);
@@ -154,6 +194,8 @@ function detach() {
   for (const event of ACTIVITY_EVENTS) {
     window.removeEventListener(event, markInput);
   }
+  window.removeEventListener("pointermove", markPointerMove);
+  document.documentElement.removeEventListener("pointerleave", handlePointerLeave);
   window.removeEventListener("focus", handleFocusOrVisibility);
   document.removeEventListener("visibilitychange", handleFocusOrVisibility);
   if (transitionTimer !== null) {
@@ -213,5 +255,6 @@ export function __resetEngagementForTests() {
   detach();
   subscribers.clear();
   lastInputAt = Date.now();
+  pointerEnteredAt = null;
   current = "active";
 }

--- a/lib/core/engagement/index.ts
+++ b/lib/core/engagement/index.ts
@@ -87,6 +87,18 @@ const subscribers = new Set<(state: Engagement) => void>();
  * decision-making to the moment someone asks — which is where it is needed.
  */
 function markInput() {
+  // Input to an UNFOCUSED window does not count.
+  //
+  // An unfocused window receives no keyboard events, but it does still receive
+  // `pointermove` when the cursor crosses it — which on a multi-monitor setup
+  // happens constantly on the way somewhere else. Without this guard a PWA
+  // parked on a second monitor would have its idle countdown reset by a mouse
+  // passing over it, and could stay "active" indefinitely without anyone ever
+  // using it. That is the exact scenario this module exists to catch.
+  //
+  // Clicking an unfocused window to use it is unaffected: the `focus` event
+  // fires first and stamps activity through handleFocusOrVisibility below.
+  if (typeof document !== "undefined" && !document.hasFocus()) return;
   lastInputAt = Date.now();
   if (current !== "active") recompute();
 }
@@ -111,7 +123,11 @@ function recompute() {
   }
 }
 
-function handleVisibilityChange() {
+function handleFocusOrVisibility() {
+  // Bound to BOTH `focus` and `visibilitychange`, which cover different
+  // transitions: `focus` fires when an unfocused window is clicked into,
+  // `visibilitychange` when a backgrounded tab is switched to.
+  //
   // Returning to a tab counts as engagement in itself — otherwise a tab that was
   // hidden for an hour would come back already idle and stay paused until the
   // user happened to move the mouse.
@@ -127,8 +143,8 @@ function attach() {
   for (const event of ACTIVITY_EVENTS) {
     window.addEventListener(event, markInput, { passive: true });
   }
-  window.addEventListener("focus", handleVisibilityChange);
-  document.addEventListener("visibilitychange", handleVisibilityChange);
+  window.addEventListener("focus", handleFocusOrVisibility);
+  document.addEventListener("visibilitychange", handleFocusOrVisibility);
   transitionTimer = setInterval(recompute, TRANSITION_CHECK_MS);
 }
 
@@ -138,8 +154,8 @@ function detach() {
   for (const event of ACTIVITY_EVENTS) {
     window.removeEventListener(event, markInput);
   }
-  window.removeEventListener("focus", handleVisibilityChange);
-  document.removeEventListener("visibilitychange", handleVisibilityChange);
+  window.removeEventListener("focus", handleFocusOrVisibility);
+  document.removeEventListener("visibilitychange", handleFocusOrVisibility);
   if (transitionTimer !== null) {
     clearInterval(transitionTimer);
     transitionTimer = null;

--- a/lib/core/engagement/index.ts
+++ b/lib/core/engagement/index.ts
@@ -1,0 +1,201 @@
+"use client";
+
+/**
+ * Engagement — the single source of truth for "is anyone actually using this tab
+ * right now?", shared by every poller and stream in the app.
+ *
+ * Three states, deliberately ordered by how much we trust them:
+ *
+ *   hidden  The tab is backgrounded. AUTHORITATIVE — the user demonstrably is
+ *           not looking, so anything may be paused or closed.
+ *   idle    Visible, but no user input for IDLE_AFTER_MS. A HEURISTIC — the user
+ *           may well be watching something (a job running, audio playing), so a
+ *           task may legitimately override this. See `keepAliveWhile`.
+ *   active  Visible and recently interacted with.
+ *
+ * Why this exists at all: on metered infrastructure a background poll is billed
+ * twice — once for the function that serves it, once for the database that never
+ * reaches its autosuspend threshold. And the meters have *different* definitions
+ * of quiet (Neon needs 5 contiguous query-free minutes; Cloud Run needs zero open
+ * WebSockets; Vercel memory needs zero held-open requests). One shared engagement
+ * signal with per-task policy is how those get satisfied without eight
+ * independent implementations drifting apart.
+ *
+ * Full rationale and decision history:
+ * docs/notes-feature/work-tracking/POLLING-DISCIPLINE-PLAN.md
+ *
+ * ── Relationship to the collaboration runtime ────────────────────────────────
+ * lib/domain/collaboration/runtime.ts has its own `lastActivityAt`, but it is
+ * reset on every local **Y.js edit** — that is EDIT activity, not INPUT activity.
+ * Someone reading a note without typing is correctly "inactive" to the runtime
+ * (nothing to sync) and correctly "active" here (they are using the app). The
+ * two signals are genuinely different and both are right for their purpose, so
+ * this module aligns with the runtime's thresholds rather than replacing them.
+ */
+
+export type Engagement = "active" | "idle" | "hidden";
+
+/**
+ * How long without input before a visible tab is considered idle.
+ *
+ * 60s is long enough that reading a paragraph without touching anything does not
+ * trip it, and short enough that a forgotten PWA goes quiet fast. It also sits
+ * comfortably inside Neon's 5-minute autosuspend window, so a tab that goes idle
+ * still leaves roughly four minutes of contiguous quiet for the database to
+ * actually suspend in.
+ */
+export const IDLE_AFTER_MS = 60_000;
+
+/**
+ * How often the transition from active → idle is noticed.
+ *
+ * This is the only timer this module owns. It is UI-only — it never touches the
+ * network — and it exists solely so that *streams* can be told to close when the
+ * user goes idle. Pull-based consumers (anything that already ticks) should call
+ * `getEngagement()` at their own tick instead and cost nothing at all.
+ *
+ * It runs only while there is at least one subscriber.
+ */
+const TRANSITION_CHECK_MS = 5_000;
+
+/**
+ * Input signals, chosen for Chromium (Vivaldi/Chrome) but standard everywhere.
+ *
+ * `pointer*` is the unified input API — it covers mouse, touch and pen in one,
+ * so no separate mousedown/touchstart pairs are needed. Scroll and wheel are
+ * registered passive so they never block the compositor.
+ */
+const ACTIVITY_EVENTS = [
+  "pointerdown",
+  "pointermove",
+  "keydown",
+  "wheel",
+  "scroll",
+] as const;
+
+let lastInputAt = Date.now();
+let current: Engagement = "active";
+let listenersAttached = false;
+let transitionTimer: ReturnType<typeof setInterval> | null = null;
+const subscribers = new Set<(state: Engagement) => void>();
+
+/**
+ * Stamp a timestamp rather than resetting a timer.
+ *
+ * `pointermove` fires 60–120 times a second; resetting a `setTimeout` on each
+ * would thrash. An assignment is effectively free, and it moves all the actual
+ * decision-making to the moment someone asks — which is where it is needed.
+ */
+function markInput() {
+  lastInputAt = Date.now();
+  if (current !== "active") recompute();
+}
+
+function computeEngagement(): Engagement {
+  if (typeof document === "undefined") return "active";
+  if (document.visibilityState === "hidden") return "hidden";
+  return Date.now() - lastInputAt >= IDLE_AFTER_MS ? "idle" : "active";
+}
+
+function recompute() {
+  const next = computeEngagement();
+  if (next === current) return;
+  current = next;
+  for (const cb of subscribers) {
+    try {
+      cb(next);
+    } catch {
+      // A misbehaving subscriber must not take down the others, or one bad
+      // consumer silently freezes engagement for the whole app.
+    }
+  }
+}
+
+function handleVisibilityChange() {
+  // Returning to a tab counts as engagement in itself — otherwise a tab that was
+  // hidden for an hour would come back already idle and stay paused until the
+  // user happened to move the mouse.
+  if (typeof document !== "undefined" && document.visibilityState === "visible") {
+    lastInputAt = Date.now();
+  }
+  recompute();
+}
+
+function attach() {
+  if (listenersAttached || typeof window === "undefined") return;
+  listenersAttached = true;
+  for (const event of ACTIVITY_EVENTS) {
+    window.addEventListener(event, markInput, { passive: true });
+  }
+  window.addEventListener("focus", handleVisibilityChange);
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  transitionTimer = setInterval(recompute, TRANSITION_CHECK_MS);
+}
+
+function detach() {
+  if (!listenersAttached || typeof window === "undefined") return;
+  listenersAttached = false;
+  for (const event of ACTIVITY_EVENTS) {
+    window.removeEventListener(event, markInput);
+  }
+  window.removeEventListener("focus", handleVisibilityChange);
+  document.removeEventListener("visibilitychange", handleVisibilityChange);
+  if (transitionTimer !== null) {
+    clearInterval(transitionTimer);
+    transitionTimer = null;
+  }
+}
+
+/**
+ * Current engagement. Cheap and synchronous — call it at tick time from anything
+ * that already has a timer, rather than subscribing.
+ */
+export function getEngagement(): Engagement {
+  // Recompute rather than trusting `current`, which is only refreshed on input,
+  // visibility change, or the 5s transition check. A puller asking at second 3
+  // of that window deserves a truthful answer.
+  return computeEngagement();
+}
+
+/** True when the tab is visible and recently interacted with. */
+export function isEngaged(): boolean {
+  return getEngagement() === "active";
+}
+
+/**
+ * Subscribe to engagement transitions. Returns an unsubscribe function.
+ *
+ * Use this for **streams**, which have no tick of their own and need telling
+ * when to close. Anything that already polls should use `getEngagement()` at its
+ * own tick instead — no subscription, no extra timer.
+ *
+ * Listeners attach on the first subscriber and detach on the last, so a page
+ * with no consumers pays nothing.
+ */
+export function subscribeEngagement(
+  callback: (state: Engagement) => void,
+): () => void {
+  subscribers.add(callback);
+  if (subscribers.size === 1) {
+    lastInputAt = Date.now();
+    current = computeEngagement();
+    attach();
+  }
+  return () => {
+    subscribers.delete(callback);
+    if (subscribers.size === 0) detach();
+  };
+}
+
+/** Milliseconds since the last user input. Exposed for diagnostics and tests. */
+export function msSinceLastInput(): number {
+  return Date.now() - lastInputAt;
+}
+
+/** Test seam — resets module state between cases. */
+export function __resetEngagementForTests() {
+  detach();
+  subscribers.clear();
+  lastInputAt = Date.now();
+  current = "active";
+}

--- a/lib/core/polling/scheduler.ts
+++ b/lib/core/polling/scheduler.ts
@@ -56,9 +56,23 @@ export interface PollingTask {
    */
   keepAliveWhile?: () => boolean;
   /**
-   * "leader" — only one tab in this browser runs it. Use for anything whose
-   * answer is identical across tabs (session checks, notification badges).
-   * "per-tab" (default) — every tab runs its own, for tab-specific state.
+   * "leader" — only one tab in this browser runs it.
+   * "per-tab" (default) — every tab runs its own.
+   *
+   * ⚠ **"leader" is only safe when the RESULT propagates cross-tab.** The elected
+   * tab performs the fetch; every other tab performs nothing. If the result
+   * lands only in the leader's own store, every follower silently starves —
+   * a frozen bell, a stale list — and it looks like a caching bug, not a
+   * scheduling one.
+   *
+   * The bar is a real cross-tab channel carrying the *answer*, not merely a
+   * "something changed, go refetch" nudge — a nudge just restores per-tab
+   * polling by another name.
+   *
+   * Today only `auth-session-check` qualifies, because `publishSignedOut()`
+   * broadcasts over BroadcastChannel with a localStorage fallback. Notification
+   * badges and workspace-sync were both tried as "leader" and reverted for
+   * exactly this reason.
    */
   scope?: "leader" | "per-tab";
   run: () => void | Promise<void>;

--- a/lib/core/polling/scheduler.ts
+++ b/lib/core/polling/scheduler.ts
@@ -1,0 +1,271 @@
+"use client";
+
+/**
+ * The polling scheduler — one timer for the whole app.
+ *
+ * Every client-side recurring network call should register here rather than
+ * calling `setInterval` directly. That buys three things, only the first of
+ * which a CI gate could ever enforce:
+ *
+ *   1. Visibility gating   — background tabs go quiet
+ *   2. Idle gating         — an always-open PWA goes quiet (the dominant case)
+ *   3. Leader election     — N open tabs make ONE request, not N
+ *
+ * Rationale, cost model and decision history:
+ * docs/notes-feature/work-tracking/POLLING-DISCIPLINE-PLAN.md
+ *
+ * ── Design notes ─────────────────────────────────────────────────────────────
+ * One base tick drives everything. Tasks declare their own interval and are run
+ * when due, so adding a task adds no timers. Engagement is *pulled* at tick time
+ * (`getEngagement()`) rather than subscribed to, which means the scheduler costs
+ * exactly one timer no matter how many tasks it carries.
+ *
+ * Leadership uses a **localStorage lease** rather than a consensus protocol.
+ * Elections are genuinely hard; a lease is not. The failure mode of a lease race
+ * is that two tabs briefly poll at once, which is precisely the situation we are
+ * in today with no election at all — so a race degrades to the status quo rather
+ * than to something broken.
+ */
+
+import { getEngagement } from "@/lib/core/engagement";
+import { clientLogger } from "@/lib/core/logger/client";
+
+export type WhenPolicy = "pause" | "run";
+
+export interface PollingTask {
+  /** Stable identifier. Also the leadership lease key for `scope: "leader"`. */
+  id: string;
+  intervalMs: number;
+  /**
+   * What to do while the tab is hidden. Defaults to "pause".
+   * "run" means this task keeps polling in a backgrounded tab and must carry an
+   * `estimatedMonthlyCostUsd` justification in scripts/validate-polling.ts.
+   */
+  whenHidden?: WhenPolicy;
+  /** What to do while the tab is visible but idle. Defaults to "pause". */
+  whenIdle?: WhenPolicy;
+  /**
+   * Overrides `whenIdle: "pause"` while it returns true — for work the user is
+   * plausibly *watching* without touching anything, such as a job in flight.
+   *
+   * Deliberately a predicate rather than a static flag: a blanket exemption
+   * would keep polling long after the work finished, whereas this goes quiet the
+   * moment the predicate flips even if the user is still sitting there.
+   *
+   * Note it does NOT override `whenHidden` — hidden is authoritative.
+   */
+  keepAliveWhile?: () => boolean;
+  /**
+   * "leader" — only one tab in this browser runs it. Use for anything whose
+   * answer is identical across tabs (session checks, notification badges).
+   * "per-tab" (default) — every tab runs its own, for tab-specific state.
+   */
+  scope?: "leader" | "per-tab";
+  run: () => void | Promise<void>;
+}
+
+interface Registered extends PollingTask {
+  nextDueAt: number;
+  inFlight: boolean;
+}
+
+/**
+ * Base tick. Fast enough that a 3–5s task is not meaningfully delayed, slow
+ * enough to be free. This is the app's only unconditional client timer.
+ */
+const BASE_TICK_MS = 1_000;
+
+const LEASE_KEY_PREFIX = "dg-poll-leader:";
+/** A lease is considered dead this long after its last renewal. */
+const LEASE_TTL_MS = 6_000;
+
+const tasks = new Map<string, Registered>();
+let baseTimer: ReturnType<typeof setInterval> | null = null;
+
+/** Identifies this tab for the lifetime of the page. */
+const tabId =
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random()}`;
+
+interface Lease {
+  tabId: string;
+  renewedAt: number;
+}
+
+/**
+ * Claim or renew leadership for a task. Returns true if this tab holds it.
+ *
+ * Storage access is wrapped because private-browsing modes and blocked-cookie
+ * settings can throw on access. Failing open (assuming leadership) is the right
+ * default — it degrades to every tab polling, which is today's behaviour, rather
+ * than to nobody polling, which would silently break the feature.
+ */
+function holdsLease(taskId: string): boolean {
+  if (typeof window === "undefined") return true;
+  const key = LEASE_KEY_PREFIX + taskId;
+  const now = Date.now();
+  try {
+    const raw = window.localStorage.getItem(key);
+    const lease = raw ? (JSON.parse(raw) as Lease) : null;
+
+    if (!lease || now - lease.renewedAt > LEASE_TTL_MS) {
+      window.localStorage.setItem(key, JSON.stringify({ tabId, renewedAt: now }));
+      return true;
+    }
+    if (lease.tabId === tabId) {
+      window.localStorage.setItem(key, JSON.stringify({ tabId, renewedAt: now }));
+      return true;
+    }
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Release leadership on unload so another tab picks it up immediately rather
+ * than waiting out the TTL.
+ */
+function releaseLease(taskId: string) {
+  if (typeof window === "undefined") return;
+  try {
+    const key = LEASE_KEY_PREFIX + taskId;
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return;
+    if ((JSON.parse(raw) as Lease).tabId === tabId) {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    /* storage unavailable — the TTL will expire it */
+  }
+}
+
+/** Whether a task is allowed to run right now. */
+function shouldRun(task: Registered): boolean {
+  const engagement = getEngagement();
+
+  // Hidden is authoritative: keepAliveWhile does NOT override it. A tab nobody
+  // can see has no claim on a meter, whatever it thinks it is doing.
+  if (engagement === "hidden") return (task.whenHidden ?? "pause") === "run";
+
+  if (engagement === "idle") {
+    if (task.keepAliveWhile?.()) return true;
+    return (task.whenIdle ?? "pause") === "run";
+  }
+
+  return true;
+}
+
+function tick() {
+  const now = Date.now();
+  for (const task of tasks.values()) {
+    if (task.inFlight || now < task.nextDueAt) continue;
+    if (!shouldRun(task)) {
+      // Push the due time forward so a task returning from a long pause fires
+      // once, immediately — rather than firing repeatedly to "catch up" on
+      // every tick it missed.
+      task.nextDueAt = now + task.intervalMs;
+      continue;
+    }
+    if ((task.scope ?? "per-tab") === "leader" && !holdsLease(task.id)) {
+      task.nextDueAt = now + task.intervalMs;
+      continue;
+    }
+
+    task.nextDueAt = now + task.intervalMs;
+    task.inFlight = true;
+    void Promise.resolve()
+      .then(task.run)
+      .catch(() => {
+        // A failing task must not stop the wheel for every other task.
+      })
+      .finally(() => {
+        task.inFlight = false;
+      });
+  }
+}
+
+function ensureTimer() {
+  if (baseTimer !== null || typeof window === "undefined") return;
+  baseTimer = setInterval(tick, BASE_TICK_MS);
+}
+
+function stopTimerIfIdle() {
+  if (tasks.size > 0 || baseTimer === null) return;
+  clearInterval(baseTimer);
+  baseTimer = null;
+}
+
+/**
+ * Register a recurring task. Returns an unregister function.
+ *
+ * The first run happens on the next base tick rather than immediately, so a
+ * component mounting does not fire a request synchronously during render.
+ * Callers that genuinely need an immediate first fetch should do it themselves
+ * on mount — that is a load, not a poll.
+ */
+export function registerPollingTask(task: PollingTask): () => void {
+  if (tasks.has(task.id)) {
+    // Overwriting silently would make double-registration invisible, and in dev
+    // React StrictMode double-mounts make it a realistic mistake.
+    clientLogger.warn({
+      layer: "ui",
+      event: "polling:duplicate_task",
+      summary: `Polling task "${task.id}" registered twice; replacing the previous registration.`,
+      attrs: { taskId: task.id },
+    });
+  }
+  tasks.set(task.id, { ...task, nextDueAt: Date.now() + task.intervalMs, inFlight: false });
+  ensureTimer();
+
+  return () => {
+    tasks.delete(task.id);
+    if ((task.scope ?? "per-tab") === "leader") releaseLease(task.id);
+    stopTimerIfIdle();
+  };
+}
+
+/** Run a task now, ignoring its schedule but not its gating. Used for catch-up. */
+export function runPollingTaskNow(id: string) {
+  const task = tasks.get(id);
+  if (!task || task.inFlight || !shouldRun(task)) return;
+  task.nextDueAt = Date.now() + task.intervalMs;
+  task.inFlight = true;
+  void Promise.resolve()
+    .then(task.run)
+    .catch(() => undefined)
+    .finally(() => {
+      task.inFlight = false;
+    });
+}
+
+/** Diagnostics: what the scheduler currently carries and whether it would run. */
+export function inspectPollingTasks() {
+  return Array.from(tasks.values()).map((t) => ({
+    id: t.id,
+    intervalMs: t.intervalMs,
+    scope: t.scope ?? "per-tab",
+    dueInMs: t.nextDueAt - Date.now(),
+    wouldRun: shouldRun(t),
+  }));
+}
+
+/**
+ * Test seam for the lease. Exported because leadership is the fiddliest logic
+ * here and is consulted at tick time, so it is unreachable through
+ * `inspectPollingTasks` — which reports engagement eligibility only.
+ */
+export function __holdsLeaseForTests(taskId: string): boolean {
+  return holdsLease(taskId);
+}
+
+/** Test seam. */
+export function __resetSchedulerForTests() {
+  for (const id of tasks.keys()) releaseLease(id);
+  tasks.clear();
+  if (baseTimer !== null) {
+    clearInterval(baseTimer);
+    baseTimer = null;
+  }
+}

--- a/lib/domain/collaboration/presence-poll.ts
+++ b/lib/domain/collaboration/presence-poll.ts
@@ -18,6 +18,7 @@
  */
 
 import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { registerPollingTask } from "@/lib/core/polling/scheduler";
 
 import { getCollaborationBrowserSessionId } from "@/lib/domain/collaboration/runtime";
 
@@ -78,7 +79,7 @@ function recordsEqual(a: PresenceRecord[], b: PresenceRecord[]): boolean {
 class PresencePoller {
   private subscribers = new Map<string, Set<() => void>>();
   private cache = new Map<string, PresenceRecord[]>();
-  private intervalId: number | null = null;
+  private unregisterPoll: (() => void) | null = null;
   // Shared by the `focus` and `visibilitychange` listeners. The visibility
   // guard matters for the latter: visibilitychange fires on the hidden
   // transition too, and refreshing on the way out is exactly the tick we are
@@ -111,27 +112,27 @@ class PresencePoller {
   }
 
   private start() {
-    if (this.intervalId !== null || typeof window === "undefined") return;
-    // Hidden tabs skip the tick entirely. Batching already collapses N
-    // subscribers into ceil(N/16) requests; gating on visibility collapses the
-    // idle case to zero, which is what actually keeps the database reaching its
-    // autosuspend threshold. The existing focus listener covers catch-up, and
-    // visibilitychange is added alongside it because a tab can become visible
-    // without the window ever receiving focus (split-screen, tab switch in an
-    // already-focused window).
-    this.intervalId = window.setInterval(() => {
-      if (document.visibilityState !== "visible") return;
-      void this.fetchIds([...this.subscribers.keys()]);
-    }, POLL_INTERVAL_MS);
+    if (this.unregisterPoll !== null || typeof window === "undefined") return;
+    // Gating (hidden AND idle both pause) lives in the scheduler. Batching still
+    // lives here: N subscribers collapse to ceil(N/16) requests per tick, which
+    // is the property that made this module the unification model in the first
+    // place. The two compose — the scheduler decides WHETHER to tick, this class
+    // decides how few requests a tick costs.
+    //
+    // per-tab, not leader: different tabs subscribe to different contentIds, so
+    // one tab's answer is not another's.
+    this.unregisterPoll = registerPollingTask({
+      id: "collaboration-presence-poll",
+      intervalMs: POLL_INTERVAL_MS,
+      run: () => this.fetchIds([...this.subscribers.keys()]),
+    });
     window.addEventListener("focus", this.onFocus);
     document.addEventListener("visibilitychange", this.onFocus);
   }
 
   private stop() {
-    if (this.intervalId !== null) {
-      window.clearInterval(this.intervalId);
-      this.intervalId = null;
-    }
+    this.unregisterPoll?.();
+    this.unregisterPoll = null;
     window.removeEventListener("focus", this.onFocus);
     document.removeEventListener("visibilitychange", this.onFocus);
   }

--- a/lib/features/notifications/transport.ts
+++ b/lib/features/notifications/transport.ts
@@ -10,6 +10,7 @@
  */
 
 import type { DmMessageDTO } from "@/lib/domain/messaging/types";
+import { registerPollingTask } from "@/lib/core/polling/scheduler";
 
 export type TransportScope =
   | { kind: "badge" }
@@ -51,7 +52,8 @@ export function getSharedNotificationTransport(): NotificationTransport {
 
 interface ThreadScopeState {
   refCount: number;
-  timer: ReturnType<typeof setInterval> | null;
+  /** Unregister function for this thread's scheduler task. */
+  timer: (() => void) | null;
   /** ISO watermark — only messages newer than this are fetched. */
   lastSeen: string;
   polling: boolean;
@@ -62,7 +64,8 @@ export function createPollingTransport(): NotificationTransport {
   const threadScopes = new Map<string, ThreadScopeState>();
 
   let badgeRefCount = 0;
-  let badgeTimer: ReturnType<typeof setInterval> | null = null;
+  // Holds an UNREGISTER function now, not a timer id.
+  let badgeTimer: (() => void) | null = null;
   let badgeSince: string | null = null;
   let badgePolling = false;
   let started = false;
@@ -127,19 +130,19 @@ export function createPollingTransport(): NotificationTransport {
     }
   }
 
-  // Hidden tabs do not poll. `handleFocus` already fires an immediate refresh
-  // when the tab becomes visible, so a backgrounded tab loses nothing by
-  // skipping ticks — it catches up the moment anyone looks at it.
-  function isVisible() {
-    return typeof document === "undefined" || document.visibilityState === "visible";
-  }
-
   function ensureBadgeTimer() {
     if (started && badgeRefCount > 0 && !badgeTimer) {
       void pollBadge();
-      badgeTimer = setInterval(() => {
-        if (isVisible()) void pollBadge();
-      }, BADGE_INTERVAL_MS);
+      // per-tab, NOT leader — despite the unread count being identical in every
+      // tab. Leader election requires the RESULT to propagate cross-tab, and
+      // `emit` here reaches only this tab's own listeners. A leader-elected badge
+      // would leave every follower tab's bell frozen. Revisit if this transport
+      // ever gains a BroadcastChannel.
+      badgeTimer = registerPollingTask({
+        id: "notifications-badge",
+        intervalMs: BADGE_INTERVAL_MS,
+        run: pollBadge,
+      });
     }
   }
 
@@ -147,9 +150,11 @@ export function createPollingTransport(): NotificationTransport {
     const scope = threadScopes.get(threadId);
     if (started && scope && !scope.timer) {
       void pollThread(threadId);
-      scope.timer = setInterval(() => {
-        if (isVisible()) void pollThread(threadId);
-      }, THREAD_INTERVAL_MS);
+      scope.timer = registerPollingTask({
+        id: `notifications-thread:${threadId}`,
+        intervalMs: THREAD_INTERVAL_MS,
+        run: () => pollThread(threadId),
+      });
     }
   }
 
@@ -183,12 +188,12 @@ export function createPollingTransport(): NotificationTransport {
       window.removeEventListener("focus", handleFocus);
       document.removeEventListener("visibilitychange", handleFocus);
       if (badgeTimer) {
-        clearInterval(badgeTimer);
+        badgeTimer();
         badgeTimer = null;
       }
       for (const scope of threadScopes.values()) {
         if (scope.timer) {
-          clearInterval(scope.timer);
+          scope.timer();
           scope.timer = null;
         }
       }
@@ -201,7 +206,7 @@ export function createPollingTransport(): NotificationTransport {
         return () => {
           badgeRefCount = Math.max(0, badgeRefCount - 1);
           if (badgeRefCount === 0 && badgeTimer) {
-            clearInterval(badgeTimer);
+            badgeTimer();
             badgeTimer = null;
           }
         };
@@ -225,7 +230,7 @@ export function createPollingTransport(): NotificationTransport {
         if (!state) return;
         state.refCount -= 1;
         if (state.refCount <= 0) {
-          if (state.timer) clearInterval(state.timer);
+          if (state.timer) state.timer();
           threadScopes.delete(threadId);
         }
       };

--- a/lib/infrastructure/auth/session-interceptor.ts
+++ b/lib/infrastructure/auth/session-interceptor.ts
@@ -1,0 +1,157 @@
+"use client";
+
+/**
+ * Session interceptor — learn about sign-out from requests we were already
+ * making, instead of asking on a timer.
+ *
+ * Every API route validates the session server-side, so **a 401 is the signal**.
+ * Before this existed the only detection path was `AuthSessionSync` polling
+ * `/api/auth/session`, which meant up to 3 × its interval to notice a revocation
+ * and — far more expensively — a database-touching request every minute forever,
+ * which is what stopped Neon ever reaching its 5-minute autosuspend threshold.
+ *
+ * With this in place detection is *instant on any user action*, costs nothing
+ * (it rides requests that were happening anyway), and the poll can be demoted to
+ * a slow safety net that lets the database sleep.
+ *
+ * See D15 in docs/notes-feature/work-tracking/POLLING-DISCIPLINE-PLAN.md.
+ *
+ * ── Why a global patch rather than a wrapper ─────────────────────────────────
+ * `tracedFetch` is the sanctioned wrapper but has ~6 adopters, and an auth
+ * interceptor is only useful if it sees *everything*. Patching once, centrally,
+ * beats migrating 200 call sites and then relying on everyone remembering.
+ */
+
+import { publishSignedOut } from "@/lib/infrastructure/auth/client-session-events";
+import { clientLogger } from "@/lib/core/logger/client";
+
+/**
+ * Paths whose 401 does NOT mean "your session died".
+ *
+ * - Auth flows 401 on a *failed sign-in attempt* — the user isn't signed in yet,
+ *   so signing them out is nonsense.
+ * - `/api/integrations/` is authenticated by browser-extension **bearer token**
+ *   (`requireBrowserExtensionBearerAuth`), not the session cookie. A 401 there
+ *   means a stale extension token, which is unrelated to this session.
+ *
+ * Everything else was audited: all 99 `status: 401` sites in `app/api` return it
+ * for session reasons. This list is the complete set of exceptions as of
+ * 2026-09-09 — extend it if a route starts 401-ing for some other reason.
+ */
+const NON_SESSION_401_PREFIXES = [
+  "/api/auth/sign-in",
+  "/api/auth/sign-up",
+  "/api/integrations/",
+];
+
+/** The confirmation endpoint. Never itself intercepted, or this would recurse. */
+const SESSION_CHECK_PATH = "/api/auth/session";
+
+let installed = false;
+let originalFetch: typeof fetch | null = null;
+let confirming = false;
+
+function isSessionRelevant(path: string): boolean {
+  if (!path.startsWith("/api/")) return false;
+  if (path.startsWith(SESSION_CHECK_PATH)) return false;
+  return !NON_SESSION_401_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+function resolvePath(input: RequestInfo | URL): string | null {
+  try {
+    const origin = typeof window !== "undefined" ? window.location.origin : undefined;
+    const raw =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : (input as Request).url;
+    const url = new URL(raw, origin);
+    // Cross-origin 401s tell us nothing about our own session.
+    if (origin && url.origin !== origin) return null;
+    return url.pathname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Confirm a 401 really means the session is gone before acting on it.
+ *
+ * A transient database failure can make `validateSession` return null, which
+ * surfaces as a 401 on a perfectly valid session — the same false positive that
+ * `CONSECUTIVE_FAILURES_REQUIRED` guards against in the poller. One confirmation
+ * request removes it, costs nothing in the normal case (it only runs when a 401
+ * was already seen), and is far cheaper than three polling cycles.
+ *
+ * Debounced: a burst of parallel 401s triggers exactly one confirmation.
+ */
+async function confirmAndSignOut() {
+  if (confirming || !originalFetch) return;
+  confirming = true;
+  try {
+    const response = await originalFetch(`${SESSION_CHECK_PATH}?required=true`, {
+      credentials: "include",
+      cache: "no-store",
+    });
+    if (response.status !== 401) {
+      clientLogger.info({
+        layer: "ui",
+        event: "session_interceptor:false_alarm",
+        summary: "Saw a 401 but the session re-verified as valid — treating it as transient.",
+      });
+      return;
+    }
+    clientLogger.warn({
+      layer: "ui",
+      event: "session_interceptor:signed_out",
+      summary: "A 401 was confirmed against the session endpoint; signing out.",
+    });
+    publishSignedOut("session-missing");
+  } catch {
+    // Network failure during confirmation is NOT a sign-out — being offline must
+    // never log anyone out.
+  } finally {
+    confirming = false;
+  }
+}
+
+/**
+ * Patch `window.fetch` to watch for session-invalidating 401s.
+ *
+ * Idempotent, and returns an uninstall function. The patch is a pure observer:
+ * it never alters the request, never consumes the body, and returns the original
+ * response untouched.
+ */
+export function installSessionInterceptor(): () => void {
+  if (installed || typeof window === "undefined") return () => {};
+  installed = true;
+  originalFetch = window.fetch.bind(window);
+
+  const patched: typeof fetch = async (input, init) => {
+    const response = await originalFetch!(input, init);
+    // Read status only. Cloning or reading the body here would break streaming
+    // responses and double-buffer every payload in the app.
+    if (response.status === 401) {
+      const path = resolvePath(input);
+      if (path && isSessionRelevant(path)) {
+        void confirmAndSignOut();
+      }
+    }
+    return response;
+  };
+
+  window.fetch = patched;
+
+  return () => {
+    if (!installed) return;
+    if (originalFetch) window.fetch = originalFetch;
+    installed = false;
+    originalFetch = null;
+  };
+}
+
+/** Test seam. */
+export function __isInterceptorInstalled() {
+  return installed;
+}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "test:e2e": "playwright test",
     "test:e2e:update": "playwright test --update-snapshots",
     "test:e2e:report": "playwright show-report",
-    "polling:check": "tsx scripts/validate-polling.ts"
+    "polling:check": "tsx scripts/validate-polling.ts",
+    "polling:smoke": "tsx scripts/polling-scheduler-smoke.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/scripts/polling-scheduler-smoke.ts
+++ b/scripts/polling-scheduler-smoke.ts
@@ -17,7 +17,6 @@ type Listener = (...args: unknown[]) => void;
 
 const store = new Map<string, string>();
 let visibility: "visible" | "hidden" = "visible";
-let focused = true;
 const listeners = new Map<string, Set<Listener>>();
 
 function addListener(type: string, fn: Listener) {
@@ -34,7 +33,10 @@ function removeListener(type: string, fn: Listener) {
   },
   addEventListener: addListener,
   removeEventListener: removeListener,
-  hasFocus: () => focused,
+  documentElement: {
+    addEventListener: addListener,
+    removeEventListener: removeListener,
+  },
 };
 
 const localStorageStub = {
@@ -104,23 +106,56 @@ async function main() {
     check("hidden takes precedence over idle", getEngagement(), "hidden");
   });
 
-  // Input to an UNFOCUSED window must not reset the idle countdown, or a mouse
-  // crossing a second-monitor PWA would keep it "active" forever.
+  // pointermove is dwell-gated: a crossing must not count, a hover must.
   reset();
-  const fireInput = () => {
-    for (const fn of listeners.get("pointermove") ?? []) fn();
+  const { subscribeEngagement, POINTER_DWELL_MS } = await import("@/lib/core/engagement");
+  const fire = (type: string) => {
+    for (const fn of listeners.get(type) ?? []) fn();
   };
-  // Subscribe so the module attaches its listeners.
-  const unsub = (await import("@/lib/core/engagement")).subscribeEngagement(() => {});
-  focused = false;
+  const unsub = subscribeEngagement(() => {});
+
+  // TRANSIT: cursor crosses, moves briefly, leaves. Never reaches the dwell bar.
   withClockOffset(IDLE_AFTER_MS + 1_000, () => {
-    fireInput();
-    check("pointermove while UNFOCUSED does not reset idle", getEngagement(), "idle");
+    fire("pointermove");                       // starts the dwell clock
+    fire("pointermove");                       // same instant — still under 3s
+    check("crossing does NOT count as engagement", getEngagement(), "idle");
   });
-  focused = true;
-  fireInput();
-  check("pointermove while focused does reset idle", getEngagement(), "active");
-  unsub();
+  fire("pointerleave");
+
+  // HOVERING: cursor enters and stays past the dwell bar, then moves.
+  reset();
+  const unsub2 = subscribeEngagement(() => {});
+  withClockOffset(IDLE_AFTER_MS + 1_000, () => {
+    fire("pointermove");                       // enters, clock starts
+  });
+  withClockOffset(IDLE_AFTER_MS + 1_000 + POINTER_DWELL_MS + 500, () => {
+    fire("pointermove");                       // still here, past the bar
+    check("hover past dwell DOES count", getEngagement(), "active");
+  });
+
+  // Leaving voids accumulated dwell.
+  //
+  // Sequenced carefully. NO reset() mid-test — a reset clears pointerEnteredAt
+  // itself, so the assertion would pass even with handlePointerLeave broken
+  // (an earlier version of this test did exactly that and mutation testing
+  // caught it). Instead the dwell clock is aged deliberately, so the ONLY thing
+  // that can keep the final move from counting is pointerleave doing its job.
+  reset();
+  const unsub3 = subscribeEngagement(() => {});
+  const enterAt = IDLE_AFTER_MS + 1_000;
+  const laterAt = enterAt + POINTER_DWELL_MS + IDLE_AFTER_MS + 2_000;
+
+  withClockOffset(enterAt, () => {
+    fire("pointermove");          // cursor enters; dwell clock starts
+  });
+  withClockOffset(laterAt, () => {
+    fire("pointerleave");         // must void the (now long) accumulated dwell
+    fire("pointermove");          // re-entry: restarts the clock, stamps nothing
+    // Without the void, this move would sit far past the dwell bar and stamp
+    // activity, reading "active".
+    check("pointerleave voids accumulated dwell", getEngagement(), "idle");
+  });
+  unsub(); unsub2(); unsub3();
 
   // ── Scheduler gating ─────────────────────────────────────────────────────────
 

--- a/scripts/polling-scheduler-smoke.ts
+++ b/scripts/polling-scheduler-smoke.ts
@@ -1,0 +1,198 @@
+/**
+ * Smoke test for the engagement core and polling scheduler.
+ *
+ * These two modules decide whether every network poll in the app runs. Getting a
+ * branch wrong costs money in one direction (a task that never pauses) or breaks
+ * a feature in the other (a task that never resumes), and neither failure is
+ * visible in normal use — which is exactly why they are worth testing.
+ *
+ * Run: pnpm polling:smoke
+ */
+
+// ── Minimal DOM stubs, installed before the modules are imported ─────────────
+// The modules read `typeof document` at call time rather than import time, so
+// stubbing here is sufficient and no jsdom dependency is needed.
+
+type Listener = (...args: unknown[]) => void;
+
+const store = new Map<string, string>();
+let visibility: "visible" | "hidden" = "visible";
+const listeners = new Map<string, Set<Listener>>();
+
+function addListener(type: string, fn: Listener) {
+  if (!listeners.has(type)) listeners.set(type, new Set());
+  listeners.get(type)!.add(fn);
+}
+function removeListener(type: string, fn: Listener) {
+  listeners.get(type)?.delete(fn);
+}
+
+(globalThis as Record<string, unknown>).document = {
+  get visibilityState() {
+    return visibility;
+  },
+  addEventListener: addListener,
+  removeEventListener: removeListener,
+};
+
+const localStorageStub = {
+  getItem: (k: string): string | null => store.get(k) ?? null,
+  setItem: (k: string, v: string) => void store.set(k, v),
+  removeItem: (k: string) => void store.delete(k),
+};
+
+(globalThis as Record<string, unknown>).window = {
+  addEventListener: addListener,
+  removeEventListener: removeListener,
+  localStorage: localStorageStub,
+};
+
+async function main() {
+  const { getEngagement, IDLE_AFTER_MS, __resetEngagementForTests } = await import("@/lib/core/engagement");
+  const {
+    registerPollingTask,
+    inspectPollingTasks,
+    __holdsLeaseForTests,
+    __resetSchedulerForTests,
+  } = await import("@/lib/core/polling/scheduler");
+
+  // ── Harness ──────────────────────────────────────────────────────────────────
+
+  let failures = 0;
+  function check(label: string, actual: unknown, expected: unknown) {
+    const ok = actual === expected;
+    if (!ok) failures += 1;
+    console.log(`${ok ? "  ✓" : "  ✗"} ${label}${ok ? "" : `  (got ${actual}, want ${expected})`}`);
+  }
+
+  function reset() {
+    __resetSchedulerForTests();
+    __resetEngagementForTests();
+    store.clear();
+    visibility = "visible";
+  }
+
+  /** Advance perceived time by moving Date.now forward. */
+  const realNow = Date.now;
+  function withClockOffset<T>(offsetMs: number, fn: () => T): T {
+    Date.now = () => realNow() + offsetMs;
+    try {
+      return fn();
+    } finally {
+      Date.now = realNow;
+    }
+  }
+
+  // ── Engagement ───────────────────────────────────────────────────────────────
+
+  console.log("\nengagement");
+  reset();
+  check("visible + recent input → active", getEngagement(), "active");
+
+  visibility = "hidden";
+  check("hidden wins over recent input", getEngagement(), "hidden");
+
+  visibility = "visible";
+  withClockOffset(IDLE_AFTER_MS + 1_000, () => {
+    check("visible + no input past threshold → idle", getEngagement(), "idle");
+  });
+
+  visibility = "hidden";
+  withClockOffset(IDLE_AFTER_MS + 1_000, () => {
+    check("hidden takes precedence over idle", getEngagement(), "hidden");
+  });
+
+  // ── Scheduler gating ─────────────────────────────────────────────────────────
+
+  console.log("\nscheduler gating");
+  reset();
+
+  function wouldRun(id: string): boolean {
+    return inspectPollingTasks().find((t) => t.id === id)?.wouldRun ?? false;
+  }
+
+  registerPollingTask({ id: "default", intervalMs: 1_000, run: () => {} });
+  check("active → runs", wouldRun("default"), true);
+
+  visibility = "hidden";
+  check("hidden → paused by default", wouldRun("default"), false);
+
+  visibility = "visible";
+  withClockOffset(IDLE_AFTER_MS + 1_000, () => {
+    check("idle → paused by default", wouldRun("default"), false);
+  });
+
+  reset();
+  registerPollingTask({
+    id: "watched",
+    intervalMs: 1_000,
+    keepAliveWhile: () => true,
+    run: () => {},
+  });
+  withClockOffset(IDLE_AFTER_MS + 1_000, () => {
+    check("keepAliveWhile overrides idle", wouldRun("watched"), true);
+  });
+  visibility = "hidden";
+  withClockOffset(IDLE_AFTER_MS + 1_000, () => {
+    check("keepAliveWhile does NOT override hidden", wouldRun("watched"), false);
+  });
+
+  reset();
+  registerPollingTask({
+    id: "background",
+    intervalMs: 1_000,
+    whenHidden: "run",
+    run: () => {},
+  });
+  visibility = "hidden";
+  check('whenHidden："run" keeps running hidden', wouldRun("background"), true);
+
+  // ── Leader lease ─────────────────────────────────────────────────────────────
+
+  console.log("\nleader lease");
+  reset();
+  check("unclaimed lease → this tab acquires it", __holdsLeaseForTests("leased"), true);
+  check("holder re-checking → still holds it", __holdsLeaseForTests("leased"), true);
+
+  // Another tab holds a FRESH lease — we must stand down.
+  store.set(
+    "dg-poll-leader:leased",
+    JSON.stringify({ tabId: "some-other-tab", renewedAt: Date.now() }),
+  );
+  check("another tab holds a fresh lease → we stand down", __holdsLeaseForTests("leased"), false);
+
+  // That tab goes away; its lease ages past the TTL and we take over.
+  store.set(
+    "dg-poll-leader:leased",
+    JSON.stringify({ tabId: "some-other-tab", renewedAt: Date.now() - 60_000 }),
+  );
+  check("stale lease past TTL → we take over", __holdsLeaseForTests("leased"), true);
+
+  // Storage throwing (private mode, blocked cookies) must FAIL OPEN — every tab
+  // polling is today's behaviour; nobody polling would silently break features.
+  const realGet = localStorageStub.getItem;
+  localStorageStub.getItem = () => {
+    throw new Error("storage blocked");
+  };
+  check("storage unavailable → fails OPEN", __holdsLeaseForTests("leased"), true);
+  localStorageStub.getItem = realGet;
+
+  // ── Unregister ───────────────────────────────────────────────────────────────
+
+  console.log("\nlifecycle");
+  reset();
+  const unregister = registerPollingTask({ id: "temp", intervalMs: 1_000, run: () => {} });
+  check("registered", inspectPollingTasks().length, 1);
+  unregister();
+  check("unregistered", inspectPollingTasks().length, 0);
+
+  reset();
+  console.log(
+    failures === 0
+      ? "\n✓ polling scheduler smoke passed\n"
+      : `\n✖ ${failures} assertion(s) failed\n`,
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+void main();

--- a/scripts/polling-scheduler-smoke.ts
+++ b/scripts/polling-scheduler-smoke.ts
@@ -17,6 +17,7 @@ type Listener = (...args: unknown[]) => void;
 
 const store = new Map<string, string>();
 let visibility: "visible" | "hidden" = "visible";
+let focused = true;
 const listeners = new Map<string, Set<Listener>>();
 
 function addListener(type: string, fn: Listener) {
@@ -33,6 +34,7 @@ function removeListener(type: string, fn: Listener) {
   },
   addEventListener: addListener,
   removeEventListener: removeListener,
+  hasFocus: () => focused,
 };
 
 const localStorageStub = {
@@ -101,6 +103,24 @@ async function main() {
   withClockOffset(IDLE_AFTER_MS + 1_000, () => {
     check("hidden takes precedence over idle", getEngagement(), "hidden");
   });
+
+  // Input to an UNFOCUSED window must not reset the idle countdown, or a mouse
+  // crossing a second-monitor PWA would keep it "active" forever.
+  reset();
+  const fireInput = () => {
+    for (const fn of listeners.get("pointermove") ?? []) fn();
+  };
+  // Subscribe so the module attaches its listeners.
+  const unsub = (await import("@/lib/core/engagement")).subscribeEngagement(() => {});
+  focused = false;
+  withClockOffset(IDLE_AFTER_MS + 1_000, () => {
+    fireInput();
+    check("pointermove while UNFOCUSED does not reset idle", getEngagement(), "idle");
+  });
+  focused = true;
+  fireInput();
+  check("pointermove while focused does reset idle", getEngagement(), "active");
+  unsub();
 
   // ── Scheduler gating ─────────────────────────────────────────────────────────
 

--- a/scripts/validate-polling.ts
+++ b/scripts/validate-polling.ts
@@ -66,11 +66,11 @@ interface Declared {
  */
 const REGISTRY: Declared[] = [
   // ── Network pollers: must pause when hidden ────────────────────────────────
-  {
-    file: "components/content/AuthSessionSync.tsx",
-    policy: "pause-when-hidden",
-    note: "60s session check. Mounts app-wide so it multiplies per tab; re-checks immediately on tab-visible.",
-  },
+  // components/content/AuthSessionSync.tsx was REMOVED from this registry when it
+  // migrated to registerPollingTask(). That is the intended end state: the
+  // registry audits RAW timers, and a scheduler-registered task declares its own
+  // policy in code (whenHidden / whenIdle / keepAliveWhile), which the type
+  // system enforces far better than a string in a list.
   {
     file: "components/content/headers/MainPanelHeader.tsx",
     policy: "pause-when-hidden",
@@ -286,8 +286,11 @@ function main() {
     if (!seen.has(d.file)) {
       errors.push(
         `STALE ENTRY   ${d.file}\n` +
-          `    Declared in the registry but no timer found (file moved, renamed, or timer removed).\n` +
-          `    Remove the entry.`
+          `    Declared in the registry but no raw timer found.\n` +
+          `    If this file MIGRATED to registerPollingTask(), that is expected — remove the\n` +
+          `    entry. A scheduler-registered task declares its own policy in code, which the\n` +
+          `    type system enforces better than this list can.\n` +
+          `    Otherwise the file moved, was renamed, or lost its timer.`
       );
     }
   }

--- a/scripts/validate-polling.ts
+++ b/scripts/validate-polling.ts
@@ -71,41 +71,6 @@ const REGISTRY: Declared[] = [
   // registry audits RAW timers, and a scheduler-registered task declares its own
   // policy in code (whenHidden / whenIdle / keepAliveWhile), which the type
   // system enforces far better than a string in a list.
-  {
-    file: "components/content/headers/MainPanelHeader.tsx",
-    policy: "pause-when-hidden",
-    note: "10s tab-strip presence. Interval is coupled to STALE_AFTER_MS=45s in presence-server.ts.",
-  },
-  {
-    file: "components/share/SharedContentViewer.tsx",
-    policy: "pause-when-hidden",
-    note: "10s heartbeat + presence read (TWO db ops per tick) on public share pages.",
-  },
-  {
-    file: "lib/features/notifications/transport.ts",
-    policy: "pause-when-hidden",
-    note: "45s badge + thread polls. handleFocus already refreshes on becoming visible.",
-  },
-  {
-    file: "lib/domain/collaboration/presence-poll.ts",
-    policy: "pause-when-hidden",
-    note: "Shared module-level poller: N subscribers collapse to ceil(N/16) requests. The unification model for this codebase.",
-  },
-  {
-    file: "extensions/workplaces/state/workspace-sync.ts",
-    policy: "pause-when-hidden",
-    note: "Reference implementation — the visibility check lives inside the interval callback.",
-  },
-  {
-    file: "extensions/studio/components/RunsPanel.tsx",
-    policy: "pause-when-hidden",
-    note: "3s, the shortest interval in the app. Justified only while a run is in flight AND the tab is visible.",
-  },
-  {
-    file: "extensions/workflows/components/RunDetail.tsx",
-    policy: "pause-when-hidden",
-    note: "3s while a run is non-terminal and the tab is visible.",
-  },
 
   // ── Server-side timers ─────────────────────────────────────────────────────
   {

--- a/scripts/validate-polling.ts
+++ b/scripts/validate-polling.ts
@@ -58,6 +58,18 @@ interface Declared {
    * continuity dominates frequency.
    */
   estimatedMonthlyCostUsd?: number;
+  /**
+   * Set on a "ui-only" entry whose FILE contains network calls that have been
+   * traced and confirmed unrelated to its timer — an event handler, a form
+   * submit, a one-shot load.
+   *
+   * This exists so the ui-only check keeps its teeth. Without it the check would
+   * be either too blunt (flagging legitimate files and training people to
+   * reclassify reflexively) or absent (letting a network poller hide behind the
+   * one policy that skips every other check). Requiring an explicit flag means
+   * somebody had to look.
+   */
+  networkUnrelated?: true;
 }
 
 /**
@@ -85,7 +97,14 @@ const REGISTRY: Declared[] = [
   },
 
   // ── Purely local timers: no network, exempt ────────────────────────────────
-  { file: "app/(public)/layout.tsx", policy: "ui-only", note: "4s hero carousel advance." },
+  {
+    file: "app/(public)/layout.tsx",
+    policy: "ui-only",
+    networkUnrelated: true,
+    note:
+      "4s hero carousel advance (goTo). The file's one fetch is an email-form submit handler — " +
+      "event-driven, unrelated to the timer. Traced 2026-09-09.",
+  },
   { file: "components/client/app-nav/app-nav.tsx", policy: "ui-only", note: "16ms animation frame driving nav rotation." },
   { file: "components/content/ai/CoBrowseIndicator.tsx", policy: "ui-only", note: "1s elapsed-time display tick." },
   { file: "components/content/ai/reasoning/reasoning-disclosure.ts", policy: "ui-only", note: "Local disclosure animation." },
@@ -164,6 +183,13 @@ const EVENTSOURCE_RE = /new\s+EventSource\s*\(/g;
  * instead. A gate that only recognised the literal form would flag correctly
  * architected code and, worse, pressure people back toward hand-rolled checks.
  */
+/**
+ * Network activity. Used to verify a "ui-only" declaration is telling the truth.
+ * Deliberately broad — a false positive costs one reclassification; a false
+ * negative hides a poller behind the one policy that skips every other check.
+ */
+const NETWORK_RE = /\bfetch\s*\(|new\s+EventSource|new\s+WebSocket|XMLHttpRequest|navigator\.sendBeacon/;
+
 const VISIBILITY_RE =
   /visibilityState|document\.hidden|getEngagement|isEngaged|subscribeEngagement|registerPollingTask/;
 
@@ -221,6 +247,27 @@ function main() {
       errors.push(
         `NOT GATED     ${rel}\n` +
           `    Declared "pause-when-hidden" but contains no visibilityState check.\n` +
+          `    ${declared.note}`
+      );
+    }
+
+    // "ui-only" is the one policy that skips every other check, which makes it
+    // the obvious place to hide a network poller — deliberately or by drift, when
+    // someone adds a fetch to a file that used to be a pure animation. Asserting
+    // the file has no network calls at all is a blunt proxy, but a correct one:
+    // a file whose timers are genuinely local has no reason to contain any.
+    if (
+      declared.policy === "ui-only" &&
+      !declared.networkUnrelated &&
+      NETWORK_RE.test(source)
+    ) {
+      errors.push(
+        `UI-ONLY LIES  ${rel}\n` +
+          `    Declared "ui-only" but the file makes network calls.\n` +
+          `    Either its timer does network work — in which case it belongs on the\n` +
+          `    scheduler via registerPollingTask() — or the calls are unrelated to the\n` +
+          `    timer, in which case trace them and set networkUnrelated: true with a note\n` +
+          `    saying what they are.\n` +
           `    ${declared.note}`
       );
     }

--- a/scripts/validate-polling.ts
+++ b/scripts/validate-polling.ts
@@ -126,6 +126,22 @@ const REGISTRY: Declared[] = [
   { file: "components/content/ai/reasoning/reasoning-disclosure.ts", policy: "ui-only", note: "Local disclosure animation." },
   { file: "components/content/folder-views/MediaLightbox.tsx", policy: "ui-only", note: "Slideshow advance." },
   { file: "lib/domain/editor/extensions/blocks/stopwatch.ts", policy: "ui-only", note: "33ms stopwatch tick, local block state." },
+  {
+    file: "lib/core/polling/scheduler.ts",
+    policy: "pause-when-hidden",
+    note:
+      "THE app's polling timer — one base tick driving every registered task. Gating lives here rather than in each " +
+      "call site, so adding a task adds no timers. Engagement is pulled at tick time; hidden is authoritative and " +
+      "keepAliveWhile cannot override it.",
+  },
+  {
+    file: "lib/core/engagement/index.ts",
+    policy: "ui-only",
+    note:
+      "The engagement core's own 5s transition check — the ONLY timer it owns. Never touches the network; exists so " +
+      "streams can be told when the user goes idle. Runs only while subscribed. Pull-based consumers should call " +
+      "getEngagement() at their own tick and cost nothing.",
+  },
 
   // ── Known, not yet audited ─────────────────────────────────────────────────
   // These files contain BOTH timers and network calls, so they cannot be
@@ -169,8 +185,22 @@ const REGISTRY: Declared[] = [
 // `ReturnType<typeof setInterval>` has no following paren, so it cannot match.
 const CALL_RE = /setInterval\s*\(/g;
 const EVENTSOURCE_RE = /new\s+EventSource\s*\(/g;
-/** Any of these near a timer counts as a visibility guard. */
-const VISIBILITY_RE = /visibilityState|document\.hidden/;
+/**
+ * What counts as being gated.
+ *
+ * Two accepted forms, and both must be recognised:
+ *
+ *   - a direct check   `document.visibilityState` / `document.hidden`
+ *   - **delegation**   to the engagement core (`getEngagement`, `isEngaged`,
+ *                      `subscribeEngagement`)
+ *
+ * The second matters increasingly: the whole point of the scheduler is that
+ * individual call sites stop writing visibility checks and declare a policy
+ * instead. A gate that only recognised the literal form would flag correctly
+ * architected code and, worse, pressure people back toward hand-rolled checks.
+ */
+const VISIBILITY_RE =
+  /visibilityState|document\.hidden|getEngagement|isEngaged|subscribeEngagement|registerPollingTask/;
 
 function walk(dir: string): string[] {
   let out: string[] = [];


### PR DESCRIPTION
**Stacked on #213.** Where #213 gated *hidden* tabs, this fixes the case that was actually driving the bill: **an always-open PWA that is visible but idle**.

## The gap #213 left

Every gate in #213 keyed on `document.visibilityState`. An installed PWA left open all day is `"visible"` the entire time and never fires `visibilitychange`, so none of that gating engaged. Worse, the interval reductions didn't help either — Neon autosuspends after 5 minutes without a query, and a 60 s poll produces a maximum gap of 60 s.

| Meter | Visible-idle PWA after #213 | After this PR |
|---|---|---|
| Neon compute | ~$19/mo (never suspends) | sleeps ~6 min after you stop touching it |
| Vercel memory | ~$15–31/mo | streams close |
| **Total** | **~$35–50/mo** | **~$2–4/mo** |

## What's here

**`lib/core/engagement`** — one source of truth for *"is anyone using this tab?"*. Three states ordered by trust: **hidden** is authoritative, **idle** is a heuristic a task may override, **active** is neither. Input via `pointerdown`/`pointermove`/`keydown`/`wheel`/`scroll`, stamping a timestamp rather than resetting a timer (`pointermove` fires 60–120×/s).

**`lib/core/polling/scheduler`** — one base tick drives every task, so adding a task adds no timers. Tasks declare `whenHidden` / `whenIdle` / `keepAliveWhile`. Leadership is a **localStorage lease**, not a consensus protocol: a lease race degrades to two tabs briefly polling, which is today's behaviour with no election at all.

**`lib/infrastructure/auth/session-interceptor`** — a 401 interceptor. Every route already validates server-side, so a 401 *is* the signal. Detection is now instant on any user action and free.

**Ten pollers migrated:**

```
auth-session-check            10 min   leader
collaboration-presence-poll   10 s
main-panel-tab-presence       10 s
notifications-badge           45 s
notifications-thread:<id>     2.5 s
workspace-sync                15 s
share-presence-heartbeat:<id> 30 s
share-presence-read:<id>      60 s
studio-runs:<folderId>        5 s      keepAliveWhile: anyRunning
workflow-run-detail           5 s      keepAliveWhile: active
```

## Self-resolved bugs:

**`scope: "leader"` requires the RESULT to propagate cross-tab (D16).** The badge and `workspace-sync` were first written as `leader` because an unread count is identical in every tab — true and irrelevant. The elected tab fetches; every follower fetches nothing. Since `transport`'s `emit()` reaches only its own listeners, a leader-elected badge would have left every follower's bell **frozen**, presenting as a caching bug. `workspace-sync` fails more subtly: its BroadcastChannel carries *"a mutation happened, go refetch"*, not the answer — a nudge is not propagation. Both reverted to per-tab; the constraint now lives on the `scope` field.

**`ui-only` was a hiding place (D17).** It skips every other check. The gate now asserts a `ui-only` file makes no network calls, with `networkUnrelated: true` for the traced legitimate case.

## Plan revisions:
**D13 said "lift the engagement core from `runtime.ts`." That was wrong.** `runtime.ts` has `lastActivityAt` but it resets on every local **Y.js edit** — *edit* activity, not *input* activity. Someone reading a note without typing is correctly "inactive" to the runtime and correctly "active" here. Both signals are right for their purpose, so this aligns rather than replaces.

**Two flagged surfaces traced and cleared.** Co-browse has only a 1 s UI tick with no network (the agent drives via CDP; results arrive over the chat stream). Quest/sitting UI has **no timers at all**.

## Gates

- **Gate:** `pnpm typecheck` — exit 0
- **Gate:** `pnpm lint` — 0 errors, 151 warnings (unchanged baseline, 175 ratchet)
- **Gate:** `pnpm polling:check` — 15 timer files
- **Gate:** `pnpm polling:smoke` — 18 assertions

**Mutation-tested five ways:** breaking hidden-gating failed 2 assertions; breaking the lease stand-down failed 1; an unregistered poller produced `UNREGISTERED`; a stripped visibility guard produced `NOT GATED`; a network poller flipped to `ui-only` produced `UI-ONLY LIES`.

**Honest limitation:** `networkUnrelated` is an escape hatch and mutation testing confirms a determined person can walk through it by asserting something false. The mitigation is that it requires a human to write the assertion and it shows in the diff.

## Pre-merge checklist

- [ ] **Smoke:** leave the PWA open and untouched for ~2 min → network tab goes quiet; touch anything → polling resumes
- [ ] **Smoke:** sign out in a second browser, then click anything in the first → signed out within a second or two (interceptor), not after minutes
- [ ] **Smoke:** open two tabs → only one issues `/api/auth/session` requests (leader election)
- [ ] **Smoke:** start a studio run, stop touching the mouse for >60 s → progress keeps updating (`keepAliveWhile`)
- [ ] **Smoke:** open a note with a Note Window block → edit gate still reflects presence elsewhere
- [ ] **Smoke:** background a tab with a chat open, return → conversation title updates reconcile (close-and-refetch)
- [ ] `pnpm polling:check` and `pnpm polling:smoke` pass locally

## Not in scope

Phase 1 (Hocuspocus awareness delegation) is forked. Three files remain `unreviewed` — `runtime.ts`, `MarkdownEditor.tsx`, `ChatMessage.tsx` — all collaboration/AI surfaces that belong with that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
