### PR TITLE
File tree: drag-and-drop tolerates stale selection ids (freshly created items movable immediately)

### DIFF
--- a/components/content/content/LeftSidebarContent.tsx
+++ b/components/content/content/LeftSidebarContent.tsx
@@ -965,14 +965,27 @@ export function LeftSidebarContent({
     };
     findPositions(originalTree);
 
-    // Resolve every dragged node. If any can't be found we bail before
-    // touching the optimistic tree.
+    // Resolve every dragged node, dropping any id that no longer names a live
+    // row rather than aborting the whole drag.
+    //
+    // react-arborist reports drag ids from its internal selection set, and it
+    // does NOT prune that set when `data` changes — its `selectedNodes` getter
+    // filters on read, but the drag hook reads the raw `selectedIds`. So a dead
+    // id can ride along in `dragIds` even though the user only grabbed live
+    // rows: a `temp-…` placeholder swapped for its real id after inline
+    // creation, or a node a refetch removed while it was selected. The row the
+    // user actually grabbed is always live (you can only drag a visible row),
+    // so keeping the resolvable ids and moving those matches how react-arborist
+    // itself treats the selection. Before this, one stale companion id aborted
+    // the entire drag with "could not be found in the current tree" — a freshly
+    // created item was unmovable until the tree was refetched (which cleared the
+    // stale id as a side effect). Only bail when nothing at all resolves.
     const dragged = dragIds
       .map((id) => ({ id, node: findTreeNodeById(originalTree, id) }))
       .filter((x): x is { id: string; node: TreeNode } => x.node !== null);
-    if (dragged.length !== dragIds.length) {
+    if (dragged.length === 0) {
       toast.error("Failed to move item", {
-        description: "One or more dragged items could not be found in the current tree.",
+        description: "The dragged item could not be found in the current tree.",
       });
       return;
     }
@@ -1117,9 +1130,12 @@ export function LeftSidebarContent({
 
       // Drag-moves refresh the tree locally (optimistic update above), so
       // outside listeners — the main-panel path breadcrumb — need their own
-      // signal that ancestry may have changed.
+      // signal that ancestry may have changed. Reports the ids that actually
+      // moved (resolved), not the raw drag ids, which may carry a stale entry.
       window.dispatchEvent(
-        new CustomEvent("dg:content-moved", { detail: { ids: dragIds } }),
+        new CustomEvent("dg:content-moved", {
+          detail: { ids: dragged.map((d) => d.id) },
+        }),
       );
 
       if (peopleDragged.length > 0) {


### PR DESCRIPTION
## Summary

Freshly created file-tree items (notes, folders, etc.) are now immediately draggable — you can renest or reorder them, and drop content into a newly created folder, **without refreshing the tree first**.

**The defect this removes:** dragging a just-created item, or dropping content into a just-created folder, failed with *"Failed to move item — One or more dragged items could not be found in the current tree,"* and no `/move` request was ever sent. A file-tree refresh (or full page reload) was required before the item could be moved.

## Root cause

A contract mismatch with `react-arborist`. Its drag hook builds `dragIds` from the raw `selectedIds` Set, which it **never prunes when `data` changes** — only its `selectedNodes` getter filters dead ids on read. So after inline creation swaps a `temp-…` placeholder for its real id (or a refetch removes a still-selected node), a dead id lingers in the selection and rides along in every subsequent drag of a selected row.

`handleMove` was **stricter than the library**: it resolved every `dragId` through `findTreeNodeById` and aborted the whole drag if a single one was missing. One stale companion id therefore killed the move before it started. A refetch papered over it because the post-refetch `select()` resets the selection Set — which is why "refresh the tree" worked around it.

## The fix

`handleMove` now matches `react-arborist`'s own tolerance: **drop the unresolvable ids and move the rest.** The row the user actually grabbed is always live (you can only drag a visible row), so the resolvable set always contains it; the handler bails only when *nothing at all* resolves. `dg:content-moved` now reports the ids that actually moved rather than the raw drag ids.

Same all-or-nothing failure class as the two earlier reference-block walker fixes (`drop a reference into a block without needing a reload`, `stop referenced content being captured by the folder it lands in`) — but the stale-id source here is the **selection Set**, not the `references` array.

## Preflight checklist

- [x] **Gate: typecheck** — `pnpm typecheck` clean
- [x] **Gate: lint** — 0 errors, 151 warnings (under the 175 ratchet; 0 new in the edited file)
- [x] **Gate: build** — `NODE_OPTIONS='--max-old-space-size=8192' pnpm build` green (prisma generate → build:tokens → tsc → collab:schema:check → lint → next build)
- [ ] **Smoke:** create a new note → drag it into a folder → it renests immediately (no "could not be found" toast, no refresh)
- [ ] **Smoke:** create a new folder → drag an existing note into it → it nests immediately
- [ ] **Smoke:** multi-select two existing items → drag → both still move (no regression)

No schema changes (no migration). No new extensions, TipTap nodes, or publishing blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)