### PR TITLE
Gate the data-rows poll, and teach polling:check to see it

### DIFF
--- a/components/content/data/DataTableViewer.tsx
+++ b/components/content/data/DataTableViewer.tsx
@@ -20,6 +20,11 @@
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { Plus, Trash2, Undo2, Redo2, Layers } from "lucide-react";
+import {
+  registerPollingTask,
+  runPollingTaskNow,
+} from "@/lib/core/polling/scheduler";
+import { subscribeEngagement } from "@/lib/core/engagement";
 import { useDataFlashcardsDialogStore } from "@/state/data-flashcards-dialog-store";
 import { FLASHCARDS_EXTENSION_ID } from "@/extensions/flashcards/manifest";
 import { FLASHCARD_CHANGED_EVENT } from "@/extensions/flashcards/events";
@@ -443,21 +448,33 @@ export function DataTableViewer({ contentId, title }: DataTableViewerProps) {
 
   // ── Poll ───────────────────────────────────────────────────────────────
   //
-  // Reuses the shared-poller shape `noteWindow` established rather than
-  // introducing a third concurrency mechanism beside Y.js and per-cell LWW.
-  // Suspended while the tab is hidden; runs once immediately on refocus.
+  // Goes through the shared scheduler, which owns BOTH the hidden and the idle
+  // gate. It used to run its own self-rescheduling setTimeout with a bare
+  // `document.hidden` check — pre-idle-gating semantics, so a table sitting
+  // open and untouched polled every 10s indefinitely. Being a setTimeout rather
+  // than a setInterval, it was also invisible to `polling:check`.
+  //
+  // `serverTime` is read through a ref so this effect depends only on the
+  // content id. Reading it from state would re-run the effect on every
+  // successful poll (each one advances serverTime), unregistering and
+  // re-registering the task on every tick.
+
+  const serverTimeRef = useRef<string | null>(null);
+  useEffect(() => {
+    serverTimeRef.current = state.serverTime;
+  }, [state.serverTime]);
 
   useEffect(() => {
-    if (!state.serverTime) return;
-
     let cancelled = false;
-    let timer: ReturnType<typeof setTimeout> | null = null;
 
     const poll = async () => {
-      if (cancelled || document.hidden) return;
+      const since = serverTimeRef.current;
+      // No baseline yet: the initial load has not landed, so there is nothing
+      // to ask for changes since.
+      if (cancelled || !since) return;
       try {
         const res = await fetch(
-          `/api/content/data/${contentId}/rows?since=${encodeURIComponent(state.serverTime!)}`,
+          `/api/content/data/${contentId}/rows?since=${encodeURIComponent(since)}`,
           { credentials: "include" }
         );
         const json = await res.json();
@@ -503,25 +520,27 @@ export function DataTableViewer({ contentId, title }: DataTableViewerProps) {
       }
     };
 
-    const schedule = () => {
-      timer = setTimeout(async () => {
-        await poll();
-        if (!cancelled) schedule();
-      }, POLL_MS);
-    };
+    const taskId = `data-rows:${contentId}`;
+    const unregister = registerPollingTask({
+      id: taskId,
+      intervalMs: POLL_MS,
+      run: poll,
+    });
 
-    const onVisibility = () => {
-      if (!document.hidden) void poll();
-    };
+    // Catch up in one request when the user comes back, rather than waiting out
+    // a full interval. Safe to pause in between because the `since` cursor
+    // means nothing is lost — the next poll asks for everything that changed
+    // while we were quiet.
+    const unsubscribe = subscribeEngagement((engagement) => {
+      if (engagement === "active") runPollingTaskNow(taskId);
+    });
 
-    schedule();
-    document.addEventListener("visibilitychange", onVisibility);
     return () => {
       cancelled = true;
-      if (timer) clearTimeout(timer);
-      document.removeEventListener("visibilitychange", onVisibility);
+      unregister();
+      unsubscribe();
     };
-  }, [contentId, state.serverTime, load]);
+  }, [contentId, load]);
 
   // ── Viewport measurement ───────────────────────────────────────────────
 

