### PR TITLE
fix(folder-views): theme-aware tokens for folder affordances and views

### DIFF
--- a/components/content/folder-views/CanvasView.tsx
+++ b/components/content/folder-views/CanvasView.tsx
@@ -109,7 +109,7 @@ export function CanvasView({
                 <span className="text-sm font-medium flex-1">
                   {item.title}
                   {displayExtension && (
-                    <span className="text-gray-600">{displayExtension}</span>
+                    <span className="text-muted-foreground">{displayExtension}</span>
                   )}
                 </span>
                 <button
@@ -121,10 +121,10 @@ export function CanvasView({
                       paneId,
                     });
                   }}
-                  className="flex-shrink-0 p-1 rounded hover:bg-white/50 transition-colors"
+                  className="flex-shrink-0 p-1 rounded hover:bg-muted transition-colors"
                   title="Open in main panel"
                 >
-                  <ExternalLink className="h-3.5 w-3.5 text-gray-600" />
+                  <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
                 </button>
               </div>
             ),
@@ -217,7 +217,7 @@ export function CanvasView({
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="text-sm text-gray-600">Loading canvas...</div>
+        <div className="text-sm text-muted-foreground">Loading canvas...</div>
       </div>
     );
   }
@@ -225,9 +225,9 @@ export function CanvasView({
   if (items.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-center px-4">
-        <FileText className="h-16 w-16 text-gray-400 mb-4" />
-        <p className="text-sm text-gray-600 mb-2">No items to display</p>
-        <p className="text-xs text-gray-500">
+        <FileText className="h-16 w-16 text-muted-foreground mb-4" />
+        <p className="text-sm text-muted-foreground mb-2">No items to display</p>
+        <p className="text-xs text-muted-foreground">
           Create content to see it visualized on the canvas
         </p>
       </div>

--- a/components/content/folder-views/DashboardView.tsx
+++ b/components/content/folder-views/DashboardView.tsx
@@ -176,7 +176,7 @@ export function DashboardView({
       const preview = item.note.searchText.substring(0, 150);
       return (
         <div className="h-full flex flex-col">
-          <p className="text-xs text-gray-600 line-clamp-4 flex-1">
+          <p className="text-xs text-muted-foreground line-clamp-4 flex-1">
             {preview}
           </p>
         </div>
@@ -185,7 +185,7 @@ export function DashboardView({
 
     return (
       <div className="h-full flex items-center justify-center">
-        <div className="text-gray-400">{getIcon(item.contentType)}</div>
+        <div className="text-muted-foreground">{getIcon(item.contentType)}</div>
       </div>
     );
   };
@@ -193,7 +193,7 @@ export function DashboardView({
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="text-sm text-gray-600">Loading dashboard...</div>
+        <div className="text-sm text-muted-foreground">Loading dashboard...</div>
       </div>
     );
   }
@@ -201,9 +201,9 @@ export function DashboardView({
   if (items.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-center px-4">
-        <ImageIcon className="h-16 w-16 text-gray-400 mb-4" />
-        <p className="text-sm text-gray-600 mb-2">No items in this folder</p>
-        <p className="text-xs text-gray-500">
+        <ImageIcon className="h-16 w-16 text-muted-foreground mb-4" />
+        <p className="text-sm text-muted-foreground mb-2">No items in this folder</p>
+        <p className="text-xs text-muted-foreground">
           Create content to see it displayed as dashboard tiles
         </p>
       </div>
@@ -238,20 +238,20 @@ export function DashboardView({
           return (
           <div
             key={item.id}
-            className="rounded-lg border border-white/10 overflow-hidden cursor-pointer hover:border-primary/30 transition-colors"
+            className="rounded-lg border border-border overflow-hidden cursor-pointer hover:border-primary/30 transition-colors"
             style={{
               background: glass0.background,
               backdropFilter: glass0.backdropFilter,
             }}
             onClick={() => handleItemClick(item)}
           >
-            <div className="drag-handle cursor-move border-b border-white/10 px-3 py-2 bg-white/5">
+            <div className="drag-handle cursor-move border-b border-border px-3 py-2 bg-muted/50">
               <div className="flex items-center gap-2">
-                <div className="text-gray-600">{getIcon(item.contentType)}</div>
-                <h4 className="text-sm font-medium text-gray-900 truncate flex-1">
+                <div className="text-muted-foreground">{getIcon(item.contentType)}</div>
+                <h4 className="text-sm font-medium text-foreground truncate flex-1">
                   {item.title}
                   {displayExtension && (
-                    <span className="text-gray-600">{displayExtension}</span>
+                    <span className="text-muted-foreground">{displayExtension}</span>
                   )}
                 </h4>
                 <button
@@ -259,10 +259,10 @@ export function DashboardView({
                     e.stopPropagation();
                     handleItemClick(item);
                   }}
-                  className="flex-shrink-0 p-1 rounded hover:bg-white/20 transition-colors"
+                  className="flex-shrink-0 p-1 rounded hover:bg-muted transition-colors"
                   title="Open in main panel"
                 >
-                  <ExternalLink className="h-3.5 w-3.5 text-gray-600" />
+                  <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
                 </button>
               </div>
             </div>

--- a/components/content/folder-views/GalleryView.tsx
+++ b/components/content/folder-views/GalleryView.tsx
@@ -181,7 +181,7 @@ export function GalleryView({
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="text-sm text-gray-600">Loading gallery...</div>
+        <div className="text-sm text-muted-foreground">Loading gallery...</div>
       </div>
     );
   }
@@ -189,9 +189,9 @@ export function GalleryView({
   if (mediaItems.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-center px-4">
-        <ImageIcon className="h-16 w-16 text-gray-400 mb-4" />
-        <p className="text-sm text-gray-600 mb-2">No media files in this folder</p>
-        <p className="text-xs text-gray-500">
+        <ImageIcon className="h-16 w-16 text-muted-foreground mb-4" />
+        <p className="text-sm text-muted-foreground mb-2">No media files in this folder</p>
+        <p className="text-xs text-muted-foreground">
           Upload images or videos to see them in gallery view
         </p>
       </div>
@@ -201,8 +201,8 @@ export function GalleryView({
   return (
     <>
       {/* Gallery Header with Slideshow Button */}
-      <div className="flex-none px-6 py-3 border-b border-white/10 flex items-center justify-between">
-        <div className="text-sm text-gray-400">
+      <div className="flex-none px-6 py-3 border-b border-border flex items-center justify-between">
+        <div className="text-sm text-muted-foreground">
           {mediaItems.length} {mediaItems.length === 1 ? "item" : "items"}
         </div>
         <Button
@@ -227,7 +227,7 @@ export function GalleryView({
               <button
                 key={item.id}
                 onClick={() => handleItemClick(index)}
-                className="group relative rounded-lg border border-white/10 overflow-hidden hover:ring-2 hover:ring-primary/50 transition-all"
+                className="group relative rounded-lg border border-border overflow-hidden hover:ring-2 hover:ring-primary/50 transition-all"
                 style={{
                   background: glass0.background,
                   backdropFilter: glass0.backdropFilter,
@@ -256,8 +256,8 @@ export function GalleryView({
                 ) : (
                   <div className="w-full h-full flex items-center justify-center">
                     {/* Loading skeleton with subtle pulse */}
-                    <div className="absolute inset-0 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 animate-pulse" />
-                    <FileImage className="h-12 w-12 text-gray-400 relative z-10" />
+                    <div className="absolute inset-0 bg-muted animate-pulse" />
+                    <FileImage className="h-12 w-12 text-muted-foreground relative z-10" />
                   </div>
                 )}
               </div>

--- a/components/content/folder-views/KanbanView.tsx
+++ b/components/content/folder-views/KanbanView.tsx
@@ -102,7 +102,7 @@ function SortableCard({
       style={style}
       {...attributes}
       {...listeners}
-      className="p-3 mb-2 rounded-lg border border-white/10 cursor-move hover:border-primary/30 transition-colors"
+      className="p-3 mb-2 rounded-lg border border-border cursor-move hover:border-primary/30 transition-colors"
     >
       <div
         style={{
@@ -111,21 +111,21 @@ function SortableCard({
         }}
       >
         <div className="flex items-start justify-between gap-2 mb-2">
-          <h4 className="text-sm font-medium text-gray-900 flex-1">
+          <h4 className="text-sm font-medium text-foreground flex-1">
             {item.title}
             {displayExtension && (
-              <span className="text-gray-600">{displayExtension}</span>
+              <span className="text-muted-foreground">{displayExtension}</span>
             )}
           </h4>
           <button
             onClick={handleOpenContent}
-            className="flex-shrink-0 p-1 rounded hover:bg-white/20 transition-colors"
+            className="flex-shrink-0 p-1 rounded hover:bg-muted transition-colors"
             title="Open in main panel"
           >
-            <ExternalLink className="h-3.5 w-3.5 text-gray-600" />
+            <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
           </button>
         </div>
-        <p className="text-xs text-gray-600 line-clamp-3">{previewLines}</p>
+        <p className="text-xs text-muted-foreground line-clamp-3">{previewLines}</p>
       </div>
     </div>
   );
@@ -402,7 +402,7 @@ export function KanbanView({
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="text-sm text-gray-600">Loading kanban board...</div>
+        <div className="text-sm text-muted-foreground">Loading kanban board...</div>
       </div>
     );
   }
@@ -419,10 +419,10 @@ export function KanbanView({
           {columns.map((column) => (
             <DroppableColumn key={column.id} column={column}>
               {/* Column header */}
-              <div className="p-4 border-b border-white/10">
-                <h3 className="text-sm font-semibold text-gray-900 flex items-center justify-between">
+              <div className="p-4 border-b border-border">
+                <h3 className="text-sm font-semibold text-foreground flex items-center justify-between">
                   {column.title}
-                  <span className="text-xs text-gray-500 ml-2">
+                  <span className="text-xs text-muted-foreground ml-2">
                     {column.items.length}
                   </span>
                 </h3>
@@ -441,17 +441,17 @@ export function KanbanView({
 
                 {column.items.length === 0 && (
                   <div className="flex flex-col items-center justify-center py-8 text-center">
-                    <FileText className="h-12 w-12 text-gray-400 mb-2" />
-                    <p className="text-xs text-gray-500">No cards yet</p>
+                    <FileText className="h-12 w-12 text-muted-foreground mb-2" />
+                    <p className="text-xs text-muted-foreground">No cards yet</p>
                   </div>
                 )}
               </div>
 
               {/* Add card button */}
-              <div className="p-4 border-t border-white/10">
+              <div className="p-4 border-t border-border">
                 <button
                   onClick={() => handleAddCard(column.id)}
-                  className="w-full flex items-center justify-center gap-2 py-2 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                  className="w-full flex items-center justify-center gap-2 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
                 >
                   <Plus className="h-4 w-4" />
                   Add Card
@@ -473,11 +473,11 @@ export function KanbanView({
               const previewLines = preview.split("\n").slice(0, 3).join("\n");
 
               return (
-                <div className="p-3 rounded-lg border border-primary bg-white shadow-lg w-80">
-                  <h4 className="text-sm font-medium text-gray-900 mb-2">
+                <div className="p-3 rounded-lg border border-primary bg-background shadow-lg w-80">
+                  <h4 className="text-sm font-medium text-foreground mb-2">
                     {activeItem.title}
                   </h4>
-                  <p className="text-xs text-gray-600 line-clamp-3">{previewLines}</p>
+                  <p className="text-xs text-muted-foreground line-clamp-3">{previewLines}</p>
                 </div>
               );
             })()

--- a/components/content/folder-views/ListView.tsx
+++ b/components/content/folder-views/ListView.tsx
@@ -133,7 +133,7 @@ export function ListView({
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="text-sm text-gray-600">Loading folder contents...</div>
+        <div className="text-sm text-muted-foreground">Loading folder contents...</div>
       </div>
     );
   }
@@ -141,9 +141,9 @@ export function ListView({
   if (children.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-center px-4">
-        <Folder className="h-16 w-16 text-gray-400 mb-4" />
-        <p className="text-sm text-gray-600 mb-2">This folder is empty</p>
-        <p className="text-xs text-gray-500">
+        <Folder className="h-16 w-16 text-muted-foreground mb-4" />
+        <p className="text-sm text-muted-foreground mb-2">This folder is empty</p>
+        <p className="text-xs text-muted-foreground">
           Add content using the plus button or context menu
         </p>
       </div>
@@ -164,7 +164,7 @@ export function ListView({
               className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg border transition-colors text-left ${
                 isSelected
                   ? "border-primary bg-primary/10 ring-2 ring-primary/20"
-                  : "border-white/10 hover:bg-white/5"
+                  : "border-border hover:bg-muted/50"
               }`}
               style={
                 isSelected
@@ -175,17 +175,17 @@ export function ListView({
                     }
               }
             >
-              <div className={isSelected ? "text-primary" : "text-gray-600"}>
+              <div className={isSelected ? "text-primary" : "text-muted-foreground"}>
                 {getIcon(child.contentType)}
               </div>
               <div className="flex-1 min-w-0">
-                <div className={`text-sm font-medium truncate ${isSelected ? "text-primary" : "text-gray-900"}`}>
+                <div className={`text-sm font-medium truncate ${isSelected ? "text-primary" : "text-foreground"}`}>
                   {child.title}
                   {displayExtension && (
-                    <span className="text-gray-600">{displayExtension}</span>
+                    <span className="text-muted-foreground">{displayExtension}</span>
                   )}
                 </div>
-                <div className="text-xs text-gray-500">
+                <div className="text-xs text-muted-foreground">
                   {child.contentType === "folder" ? "Folder" : "Document"}
                 </div>
               </div>

--- a/components/content/viewer/FolderViewer.tsx
+++ b/components/content/viewer/FolderViewer.tsx
@@ -116,14 +116,14 @@ export function FolderViewer({
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-white/10 px-6 py-2">
+      <div className="flex items-center justify-between border-b border-border px-6 py-2">
         <div className="flex items-center gap-2">
-          <Folder className="h-4 w-4 text-gray-600" />
-          <h1 className="text-sm font-medium text-gray-900 leading-tight">{title}</h1>
+          <Folder className="h-4 w-4 text-muted-foreground" />
+          <h1 className="text-sm font-medium text-foreground leading-tight">{title}</h1>
         </div>
 
         {/* View Mode Toggle */}
-        <div className="flex items-center gap-1 rounded-md border border-white/10 bg-white/5 p-1">
+        <div className="flex items-center gap-1 rounded-md border border-border bg-muted/50 p-1">
           {(["list", "gallery", "kanban", "dashboard", "canvas"] as const).map((mode) => (
             <button
               key={mode}
@@ -131,7 +131,7 @@ export function FolderViewer({
               className={`rounded p-1.5 transition-colors ${
                 viewMode === mode
                   ? "bg-primary/20 text-primary"
-                  : "text-gray-400 hover:bg-white/10 hover:text-white"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
               }`}
               title={`${mode.charAt(0).toUpperCase() + mode.slice(1)} view`}
             >


### PR DESCRIPTION
## Sprint 63 — Bug squash 2026-W37

The folder viewer and its five view components were authored **dark-first** — glass chrome via `bg-white/5` and `border-white/10` — but their text colours were left as fixed light-mode greys with no `dark:` companion. The two conventions fight each other, so these surfaces were wrong in *both* themes: item titles rendered `text-gray-900` on the dark glass panel (the near-invisible text in the reporter's screenshots), while the view-switcher shell nearly disappeared in *light* mode.

This converts the six folder-affordance files to the semantic tokens the rest of `components/content/` already uses.

- `text-gray-900` → `text-foreground`; `text-gray-400/500/600` → `text-muted-foreground`
- `border-white/10` → `border-border`; `bg-white/5` → `bg-muted/50`
- `hover:bg-white/{5,10,20,50}` → `hover:bg-muted`; `hover:text-white` → `hover:text-foreground`
- `KanbanView` drag preview `bg-white` → `bg-background` (`KanbanView.tsx:476`)
- `GalleryView` loading shimmer: light-only grey gradient → `bg-muted` (`GalleryView.tsx:259`)

Files: `FolderViewer.tsx`, `ListView.tsx`, `DashboardView.tsx`, `KanbanView.tsx`, `CanvasView.tsx`, `GalleryView.tsx`. **Class strings only — no logic, markup, or component-structure changes.**

**Diagnosis:** the folder surfaces simply never got converted to the theme-aware convention the rest of the directory uses. `components/content/viewer/FolderViewer.tsx:122` renders the folder title as `text-gray-900` inside a container whose chrome is `border-white/10 bg-white/5` (`:119`, `:126`) — a near-black title on a dark glass panel. Same pattern in the five views, e.g. `components/content/folder-views/KanbanView.tsx:114` and `components/content/folder-views/ListView.tsx:182`. The repo already standardises on `text-muted-foreground` (197 uses), `bg-muted` (83), `text-foreground` (78) and `border-border` (76) across `components/content/`.

**Two notes where I departed from the plan doc, deliberately:**

1. The plan suggested routing the dark-first glass through `getSurfaceStyles()` from `lib/design/system/`. I used the Tailwind semantic tokens instead: those are applied as inline `style` props, so adopting them here would have restructured the markup of all six files, against "keep each change minimal and on-topic". `bg-muted`/`border-border` is what the 76–83 neighbouring usages in this same directory already do, and it fixes both themes at once.
2. `GalleryView.tsx:259` (the light-only grey gradient shimmer) is one line beyond the plan's enumeration. It is the same defect class, inside a scoped file, on a surface the smoke test exercises — a bright grey flash on the dark surface. Fixed rather than left, since leaving it would have failed the very check below.

**For the owner, not fixed here** (out of scope, noted per the "resist widening" instruction in the plan):

- `--muted-foreground` in dark mode is `#7A9A9A` on a `#465E73` background — roughly 2.2:1, below WCAG AA for body text. Card surfaces (`--card: #2D4A4B`) fare better at ~3:1. That is a **token-level** issue affecting all 197 usages app-wide, not something to change under one bug fix, but it caps how legible the muted text in this PR can get.
- `components/content/skeletons/*.tsx` are still dark-first (`bg-white/10`), same defect class, outside the six-file slice.

**Gates — all three ran to completion in this environment:**

- **typecheck ✅** — `pnpm typecheck`, exit 0.
- **lint ✅** — `pnpm lint`, exit 0, `151 problems (0 errors, 151 warnings)`: exactly the `--max-warnings 151` ratchet, so no new warnings and the ratchet was not touched. The warnings that do appear in the touched files are pre-existing unused-arg and `react-hooks/exhaustive-deps` findings at lines 32–191 (e.g. `folderTitle`, `loadChildren`), untouched by a className-only change; `FolderViewer.tsx` produces none.
- **build ✅** — `NODE_OPTIONS='--max-old-space-size=8192' pnpm build`, exit 0. All 19 CI gates passed (`collab:schema:check`, `markdown:blocks:check`, `extensions:check`, `ai:drift:check`, …), then `✓ Compiled successfully in 114s` and `✓ Generating static pages (234/234)`.

No automated gate covers this change: `pnpm publishing:audit:themes` only scans `.public-prose .block-*` CSS rules and cannot see Tailwind classes in components, and the Playwright dark-mode suite cannot reach a folder route (`tests/e2e/dark-mode/authenticated-routes.spec.ts` is still `test.skip` pending the auth fixture). **Verification is manual, in both themes.**

## Pre-merge checklist

- [ ] `pnpm build` green locally
- [ ] Dark-mode folder pass: open a folder in dark mode, switch through List / Dashboard /
      Kanban / Canvas / Gallery → every item title, extension label and the view-switcher's
      inactive icons are legible against the dark surface; repeat in light mode and confirm
      the switcher shell and Kanban drag preview are still visible

> **The absent `Smoke #184:` marker is deliberate — please keep it that way.** Issue #184 is a
> never-closing checklist issue ("should never be closed until darkmode contrast issues are
> fully squashed"), and a ticked `**Smoke #184:**` line is exactly what authorises
> `/pr-closeout` to close it. Written as a plain checklist line it still gates this merge
> without arming the closer. This PR closes nothing; it addresses the "folder affordances,
> including various folder views" checklist item only. Rationale is in the W37 plan doc
> (`BUG-SQUASH-2026-W37.md`), which specifies the line in exactly this form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjubGuDgAS5zHC3HnmeECD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjubGuDgAS5zHC3HnmeECD)_