### PR TITLE
Workplaces: clear-tabs menu gains targeted actions and a 10-second undo

### DIFF
--- a/extensions/workplaces/shell/WorkplacesShellNavigationTrailingControls.tsx
+++ b/extensions/workplaces/shell/WorkplacesShellNavigationTrailingControls.tsx
@@ -1,104 +1,334 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { CircleX } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { CircleX, type LucideIcon } from "lucide-react";
 import { toast } from "sonner";
 import { useWorkspaceStore } from "@/extensions/workplaces/state/workspace-store";
 import {
   useContentStore,
   getVisiblePaneIds,
   getPaneLabel,
+  markLocalOpenIntents,
   type WorkspacePaneId,
+  type WorkspaceStateSnapshot,
 } from "@/state/content-store";
 import { collectPaneAttachedTabs } from "@/state/workspace-tab-filter-store";
+import { useNavigationHistoryStore } from "@/state/navigation-history-store";
+import {
+  buildActivationTimes,
+  resolveLastTouchedAt,
+  useTabActivityStore,
+} from "@/state/tab-activity-store";
+import { useAnchoredMenu } from "@/lib/core/use-anchored-menu";
+import {
+  buildIdleTargets,
+  buildOthersTarget,
+  buildTypeTargets,
+} from "./clear-tabs-targets";
 
 /**
  * Clear-tabs control.
  *
- * Click        → clear every tab in the workplace (the common case).
- * Hold (250ms) → menu of targets: each visible pane individually, or all panes.
+ * Tap          → clear every tab in the workplace (the common case).
+ * Hold (250ms) → the options menu. Right-click opens it too, since a hold is
+ *                undiscoverable on a pointer device and unreachable by anyone
+ *                who can't hold a button down.
  *
  * The hold-for-options gesture mirrors the back button's hold-for-history in
  * MainPanelNavigation, so the whole navigation bar shares one interaction
  * grammar: tap does the obvious thing, hold reveals the choices.
+ *
+ * MENU SHAPE — full-width rows for targets you pick by name (a pane, the
+ * others, everything), and chip rows for the dimensions that would otherwise
+ * need a submenu each. A chip row keeps a whole dimension on one line, and
+ * `clear-tabs-targets` drops the chips that wouldn't decide anything, so the
+ * menu stays about as tall as the old one while offering much more.
+ *
+ * Every action is undoable for UNDO_WINDOW_MS through the toast, which is what
+ * makes a tap-to-clear-everything default defensible.
+ *
+ * Tabs are always read through `collectPaneAttachedTabs`: the content store's
+ * `tabs` record accumulates entries across workspace switches, so counting it
+ * directly would offer to close another workspace's content.
  */
 
 const HOLD_THRESHOLD_MS = 250;