--- a/scripts/validate-polling.ts
+++ b/scripts/validate-polling.ts
@@ -281,6 +281,92 @@ function walk(dir: string): string[] {
   return out;
 }
 
+/**
+ * Self-rescheduling `setTimeout` — a recurring timer that never says
+ * `setInterval`.
+ *
+ *   const schedule = () => {
+ *     timer = setTimeout(async () => { await poll(); schedule(); }, MS);
+ *   };
+ *
+ * This is the THIRD spelling of "recurring" to get past this gate, after `.js`
+ * files and `chrome.alarms`. It hid a 10s data-rows poll that was hidden-gated
+ * but not idle-gated, so an open table polled forever while nobody touched it —
+ * found by the owner in a network tab, not by CI.
+ *
+ * Matching is deliberately narrow, because precision matters more here than in
+ * the setInterval check: `setInterval` is ALWAYS recurring, whereas `setTimeout`
+ * is overwhelmingly one-shots and debounces (59 files pair it with a fetch).
+ * Three conditions must hold together:
+ *
+ *   1. a named function/method containing a `setTimeout` within ~1200 chars,
+ *   2. that same name called again inside the ~600 chars after it (the
+ *      recursion — and NOT a fresh `const`/`let` binding of the name, which is
+ *      shadowing, e.g. `const blob = await res.blob()`),
+ *   3. the file reaches the network at all.
+ *
+ * False positives remain (an AbortController timeout near a same-named call).
+ * They cost one line in REVIEWED_RECURRING_TIMEOUTS; a false negative costs a
+ * poller nobody sees until it shows up on an invoice.
+ */
+const RECURRING_KEYWORDS = new Set([
+  "if", "for", "while", "switch", "catch", "return",
+  "function", "constructor", "typeof", "await", "new", "do", "else",
+]);
+const RECURRING_NETWORK_RE = /\bfetch\s*\(|navigator\.sendBeacon|XMLHttpRequest/;
+
+function findSelfReschedulingTimers(source: string): string[] {
+  const found: string[] = [];
+  if (!RECURRING_NETWORK_RE.test(source)) return found;
+  const decl =
+    /(?:function\s+(\w+)\s*\(|(?:const|let|var)\s+(\w+)\s*=|^[ \t]*(?:private|protected|public)?[ \t]*(?:static[ \t]+)?(?:async[ \t]+)?(\w+)[ \t]*\([^)]*\)[ \t]*[:{])/gm;
+  let match: RegExpExecArray | null;
+  while ((match = decl.exec(source))) {
+    const name = match[1] ?? match[2] ?? match[3];
+    if (!name || RECURRING_KEYWORDS.has(name)) continue;
+    const timeoutAt = source.indexOf("setTimeout(", match.index);
+    if (timeoutAt === -1 || timeoutAt - match.index > 1200) continue;
+    const body = source.slice(timeoutAt, timeoutAt + 600);
+    if (!new RegExp(`\\b${name}\\s*\\(`).test(body)) continue;
+    if (new RegExp(`(?:const|let|var)\\s+${name}\\b`).test(body)) continue;
+    found.push(name);
+  }
+  return [...new Set(found)];
+}
+
+/**
+ * Files whose self-rescheduling timers have been traced. One line each: what
+ * the timer is, and why it is not an ungated poll.
+ */
+const REVIEWED_RECURRING_TIMEOUTS: Record<string, string> = {
+  "lib/domain/collaboration/runtime.ts":
+    "schedulePresenceHeartbeat — THE recurring one, tiered and audited in the registry above. shouldReconnectProvider is reconnect backoff, bounded by PROVIDER_RECONNECT_MAX_MS.",
+  "components/content/ai/ChatMessage.tsx":
+    "dispatch — false positive; the only timer is WorkingIndicator's 1s display counter (registered above as ui-only).",
+  "extensions/workplaces/state/workspace-sync.ts":
+    "fetchAndApply — already on the scheduler via registerPollingTask; the setTimeout is a retry, not the cadence.",
+  "lib/core/logger/client.ts":
+    "scheduleFlush — DEBOUNCED batch flush, not a poll: it only arms when a log event is queued, returns early if a timer already exists, and flushBeacon returns early on an empty queue. No events, no timer, no request.",
+  "extensions/daily-notes/components/PeriodicNotesShellController.tsx":
+    "scheduleNextRun — genuinely recurring, but the delay is getNextPeriodicRolloverDelay(): it fires at the next DAILY rollover. One request per day.",
+  "components/content/ai-context/ContextAiPanel.tsx":
+    "saveDirectives — debounced save, armed by user edits.",
+  "components/settings/ui/save-state.ts":
+    "send / clearTimer — the settings autosave debounce.",
+  "lib/domain/ai/acquisition/server-fetch.ts":
+    "fetchOnce — server-side retry with backoff, bounded by attempt count.",
+  "lib/domain/ai/image/generate.ts":
+    "json — false positive; a poll-for-result loop bounded by a deadline, server-side.",
+  "lib/domain/tenancy/use-user-tenants.ts":
+    "fetchUserTenants — false positive. The setTimeout is `inflight = null` at delay 0, an in-flight dedup reset.",
+  "extensions/workplaces/state/workspace-store.ts":
+    "fetchWorkspaceMutation — false positive. The setTimeout is an AbortController request timeout.",
+  "extensions/flashcards/components/FlashcardReviewOverlay.tsx":
+    "goToIndex — false positive; card-advance animation timing.",
+  "extensions/browser-bookmarks/browser-extension/src/background/index.js":
+    "finish — false positive; a co-browse operation timeout.",
+};
+
 function countMatches(source: string, re: RegExp): number {
   return (source.match(new RegExp(re.source, "g")) ?? []).length;
 }
@@ -290,6 +376,7 @@ function main() {
   const errors: string[] = [];
   const warnings: string[] = [];
   const seen = new Set<string>();
+  const reschedulingSeen = new Set<string>();
 
   const files = SCAN_ROOTS.filter((root) => {
     try {
@@ -302,6 +389,25 @@ function main() {
   for (const abs of files) {
     const rel = relative(REPO_ROOT, abs);
     const source = readFileSync(abs, "utf8");
+
+    // Self-rescheduling setTimeout is checked SEPARATELY from the timer count,
+    // against its own reviewed list. It has lower precision than the other
+    // matchers, so folding it into the main registry would flood a list whose
+    // value depends on every entry being worth reading.
+    const rescheduling = findSelfReschedulingTimers(source);
+    if (rescheduling.length > 0) {
+      reschedulingSeen.add(rel);
+      if (!(rel in REVIEWED_RECURRING_TIMEOUTS)) {
+        errors.push(
+          `RECURRING     ${rel}\n` +
+            `    Self-rescheduling setTimeout: ${rescheduling.join(", ")}\n` +
+            `    A setTimeout that re-arms itself is a recurring timer, and this file\n` +
+            `    reaches the network. Route it through registerPollingTask() so it\n` +
+            `    inherits hidden AND idle gating, or add a line to\n` +
+            `    REVIEWED_RECURRING_TIMEOUTS saying why it is not a poll.`
+        );
+      }
+    }
 
     const timers =
       countMatches(source, CALL_RE) +
@@ -390,6 +496,15 @@ function main() {
   if (warnings.length > 0) {
     console.warn(`\n⚠  ${warnings.length} timer file(s) awaiting audit:\n`);
     for (const w of warnings) console.warn(`  ${w}\n`);
+  }
+
+  for (const file of Object.keys(REVIEWED_RECURRING_TIMEOUTS)) {
+    if (reschedulingSeen.has(file)) continue;
+    errors.push(
+      `STALE RECURRING  ${file}\n` +
+        `    Listed in REVIEWED_RECURRING_TIMEOUTS but no self-rescheduling timer\n` +
+        `    was found. If it moved to registerPollingTask(), remove the entry.`
+    );
   }
 
   if (errors.length > 0) {


### PR DESCRIPTION
Owner found `/api/content/data/<id>/rows?since=` still firing every 10s in a tab nobody was touching.

## The poll

`DataTableViewer` ran its own self-rescheduling `setTimeout` with a bare `document.hidden` check — **pre-idle-gating semantics**. Hidden tabs stopped; a table left open and untouched polled forever.

Moved onto `registerPollingTask`, which owns both the hidden and the idle gate, with a `runPollingTaskNow` catch-up on the return to active. Safe to pause because the `since` cursor means nothing is lost — the next poll asks for everything that changed while we were quiet.

Also fixed a smaller thing while in there: `serverTime` now comes from a ref, so the effect depends only on the content id. Reading it from state re-ran the effect on **every successful poll** (each one advances `serverTime`), unregistering and re-registering the task every tick.

## Why CI missed it — the more important half

`polling:check` matched `setInterval`, `EventSource` and `chrome.alarms`. A `setTimeout` that re-arms itself is none of those:

```ts
const schedule = () => {
  timer = setTimeout(async () => { await poll(); schedule(); }, POLL_MS);
};
```

**This is the third spelling of "recurring" to get past this gate**, after `.js` files and `chrome.alarms` — and the third time the hole was in what the matcher *recognises*, not in where it looks.

### The detector, and why it is narrow

Precision matters more here than for `setInterval`, which is always recurring. `setTimeout` is overwhelmingly one-shots and debounces — **59 files** pair it with a `fetch`, so flagging that pairing would flood the registry and train people to reclassify reflexively.

Three conditions must hold together:

1. a named function or method containing a `setTimeout` within ~1200 chars
2. that same name called again inside the ~600 chars after it — and **not** re-declared there, which is shadowing (`const blob = await res.blob()`)
3. the file reaches the network at all

That takes 59 candidates to **13**.

### All 13 traced

No other genuine ungated poller among them:

| File | Verdict |
|---|---|
| `logger/client.ts` | `scheduleFlush` is a **debounced batch**, not a poll — only arms when a log event is queued, and `flushBeacon` returns early on an empty queue |
| `PeriodicNotesShellController` | genuinely recurring, but the delay is `getNextPeriodicRolloverDelay()` — **once per day** |
| `use-user-tenants.ts` | false positive: the `setTimeout` is `inflight = null` at delay 0, an in-flight dedup reset |
| `workspace-store.ts` | false positive: an `AbortController` request timeout |
| the rest | debounced saves, retry backoff, animation timing |

Each is one line in `REVIEWED_RECURRING_TIMEOUTS`. Stale entries are reported the same way the main registry's are, so a file that later migrates to `registerPollingTask` has to drop its line.

## Gates

- **Gate:** `pnpm typecheck` — exit 0
- **Gate:** `pnpm lint` — 0 errors, 151 warnings (unchanged baseline)
- **Gate:** `pnpm polling:check` — 17 files, 0 awaiting audit
- **Gate:** `pnpm polling:smoke` — 60 assertions

**Mutation-tested two ways:** reverting `DataTableViewer` to the exact code the owner found reports `RECURRING`, and a fresh recursive fetch loop in an unlisted file does too.

## Pre-merge checklist

- [ ] **Smoke:** open a database table, leave it untouched ~90s → `rows?since=` requests **stop** in the network tab
- [ ] **Smoke:** touch the table → one catch-up request fires immediately, then the 10s cadence resumes
- [ ] **Smoke:** edit a row in a second browser while the first sits idle, then return to the first → the change appears on the catch-up poll (the `since` cursor loses nothing)
- [ ] **Smoke:** a table under a view **sort** still reloads correctly on changes (the sort branch is untouched, worth one pass)
- [ ] `pnpm polling:check` and `pnpm polling:smoke` pass locally

No migration, no TipTap schema change → **no Hocuspocus redeploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)