+const UNDO_WINDOW_MS = 10_000;
+const MENU_WIDTH = 268;
+const MENU_MAX_HEIGHT = 420;
+
+function pluralizeTabs(count: number): string {
+  return count === 1 ? "1 tab" : `${count} tabs`;
+}
+
+function RowButton({
+  label,
+  count,
+  description,
+  destructive,
+  onSelect,
+}: {
+  label: string;
+  count: number;
+  description: string;
+  destructive?: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onSelect}
+      title={description}
+      aria-label={description}
+      className={`flex w-full items-center justify-between gap-3 rounded px-2.5 py-1.5 text-left text-sm transition-colors ${
+        destructive
+          ? "text-gray-700 hover:bg-red-500/10 hover:text-red-600 dark:text-gray-200 dark:hover:bg-red-500/10 dark:hover:text-red-400"
+          : "text-gray-700 hover:bg-black/5 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-white/5 dark:hover:text-white"
+      }`}
+    >
+      <span className="truncate">{label}</span>
+      <span className="shrink-0 text-xs tabular-nums text-gray-400">{count}</span>
+    </button>
+  );
+}
+
+function ChipRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={`Clear tabs by ${label.toLowerCase()}`}
+      className="flex items-start gap-2 px-2.5 py-1"
+    >
+      <span className="mt-1 w-8 shrink-0 text-[10px] uppercase tracking-[0.14em] text-gray-500">
+        {label}
+      </span>
+      <div className="flex flex-wrap gap-1">{children}</div>
+    </div>
+  );
+}
+
+function ClearChip({
+  label,
+  icon: Icon,
+  count,
+  description,
+  onSelect,
+}: {
+  label: string;
+  icon?: LucideIcon;
+  count: number;
+  description: string;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onSelect}
+      title={description}
+      aria-label={description}
+      className="inline-flex items-center gap-1 rounded border border-white/10 bg-black/[0.02] px-1.5 py-0.5 text-xs text-gray-600 transition-colors hover:bg-red-500/10 hover:text-red-600 dark:bg-white/[0.03] dark:text-gray-300 dark:hover:bg-red-500/10 dark:hover:text-red-400"
+    >
+      {Icon ? (
+        <Icon className="h-3 w-3" aria-hidden="true" />
+      ) : (
+        <span>{label}</span>
+      )}
+      <span className="text-[10px] tabular-nums opacity-55">{count}</span>
+    </button>
+  );
+}
 
 export function WorkplacesShellNavigationTrailingControls() {
   const clearAllWorkspaceTabs = useContentStore(
     (state) => state.clearAllWorkspaceTabs
   );
   const closeContentTab = useContentStore((state) => state.closeContentTab);
-  // Pane-attached tabs only — the raw `tabs` record accumulates entries
-  // across workspace switches (restoreWorkspace merges; panes are rebuilt),
-  // so counting it directly inflates the number with other workspaces'
-  // residue. See collectPaneAttachedTabs.
-  const workspaceTabCount = useContentStore(
-    (state) => collectPaneAttachedTabs(state.panes, state.tabs).length
-  );
+  const restoreWorkspace = useContentStore((state) => state.restoreWorkspace);
   const layoutMode = useContentStore((state) => state.layoutMode);
   const panes = useContentStore((state) => state.panes);
+  const tabsById = useContentStore((state) => state.tabs);
+  const activePaneId = useContentStore((state) => state.activePaneId);
   const persistActiveWorkspace = useWorkspaceStore(
     (state) => state.persistActiveWorkspace
   );
+  const historyByPaneId = useNavigationHistoryStore((state) => state.byPaneId);
+  const firstSeenAt = useTabActivityStore((state) => state.firstSeenAt);
+  const noteSeen = useTabActivityStore((state) => state.noteSeen);
 
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { open, openMenu, close, triggerRef, menuRef, menuStyle } =
+    useAnchoredMenu({ width: MENU_WIDTH, maxHeight: MENU_MAX_HEIGHT });
+
+  // Sampled when the menu opens: Date.now() during render is impure, and the
+  // buckets only need to be right at the moment they're offered.
+  const [menuOpenedAt, setMenuOpenedAt] = useState<number | null>(null);
+
   const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isHoldingRef = useRef(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const isPressingRef = useRef(false);
+  const openedByHoldRef = useRef(false);
 
+  const tabs = useMemo(
+    () => collectPaneAttachedTabs(panes, tabsById),
+    [panes, tabsById]
+  );
+  const tabCount = tabs.length;
   const visiblePaneIds = getVisiblePaneIds(layoutMode);
   const isMultiPane = visiblePaneIds.length > 1;
 
-  const persist = useCallback(
-    (message: string) => {
-      void persistActiveWorkspace()
-        .then(() => toast.success(message))
-        .catch((error) => {
-          console.error(
-            "[WorkplacesShellNavigationTrailingControls] Failed to persist cleared workplace:",
-            error
-          );
-          toast.error(
-            error instanceof Error
-              ? error.message
-              : "Failed to persist cleared workplace tabs"
-          );
-        });
+  // A tab restored with a workspace and never clicked has no navigation
+  // entry; stamping it on arrival starts its idle clock there.
+  useEffect(() => {
+    if (tabs.length === 0) return;
+    noteSeen(tabs.map((tab) => tab.contentId));
+  }, [tabs, noteSeen]);
+
+  const idleTargets = useMemo(() => {
+    if (!open || menuOpenedAt === null) return [];
+    const activationAt = buildActivationTimes(historyByPaneId);
+    return buildIdleTargets(
+      tabs,
+      (contentId) => resolveLastTouchedAt(contentId, firstSeenAt, activationAt),
+      menuOpenedAt
+    );
+  }, [open, menuOpenedAt, tabs, historyByPaneId, firstSeenAt]);
+
+  const typeTargets = useMemo(
+    () => (open ? buildTypeTargets(tabs) : []),
+    [open, tabs]
+  );
+
+  const othersTarget = useMemo(
+    () =>
+      open
+        ? buildOthersTarget(tabs, panes[activePaneId]?.activeTabId ?? null)
+        : null,
+    [open, tabs, panes, activePaneId]
+  );
+
+  const persistQuietly = useCallback(() => {
+    void persistActiveWorkspace().catch((error) => {
+      console.error(
+        "[WorkplacesShellNavigationTrailingControls] Failed to persist cleared workplace:",
+        error
+      );
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to persist cleared workplace tabs"
+      );
+    });
+  }, [persistActiveWorkspace]);
+
+  const undoClear = useCallback(
+    (
+      before: WorkspaceStateSnapshot,
+      tabMeta: Record<string, { title?: string | null; contentType?: string | null }>
+    ) => {
+      const current = useContentStore.getState().getWorkspaceStateSnapshot();
+      const paneIds = new Set<WorkspacePaneId>([
+        ...(Object.keys(before.paneTabContentIds) as WorkspacePaneId[]),
+        ...(Object.keys(current.paneTabContentIds) as WorkspacePaneId[]),
+      ]);
+
+      const paneTabContentIds: Partial<Record<WorkspacePaneId, string[]>> = {};
+      const restored: string[] = [];
+      for (const paneId of paneIds) {
+        const wasOpen = before.paneTabContentIds[paneId]?.contentIds ?? [];
+        const nowOpen = current.paneTabContentIds[paneId]?.contentIds ?? [];
+        // Anything opened during the undo window survives: undo puts back what
+        // the clear removed, it doesn't rewind the workspace.
+        const merged = [...wasOpen];
+        for (const contentId of nowOpen) {
+          if (!merged.includes(contentId)) merged.push(contentId);
+        }
+        paneTabContentIds[paneId] = merged;
+        for (const contentId of wasOpen) {
+          if (!nowOpen.includes(contentId)) restored.push(contentId);
+        }
+      }
+      if (restored.length === 0) return;
+
+      // The clear recorded close-intents, and a peer may already have written a
+      // snapshot without these tabs. Without matching open-intents the next
+      // reconcile would faithfully close them again.
+      markLocalOpenIntents(restored);
+      restoreWorkspace({
+        activeContentId: before.activeContentId,
+        activePaneId: before.activePaneId,
+        layoutMode: before.layoutMode,
+        paneTabContentIds,
+        tabMeta,
+      });
+      persistQuietly();
+      toast.success(`Restored ${pluralizeTabs(restored.length)}`);
     },
-    [persistActiveWorkspace]
+    [restoreWorkspace, persistQuietly]
+  );
+
+  /**
+   * `perform` exists for the all-tabs case, which keeps using the store's
+   * dedicated clear action rather than a loop over closeContentTab.
+   */
+  const runClear = useCallback(
+    (message: string, tabIds: string[], perform?: () => void) => {
+      if (tabIds.length === 0) return;
+      const store = useContentStore.getState();
+      const before = store.getWorkspaceStateSnapshot();
+      const tabMeta: Record<
+        string,
+        { title?: string | null; contentType?: string | null }
+      > = {};
+      for (const tabId of tabIds) {
+        const tab = store.tabs[tabId];
+        if (tab) {
+          tabMeta[tab.contentId] = {
+            title: tab.title,
+            contentType: tab.contentType,
+          };
+        }
+      }
+
+      if (perform) perform();
+      // Snapshot the ids first: closeContentTab mutates pane tabIds as it goes.
+      else [...tabIds].forEach((tabId) => closeContentTab(tabId));
+
+      persistQuietly();
+      toast.success(message, {
+        duration: UNDO_WINDOW_MS,
+        action: { label: "Undo", onClick: () => undoClear(before, tabMeta) },
+      });
+    },
+    [closeContentTab, persistQuietly, undoClear]
   );
 
   const clearAll = useCallback(() => {
-    if (workspaceTabCount === 0) return;
-    clearAllWorkspaceTabs();
-    persist("Cleared all workplace tabs");
-  }, [clearAllWorkspaceTabs, persist, workspaceTabCount]);
+    runClear(
+      `Cleared all tabs (${tabs.length})`,
+      tabs.map((tab) => tab.id),
+      clearAllWorkspaceTabs
+    );
+  }, [clearAllWorkspaceTabs, runClear, tabs]);
 
-  const clearPane = useCallback(
-    (paneId: WorkspacePaneId) => {
-      const tabIds = panes[paneId]?.tabIds ?? [];
-      if (tabIds.length === 0) return;
-      // Snapshot first: closeContentTab mutates the pane's tabIds as it goes.
-      [...tabIds].forEach((tabId) => closeContentTab(tabId));
-      persist(`Cleared ${getPaneLabel(layoutMode, paneId).toLowerCase()}`);
+  const openClearMenu = useCallback(() => {
+    setMenuOpenedAt(Date.now());
+    openMenu();
+  }, [openMenu]);
+
+  const selectTarget = useCallback(
+    (message: string, tabIds: string[]) => {
+      close();
+      runClear(message, tabIds);
     },
-    [closeContentTab, layoutMode, panes, persist]
+    [close, runClear]
   );
-
-  useEffect(() => {
-    if (!isMenuOpen) return;
-    const handlePointerDown = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (menuRef.current?.contains(target)) return;
-      if (buttonRef.current?.contains(target)) return;
-      setIsMenuOpen(false);
-    };
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  }, [isMenuOpen]);
 
   useEffect(() => {
     return () => {
@@ -106,93 +336,169 @@ export function WorkplacesShellNavigationTrailingControls() {
     };
   }, []);
 
-  const handleMouseDown = () => {
-    if (workspaceTabCount === 0) return;
-    isHoldingRef.current = true;
+  // Pointer events rather than mouse events: the same handlers then cover
+  // touch, where a crowded tab strip is hardest to prune by hand.
+  const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (event.button > 0) return;
+    if (tabCount === 0) return;
+    isPressingRef.current = true;
+    openedByHoldRef.current = false;
     holdTimerRef.current = setTimeout(() => {
-      if (isHoldingRef.current) setIsMenuOpen(true);
+      if (!isPressingRef.current) return;
+      openedByHoldRef.current = true;
+      openClearMenu();
     }, HOLD_THRESHOLD_MS);
   };
 
-  const handleMouseUp = () => {
+  const handlePointerUp = () => {
     if (holdTimerRef.current) {
       clearTimeout(holdTimerRef.current);
       holdTimerRef.current = null;
     }
-    // A short press that didn't open the menu is the plain "clear all" action.
-    if (!isMenuOpen && isHoldingRef.current) clearAll();
-    isHoldingRef.current = false;
+    const wasPressing = isPressingRef.current;
+    isPressingRef.current = false;
+    if (!wasPressing || openedByHoldRef.current) return;
+    // Pressing the trigger while the menu stands dismisses it; otherwise a
+    // short press is the plain clear-all action.
+    if (open) close();
+    else clearAll();
   };
 
-  const handleMouseLeave = () => {
+  const cancelPress = () => {
     if (holdTimerRef.current) {
       clearTimeout(holdTimerRef.current);
       holdTimerRef.current = null;
     }
-    isHoldingRef.current = false;
+    isPressingRef.current = false;
   };
 
   return (
-    <div className="relative">
+    <>
       <button
-        ref={buttonRef}
+        ref={triggerRef}
         type="button"
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseLeave}
-        disabled={workspaceTabCount === 0}
-        className="inline-flex items-center justify-center rounded-md border border-white/10 p-1.5 text-gray-500 transition-colors hover:bg-black/5 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-35 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-red-400"
-        title={
-          isMultiPane
-            ? "Clear all tabs — hold to choose a pane"
-            : "Clear all tabs — hold for options"
-        }
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={cancelPress}
+        onPointerCancel={cancelPress}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          if (tabCount > 0) openClearMenu();
+        }}
+        disabled={tabCount === 0}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="touch-callout-none inline-flex items-center justify-center rounded-md border border-white/10 p-1.5 text-gray-500 transition-colors hover:bg-black/5 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-35 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-red-400"
+        title={`Clear all tabs (${tabCount}) — hold for options`}
       >
         <CircleX className="h-3.5 w-3.5" />
       </button>
 
-      {isMenuOpen && (
-        <div
-          ref={menuRef}
-          className="absolute right-0 top-full z-50 mt-2 min-w-52 rounded-md border border-white/10 bg-white/95 p-1 shadow-lg backdrop-blur-sm dark:bg-gray-900/95"
-        >
-          <div className="px-2.5 py-1.5 text-[10px] uppercase tracking-[0.18em] text-gray-500">
-            Clear tabs
-          </div>
+      {open && menuStyle
+        ? createPortal(
+            <div
+              ref={menuRef}
+              role="menu"
+              style={menuStyle}
+              className="z-[100] overflow-auto rounded-md border border-white/10 bg-white/95 p-1 shadow-lg backdrop-blur-sm dark:bg-gray-900/95"
+            >
+              <div className="px-2.5 py-1.5 text-[10px] uppercase tracking-[0.18em] text-gray-500">
+                Clear tabs
+              </div>
 
-          {isMultiPane &&
-            visiblePaneIds.map((paneId) => {
-              const count = panes[paneId]?.tabIds.length ?? 0;
-              return (
-                <button
-                  key={paneId}
-                  type="button"
-                  disabled={count === 0}
-                  onClick={() => {
-                    clearPane(paneId);
-                    setIsMenuOpen(false);
-                  }}
-                  className="flex w-full items-center justify-between gap-3 rounded px-2.5 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-black/5 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-200 dark:hover:bg-white/5 dark:hover:text-white"
-                >
-                  <span>{getPaneLabel(layoutMode, paneId)}</span>
-                  <span className="text-xs text-gray-400">{count}</span>
-                </button>
-              );
-            })}
+              {isMultiPane
+                ? visiblePaneIds.map((paneId) => {
+                    const paneTabIds = panes[paneId]?.tabIds ?? [];
+                    if (paneTabIds.length === 0) return null;
+                    const label = getPaneLabel(layoutMode, paneId);
+                    return (
+                      <RowButton
+                        key={paneId}
+                        label={label}
+                        count={paneTabIds.length}
+                        description={`Close ${pluralizeTabs(paneTabIds.length)} in the ${label.toLowerCase()}`}
+                        onSelect={() =>
+                          selectTarget(
+                            `Cleared ${label.toLowerCase()}`,
+                            [...paneTabIds]
+                          )
+                        }
+                      />
+                    );
+                  })
+                : null}
 
-          <button
-            type="button"
-            onClick={() => {
-              clearAll();
-              setIsMenuOpen(false);
-            }}
-            className="flex w-full items-center justify-between gap-3 rounded px-2.5 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-red-500/10 hover:text-red-600 dark:text-gray-200 dark:hover:bg-red-500/10 dark:hover:text-red-400"
-          >
-            <span>{isMultiPane ? "All panes" : "All tabs"}</span>
-            <span className="text-xs text-gray-400">{workspaceTabCount}</span>
-          </button>
-        </div>
-      )}
-    </div>
+              {othersTarget ? (
+                <RowButton
+                  label={othersTarget.label}
+                  count={othersTarget.tabIds.length}
+                  description={othersTarget.description}
+                  onSelect={() =>
+                    selectTarget(
+                      `Closed ${pluralizeTabs(othersTarget.tabIds.length)}`,
+                      othersTarget.tabIds
+                    )
+                  }
+                />
+              ) : null}
+
+              <RowButton
+                label={isMultiPane ? "All panes" : "All tabs"}
+                count={tabCount}
+                description={`Close all ${pluralizeTabs(tabCount)}`}
+                destructive
+                onSelect={() => {
+                  close();
+                  clearAll();
+                }}
+              />
+
+              {idleTargets.length > 0 || typeTargets.length > 0 ? (
+                <div className="my-1 h-px bg-black/5 dark:bg-white/10" />
+              ) : null}
+
+              {idleTargets.length > 0 ? (
+                <ChipRow label="Idle">
+                  {idleTargets.map((target) => (
+                    <ClearChip
+                      key={target.key}
+                      label={target.label}
+                      count={target.tabIds.length}
+                      description={target.description}
+                      onSelect={() =>
+                        selectTarget(
+                          `Closed ${pluralizeTabs(target.tabIds.length)} idle ${target.label}+`,
+                          target.tabIds
+                        )
+                      }
+                    />
+                  ))}
+                </ChipRow>
+              ) : null}
+
+              {typeTargets.length > 0 ? (
+                <ChipRow label="Type">
+                  {typeTargets.map((target) => (
+                    <ClearChip
+                      key={target.key}
+                      label={target.label}
+                      icon={target.icon}
+                      count={target.tabIds.length}
+                      description={target.description}
+                      onSelect={() =>
+                        selectTarget(
+                          `Closed ${pluralizeTabs(target.tabIds.length)} — ${target.label}`,
+                          target.tabIds
+                        )
+                      }
+                    />
+                  ))}
+                </ChipRow>
+              ) : null}
+            </div>,
+            document.body
+          )
+        : null}
+    </>
   );
 }

--- a/extensions/workplaces/shell/clear-tabs-targets.ts
+++ b/extensions/workplaces/shell/clear-tabs-targets.ts
@@ -1,0 +1,146 @@
+import type { LucideIcon } from "lucide-react";
+import type { WorkspaceTabState } from "@/state/content-store";
+import {
+  getTabIcon,
+  getTabIconGroupKey,
+} from "@/components/content/headers/tab-icons";
+
+/**
+ * Target math for the clear-tabs menu — pure, so the component stays a
+ * rendering concern and each rule is readable on its own.
+ *
+ * Every target carries the tab ids it would close and the count is derived
+ * from that same list, so a row can never advertise a number it won't act on.
+ * Empty targets are dropped by the builders rather than rendered disabled:
+ * the menu is a set of offers, and an offer that does nothing isn't one.
+ */
+
+export interface ClearTarget {
+  key: string;
+  /** Compact chip text ("3h", "1d") or row label ("Others"). */
+  label: string;
+  /** Full sentence for the tooltip / aria-label. */
+  description: string;
+  tabIds: string[];
+}
+
+export interface TypeClearTarget extends ClearTarget {
+  icon: LucideIcon;
+}
+
+/** Ascending, so each bucket is a subset of the one before it. */
+const IDLE_BUCKET_HOURS = [1, 3, 8, 24, 48] as const;
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function formatBucket(hours: number): string {
+  return hours >= 24 ? `${hours / 24}d` : `${hours}h`;
+}
+
+function pluralizeTabs(count: number): string {
+  return count === 1 ? "1 tab" : `${count} tabs`;
+}
+
+/**
+ * Idle buckets: tabs untouched for at least N hours.
+ *
+ * Two rules keep the row short (the whole point of a chip row rather than a
+ * submenu). Buckets with nothing in them are dropped, and a bucket whose
+ * membership is identical to the previous one is dropped too — "8h" and "1d"
+ * offering the same five tabs is one choice wearing two labels. What survives
+ * is the set of thresholds that actually decide something, typically two or
+ * three chips.
+ *
+ * Tabs with no activity signal at all sit out entirely; see
+ * `resolveLastTouchedAt`.
+ */
+export function buildIdleTargets(
+  tabs: WorkspaceTabState[],
+  lastTouchedAt: (contentId: string) => number | null,
+  now: number
+): ClearTarget[] {
+  const targets: ClearTarget[] = [];
+  let previousCount: number | null = null;
+
+  for (const hours of IDLE_BUCKET_HOURS) {
+    const cutoff = now - hours * HOUR_MS;
+    const tabIds = tabs
+      .filter((tab) => {
+        const touchedAt = lastTouchedAt(tab.contentId);
+        return touchedAt !== null && touchedAt <= cutoff;
+      })
+      .map((tab) => tab.id);
+
+    if (tabIds.length === 0) continue;
+    if (tabIds.length === previousCount) continue;
+    previousCount = tabIds.length;
+
+    const label = formatBucket(hours);
+    targets.push({
+      key: `idle:${hours}`,
+      label,
+      description: `Close ${pluralizeTabs(tabIds.length)} untouched for ${label} or longer`,
+      tabIds,
+    });
+  }
+
+  return targets;
+}
+
+/**
+ * One target per tab-icon group, mirroring the filter chips that sit beside
+ * this control — same grouping key, same icons, so "the notes" means the same
+ * thing in both places. Rendered only when more than one type is open; a
+ * single-type strip already has "All tabs".
+ */
+export function buildTypeTargets(tabs: WorkspaceTabState[]): TypeClearTarget[] {
+  const byKey = new Map<
+    string,
+    { icon: LucideIcon; types: Set<string>; tabIds: string[] }
+  >();
+
+  for (const tab of tabs) {
+    const key = getTabIconGroupKey(tab.contentType);
+    let group = byKey.get(key);
+    if (!group) {
+      group = { icon: getTabIcon(tab.contentType), types: new Set(), tabIds: [] };
+      byKey.set(key, group);
+    }
+    group.types.add((tab.contentType ?? "file").replace(/-/g, " "));
+    group.tabIds.push(tab.id);
+  }
+
+  if (byKey.size < 2) return [];
+
+  return Array.from(byKey.entries())
+    .map(([key, group]) => {
+      const label = Array.from(group.types).join(" / ");
+      return {
+        key: `type:${key}`,
+        label,
+        description: `Close ${pluralizeTabs(group.tabIds.length)} — ${label}`,
+        icon: group.icon,
+        tabIds: group.tabIds,
+      };
+    })
+    .sort((left, right) => left.key.localeCompare(right.key));
+}
+
+/** Every tab except the one the user is looking at. */
+export function buildOthersTarget(
+  tabs: WorkspaceTabState[],
+  activeTabId: string | null
+): ClearTarget | null {
+  if (!activeTabId || tabs.length < 2) return null;
+  const tabIds = tabs
+    .filter((tab) => tab.id !== activeTabId)
+    .map((tab) => tab.id);
+  if (tabIds.length === 0) return null;
+
+  return {
+    key: "others",
+    label: "Others",
+    description: `Close ${pluralizeTabs(tabIds.length)}, keeping the active one`,
+    tabIds,
+  };
+}

--- a/lib/core/use-anchored-menu.ts
+++ b/lib/core/use-anchored-menu.ts
@@ -95,5 +95,8 @@ export function useAnchoredMenu<
       }
     : undefined;
 
-  return { open, toggle, close, triggerRef, menuRef, menuStyle };
+  // `openMenu` is exposed alongside `toggle` for triggers whose open gesture
+  // isn't a click — press-and-hold, right-click — where toggling on an
+  // already-open menu would close it mid-gesture.
+  return { open, openMenu, toggle, close, triggerRef, menuRef, menuStyle };
 }

--- a/state/tab-activity-store.ts
+++ b/state/tab-activity-store.ts
@@ -1,0 +1,98 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { PaneHistoryState } from "./navigation-history-store";
+
+/**
+ * When each open content was last "touched" — the signal behind the clear-tabs
+ * control's idle buckets ("close what I haven't been using").
+ *
+ * Two sources, merged at read time:
+ *
+ *  - ACTIVATION comes from `navigation-history-store`, which already stamps
+ *    every pane navigation with a timestamp and persists it. Nothing new needs
+ *    to record it, and it covers panes this component never watches.
+ *  - FIRST SIGHTING is what this store adds. A tab restored with a workspace
+ *    and never clicked has no activation entry at all, and treating "unknown"
+ *    as "idle forever" would put every just-restored tab in the 1h bucket the
+ *    moment the workspace opens. Stamping it when first seen means a restored
+ *    tab starts its idle clock on arrival, which is what a user means by
+ *    "I haven't touched that since I got here".
+ *
+ * Deliberately per-device and lossy: an idle bucket is a convenience for
+ * pruning a crowded strip, not a record anything depends on. Entries are
+ * pruned past RETENTION_MS so the persisted map can't grow without bound.
+ */
+
+const RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+interface TabActivityState {
+  /** contentId → epoch ms when this surface first saw the tab open. */
+  firstSeenAt: Record<string, number>;
+  /** Stamp ids with no record yet; known ids keep their original stamp. */
+  noteSeen: (contentIds: Iterable<string>) => void;
+}
+
+export const useTabActivityStore = create<TabActivityState>()(
+  persist(
+    (set) => ({
+      firstSeenAt: {},
+      noteSeen: (contentIds) =>
+        set((state) => {
+          const now = Date.now();
+          const unseen = [...contentIds].filter(
+            (contentId) => state.firstSeenAt[contentId] === undefined
+          );
+          const stale = Object.entries(state.firstSeenAt).filter(
+            ([, at]) => now - at > RETENTION_MS
+          );
+          if (unseen.length === 0 && stale.length === 0) return state;
+
+          const next = { ...state.firstSeenAt };
+          for (const [contentId] of stale) delete next[contentId];
+          for (const contentId of unseen) next[contentId] = now;
+          return { firstSeenAt: next };
+        }),
+    }),
+    {
+      name: "notes:tab-activity",
+      version: 1,
+      partialize: (state) => ({ firstSeenAt: state.firstSeenAt }),
+    }
+  )
+);
+
+/**
+ * Newest activation per contentId across every pane's navigation history.
+ * A content id can appear in several panes' stacks; the most recent wins.
+ */
+export function buildActivationTimes(
+  byPaneId: Record<string, PaneHistoryState>
+): Map<string, number> {
+  const activationAt = new Map<string, number>();
+  for (const paneState of Object.values(byPaneId)) {
+    for (const item of paneState.history) {
+      if (!item.contentId) continue;
+      const previous = activationAt.get(item.contentId);
+      if (previous === undefined || item.timestamp > previous) {
+        activationAt.set(item.contentId, item.timestamp);
+      }
+    }
+  }
+  return activationAt;
+}
+
+/**
+ * Effective last-touched time, or null when this surface has no signal at all
+ * (the caller decides what to do with an unknown — the clear-tabs menu leaves
+ * such tabs out of every idle bucket rather than guessing them stale).
+ */
+export function resolveLastTouchedAt(
+  contentId: string,
+  firstSeenAt: Record<string, number>,
+  activationAt: Map<string, number>
+): number | null {
+  const activated = activationAt.get(contentId);
+  const seen = firstSeenAt[contentId];
+  if (activated === undefined && seen === undefined) return null;
+  return Math.max(activated ?? 0, seen ?? 0);
+}


### PR DESCRIPTION
## Summary

Holding the clear-tabs "X" now offers more than per-pane clears, and every clear — including the existing tap-to-clear-all — is undoable for 10 seconds.

- **Others** — everything but the active tab.
- **Idle** — tabs untouched for `1h` / `3h` / `8h` / `1d` / `2d`.
- **Type** — one chip per content type, using the same icon grouping as the filter chips beside it.

**Stacked on #229** (base `feat/workspace-scoped-clear-control`) — that PR made the control's counts workspace-scoped, which these targets depend on to avoid offering another workspace's content.

## Compact by construction

Time and type are **chip rows**, not submenus: one line per dimension, label on the left, chips inline.

```
CLEAR TABS
Top left            3
Others              8
All panes           9
────────────────────────
IDLE   1h 5  3h 3  1d 1
TYPE   📄5  📊2  🔗1
```

`clear-tabs-targets.ts` drops chips that wouldn't decide anything — empty buckets, and any bucket offering the same set as the one before it (`8h` and `1d` proposing the same five tabs is one choice in two labels). Typically two or three chips survive per row, so the menu stays about its old height. Counts are derived from the exact tab-id list each target would close, so a row can't advertise a number it won't act on.

## Undo

Actions raise a 10s toast with **Undo**. It restores the pre-clear snapshot **unioned with anything opened since** (undo puts back what the clear removed; it doesn't rewind the workspace) and records open-intents for the restored ids — without them the next peer reconcile would faithfully close them again, since the clear already recorded close-intents.

## Idle signal

Merged from two sources, no new API calls: activations already stamped by `navigation-history-store`, plus a first-sighting stamp from the new `tab-activity-store` — so a tab restored with a workspace and never clicked starts its idle clock on arrival instead of reading as stale forever. Tabs with no signal at all sit out of every bucket rather than being guessed stale.

## Also

- Menu portals to `document.body` via `use-anchored-menu` (it was a plain `absolute` div that clipped near the viewport edge). `openMenu` is now exposed from that hook for non-click open gestures.
- Hold gesture moved from mouse to **pointer** events — it works on touch for the first time. Right-click opens the menu too, since a hold is undiscoverable and unreachable for some users.
- `role="menu"` / `menuitem` / labelled chip groups.

## Not in this PR

**Opened** and **Edited** buckets, and **by folder**, need data the client doesn't have yet: `ContentWorkspaceTab.addedAt` exists but is dropped in `service.ts` before it reaches the client, and `updatedAt` + ancestry need a tree fetch when the menu opens. Both are additive to the same chip-row shape.

## Preflight checklist

- [x] **Gate: typecheck** — clean
- [x] **Gate: lint** — 0 errors, 151/175 warnings, none new and none in the changed files
- [x] **Gate: build** — `NODE_OPTIONS='--max-old-space-size=8192' pnpm build` green
- [ ] **Smoke:** hold the X → menu opens portaled; counts on every row match what closing it actually removes
- [ ] **Smoke:** click any row/chip → toast appears → **Undo** within 10s restores those tabs to their original panes
- [ ] **Smoke:** clear tabs, open a different note during the undo window, then Undo → restored tabs AND the newly opened one are both present
- [ ] **Smoke:** tap (don't hold) the X → still clears all, now with an Undo toast
- [ ] **Smoke:** right-click the X → same menu; on a touch device, long-press opens it
- [ ] **Smoke:** with one content type open, the Type row is absent; with several, each chip closes only its own type

No schema changes (no migration). No Hocuspocus impact — client state only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)